### PR TITLE
Fix custom OpenAI-compatible API URL initialization

### DIFF
--- a/mineai/engines/openrouter.py
+++ b/mineai/engines/openrouter.py
@@ -11,6 +11,7 @@ class OpenRouterEngine(BatchLlmEngine):
         api_key: str,
         model: str,
         *,
+        api_url: str = OPENROUTER_API,
         mode: str = "safe",
         context: str = "",
         site_url: str = "",


### PR DESCRIPTION
## What changed

Adds the missing `api_url` parameter to `OpenRouterEngine.__init__`, with the existing `OPENROUTER_API` constant as its default value.

## Why

`TranslationService` passes the configured API URL to `OpenRouterEngine`, but the constructor does not currently accept it. This causes the OpenRouter provider to fail before making a request:

```text
TypeError: OpenRouterEngine.__init__() got an unexpected keyword argument 'api_url'
```

The fix restores support for custom OpenAI-compatible endpoints introduced in 9.2.1 while preserving the current OpenRouter endpoint as the default.

## Verification

- Confirmed the module compiles successfully.
- Confirmed initialization with the default OpenRouter endpoint.
- Confirmed initialization with a custom `/v1/chat/completions` endpoint.
