### PR TITLE
Harden batched LLM response validation and partial retries

### DIFF
--- a/mineai/engines/llm_common.py
+++ b/mineai/engines/llm_common.py
@@ -1,11 +1,19 @@
 import json
 import re
+from collections import Counter
 from typing import Callable
 
 import requests
 
 from mineai.engines.base import EngineCallbacks, EngineItem, TranslationEngine
-from mineai.text_processing import polish_translation, unmask_translation
+from mineai.text_processing import (
+    PLACEHOLDER_PATTERN,
+    polish_translation,
+    unmask_translation,
+)
+
+
+RETRY_BATCH_SIZE = 10
 
 
 def build_translation_prompt(
@@ -18,23 +26,40 @@ def build_translation_prompt(
     blob = json.dumps(payload, ensure_ascii=False)
     if mode == "context" and context:
         return (
-            f"Ты локализатор Minecraft. Переведи строки мода/квеста «{context}» на {lang_name}. "
-            f"Сохраняй игровой стиль и лор. Не переводи JSON-ключи. Теги [#0#] не менять. "
-            f"Верни ТОЛЬКО валидный JSON с теми же ключами. Данные: {blob}"
+            f"Ты локализатор Minecraft. Переведи строки мода/квеста "
+            f"«{context}» на {lang_name}. Сохраняй игровой стиль и лор. "
+            f"Не переводи JSON-ключи. Все маркеры вида [#N#], например "
+            f"[#0#] и [#1#], сохраняй без изменений: не удаляй, не "
+            f"добавляй, не дублируй и не переименовывай их. Верни ТОЛЬКО "
+            f"валидный JSON с теми же ключами. Данные: {blob}"
         )
     return (
         f"Translate JSON string values from English to {lang_name}. "
-        f"Do not translate keys. Preserve [#0#] tags exactly. "
-        f"Return ONLY valid JSON with the same keys. Data: {blob}"
+        f"Do not translate keys. Preserve every [#N#] placeholder exactly, "
+        f"for example [#0#] and [#1#]. Do not add, remove, duplicate, or "
+        f"rename placeholders. Return ONLY valid JSON with the same keys. "
+        f"Data: {blob}"
     )
 
 
-def parse_llm_json_response(content: str) -> dict:
-    text = re.sub(r"^```json\s*|^```\s*|```$", "", content.strip(), flags=re.IGNORECASE).strip()
+def parse_llm_json_response(content: str) -> dict[str, object]:
+    text = re.sub(
+        r"^```json\s*|^```\s*|```$",
+        "",
+        content.strip(),
+        flags=re.IGNORECASE,
+    ).strip()
     data = json.loads(text)
     if not isinstance(data, dict):
         raise TypeError("LLM response is not a JSON object")
     return data
+
+
+def placeholders_match(text: str, expected_text: str) -> bool:
+    """Return whether all placeholders are preserved with equal multiplicity."""
+    expected_ids = Counter(PLACEHOLDER_PATTERN.findall(expected_text))
+    actual_ids = Counter(PLACEHOLDER_PATTERN.findall(text))
+    return actual_ids == expected_ids
 
 
 class BatchLlmEngine(TranslationEngine):
@@ -66,14 +91,37 @@ class BatchLlmEngine(TranslationEngine):
         i = 0
         while i < len(keys) and callbacks.should_run():
             callbacks.wait_if_paused()
+            if not callbacks.should_run():
+                break
+
             chunk = keys[i : i + self.batch_size]
-            if not self._translate_chunk(chunk, items, target_lang, result, callbacks):
-                callbacks.on_log(f"❌ Ошибка {self.label}. Дробим пакет...", "yellow")
-                for j in range(0, len(chunk), 10):
-                    sub = chunk[j : j + 10]
-                    if not self._translate_chunk(sub, items, target_lang, result, callbacks):
-                        for key in sub:
-                            result[key] = items[key].original
+            failed = self._translate_chunk(
+                chunk,
+                items,
+                target_lang,
+                result,
+                callbacks,
+            )
+            if failed and callbacks.should_run():
+                callbacks.on_log(
+                    f"❌ Ошибка {self.label}. Повторяем проблемные строки...",
+                    "yellow",
+                )
+                for j in range(0, len(failed), RETRY_BATCH_SIZE):
+                    if not callbacks.should_run():
+                        break
+                    callbacks.wait_if_paused()
+                    if not callbacks.should_run():
+                        break
+
+                    sub = failed[j : j + RETRY_BATCH_SIZE]
+                    self._translate_chunk(
+                        sub,
+                        items,
+                        target_lang,
+                        result,
+                        callbacks,
+                    )
             i += self.batch_size
         return result
 
@@ -84,8 +132,8 @@ class BatchLlmEngine(TranslationEngine):
         target_lang: dict,
         result: dict[str, str],
         callbacks: EngineCallbacks,
-    ) -> bool:
-        payload = {k: items[k].masked for k in chunk_keys}
+    ) -> list[str]:
+        payload = {key: items[key].masked for key in chunk_keys}
         prompt = build_translation_prompt(
             payload,
             target_lang["name"],
@@ -96,18 +144,40 @@ class BatchLlmEngine(TranslationEngine):
         try:
             content = self._call_api(prompt, self.max_tokens)
             if not content:
-                return False
+                return chunk_keys
+
             translated = parse_llm_json_response(content)
+            unexpected = set(translated) - set(chunk_keys)
+            if unexpected:
+                callbacks.on_log(
+                    f"⚠️ {self.label}: отброшены лишние JSON-ключи — "
+                    f"{len(unexpected)}",
+                    "yellow",
+                )
+
+            failed: list[str] = []
             for key in chunk_keys:
-                if key in translated:
-                    text = unmask_translation(str(translated[key]), items[key].mapping)
-                    result[key] = polish_translation(text)
-                else:
-                    result[key] = items[key].original
-            return True
+                raw = translated.get(key)
+                if not isinstance(raw, str):
+                    failed.append(key)
+                    continue
+                if not placeholders_match(raw, items[key].masked):
+                    failed.append(key)
+                    continue
+
+                text = unmask_translation(raw, items[key].mapping)
+                result[key] = polish_translation(text)
+
+            if failed:
+                callbacks.on_log(
+                    f"❌ {self.label}: не прошли проверку — "
+                    f"{len(failed)} строк",
+                    "red",
+                )
+            return failed
         except (json.JSONDecodeError, TypeError, KeyError) as exc:
             callbacks.on_log(f"❌ {self.label}: неверный JSON — {exc}", "red")
-            return False
+            return chunk_keys
         except requests.RequestException as exc:
             callbacks.on_log(f"❌ {self.label}: сеть — {exc}", "red")
-            return False
+            return chunk_keys

--- a/mineai/text_processing.py
+++ b/mineai/text_processing.py
@@ -4,6 +4,9 @@ from functools import lru_cache
 
 from mineai.constants import DICT_FILE, IGNORE_TERMS
 
+
+PLACEHOLDER_PATTERN = re.compile(r"\[\s*#\s*(\d+)\s*#\s*\]")
+
 FORMAT_PATTERN = re.compile(
     r"("
     r"\$\([^)]+\)|"
@@ -93,11 +96,17 @@ def polish_translation(text: str) -> str:
 
 
 def mask_protected_fragments(text: str) -> tuple[str, dict[str, str]]:
-    """Replace format codes and protected terms with [#n#] placeholders."""
+    """Replace format codes and protected terms with collision-free placeholders."""
     mapping: dict[str, str] = {}
+    reserved_ids = set(PLACEHOLDER_PATTERN.findall(text))
+    next_id = 0
 
     def replacer(match: re.Match) -> str:
-        token = f"[#{len(mapping)}#]"
+        nonlocal next_id
+        while str(next_id) in reserved_ids:
+            next_id += 1
+        token = f"[#{next_id}#]"
+        next_id += 1
         mapping[token] = match.group(0)
         return token
 

--- a/tests/test_llm_common.py
+++ b/tests/test_llm_common.py
@@ -1,0 +1,435 @@
+import json
+import os
+import tempfile
+import unittest
+
+import requests
+
+
+# Importing the application creates default settings and dictionary files.
+# Keep those import-time side effects outside the repository during tests.
+_original_cwd = os.getcwd()
+with tempfile.TemporaryDirectory() as _import_cwd:
+    os.chdir(_import_cwd)
+    try:
+        from mineai.engines.base import EngineCallbacks, EngineItem
+        from mineai.engines.llm_common import BatchLlmEngine, build_translation_prompt
+        from mineai.engines.service import TranslationService
+        from mineai.text_processing import mask_protected_fragments
+    finally:
+        os.chdir(_original_cwd)
+
+
+TARGET_LANG = {"api": "ru", "name": "Russian"}
+
+
+def callbacks(
+    *,
+    should_run=lambda: True,
+    wait_if_paused=lambda: None,
+) -> EngineCallbacks:
+    return EngineCallbacks(
+        should_run=should_run,
+        wait_if_paused=wait_if_paused,
+        on_log=lambda _message, _tag: None,
+        on_status=lambda _message: None,
+    )
+
+
+def prompt_payload(prompt: str) -> dict[str, str]:
+    for marker in ("Data: ", "Данные: "):
+        if marker in prompt:
+            return json.loads(prompt.split(marker, 1)[1])
+    raise AssertionError("Prompt does not contain a JSON payload marker")
+
+
+class MemoryCache:
+    def __init__(self) -> None:
+        self.values: dict[tuple[str, str], str] = {}
+
+    def get(self, api_code: str, source: str) -> str | None:
+        return self.values.get((api_code, source))
+
+    def set(self, api_code: str, source: str, translated: str) -> None:
+        self.values[(api_code, source)] = translated
+
+    def save_if_threshold(self) -> None:
+        pass
+
+
+class ConfigWithoutSmartGlue:
+    def getboolean(self, _section: str, _key: str) -> bool:
+        return False
+
+
+class ServiceWithEngine(TranslationService):
+    def __init__(self, cache: MemoryCache, engine: BatchLlmEngine) -> None:
+        super().__init__("ai", cache, ConfigWithoutSmartGlue())
+        self.engine = engine
+
+    def _build_engine(self, context: str = "") -> BatchLlmEngine:
+        return self.engine
+
+
+class BatchLlmEngineTests(unittest.TestCase):
+    def test_safe_prompt_requires_all_numbered_placeholders(self) -> None:
+        prompt = build_translation_prompt(
+            {"key": "Requires [#0#] and [#1#]"},
+            "Russian",
+            mode="safe",
+            context="",
+        )
+
+        self.assertIn("every [#N#] placeholder", prompt)
+        self.assertIn("Do not add, remove, duplicate, or rename", prompt)
+
+    def test_context_prompt_requires_all_numbered_placeholders(self) -> None:
+        prompt = build_translation_prompt(
+            {"key": "Requires [#0#] and [#1#]"},
+            "Russian",
+            mode="context",
+            context="Example Mod",
+        )
+
+        self.assertIn("Все маркеры вида [#N#]", prompt)
+        self.assertIn("не удаляй, не добавляй, не дублируй", prompt)
+
+    def test_retries_only_a_missing_key(self) -> None:
+        calls: list[dict[str, str]] = []
+
+        def call_api(prompt: str, _max_tokens: int) -> str:
+            payload = prompt_payload(prompt)
+            calls.append(payload)
+            if len(calls) == 1:
+                return json.dumps({"first": "Первый"}, ensure_ascii=False)
+            return json.dumps({"second": "Второй"}, ensure_ascii=False)
+
+        engine = BatchLlmEngine(call_api=call_api)
+        items = {
+            "first": EngineItem("first", "First", "First"),
+            "second": EngineItem("second", "Second", "Second"),
+        }
+
+        result = engine.translate_batch(items, TARGET_LANG, callbacks())
+
+        self.assertEqual(result, {"first": "Первый", "second": "Второй"})
+        self.assertEqual(
+            [set(call) for call in calls],
+            [{"first", "second"}, {"second"}],
+        )
+
+    def test_retries_only_the_value_with_a_lost_placeholder(self) -> None:
+        calls: list[dict[str, str]] = []
+
+        def call_api(prompt: str, _max_tokens: int) -> str:
+            payload = prompt_payload(prompt)
+            calls.append(payload)
+            if len(calls) == 1:
+                return json.dumps(
+                    {"power": "Требуется энергия", "title": "Генератор"},
+                    ensure_ascii=False,
+                )
+            return json.dumps(
+                {"power": "Требуется [#0#] RF/t"},
+                ensure_ascii=False,
+            )
+
+        engine = BatchLlmEngine(call_api=call_api)
+        items = {
+            "power": EngineItem(
+                "power",
+                "Requires %s RF/t",
+                "Requires [#0#] RF/t",
+                {"[#0#]": "%s"},
+            ),
+            "title": EngineItem("title", "Generator", "Generator"),
+        }
+
+        result = engine.translate_batch(items, TARGET_LANG, callbacks())
+
+        self.assertEqual(result["power"], "Требуется %s RF/t")
+        self.assertEqual(result["title"], "Генератор")
+        self.assertEqual(set(calls[1]), {"power"})
+
+    def test_rejects_all_non_string_json_values(self) -> None:
+        invalid_values = [None, 42, True, ["Перевод"], {"text": "Перевод"}]
+
+        for invalid_value in invalid_values:
+            with self.subTest(invalid_value=invalid_value):
+                responses = iter(
+                    [
+                        json.dumps({"key": invalid_value}, ensure_ascii=False),
+                        json.dumps({"key": "Перевод"}, ensure_ascii=False),
+                    ]
+                )
+                engine = BatchLlmEngine(
+                    call_api=lambda _prompt, _limit: next(responses)
+                )
+                items = {"key": EngineItem("key", "Translation", "Translation")}
+
+                result = engine.translate_batch(items, TARGET_LANG, callbacks())
+
+                self.assertEqual(result["key"], "Перевод")
+
+    def test_discards_an_unexpected_key_without_retry(self) -> None:
+        calls = 0
+
+        def call_api(_prompt: str, _limit: int) -> str:
+            nonlocal calls
+            calls += 1
+            return json.dumps(
+                {"key": "Перевод", "explanation": "Готово"},
+                ensure_ascii=False,
+            )
+
+        engine = BatchLlmEngine(call_api=call_api)
+        items = {"key": EngineItem("key", "Translation", "Translation")}
+
+        result = engine.translate_batch(items, TARGET_LANG, callbacks())
+
+        self.assertEqual(result, {"key": "Перевод"})
+        self.assertEqual(calls, 1)
+
+    def test_omits_value_after_two_invalid_responses(self) -> None:
+        engine = BatchLlmEngine(
+            call_api=lambda _prompt, _limit: json.dumps({"key": None})
+        )
+        items = {"key": EngineItem("key", "Original", "Original")}
+
+        result = engine.translate_batch(items, TARGET_LANG, callbacks())
+
+        self.assertNotIn("key", result)
+
+    def test_rejects_an_added_placeholder(self) -> None:
+        responses = iter(
+            [
+                json.dumps({"key": "Значение [#9#]"}, ensure_ascii=False),
+                json.dumps({"key": "Значение"}, ensure_ascii=False),
+            ]
+        )
+        engine = BatchLlmEngine(call_api=lambda _prompt, _limit: next(responses))
+        items = {"key": EngineItem("key", "Value", "Value")}
+
+        result = engine.translate_batch(items, TARGET_LANG, callbacks())
+
+        self.assertEqual(result["key"], "Значение")
+
+    def test_rejects_a_duplicated_placeholder(self) -> None:
+        responses = iter(
+            [
+                json.dumps({"key": "Значение [#0#] [#0#]"}, ensure_ascii=False),
+                json.dumps({"key": "Значение [#0#]"}, ensure_ascii=False),
+            ]
+        )
+        engine = BatchLlmEngine(call_api=lambda _prompt, _limit: next(responses))
+        items = {
+            "key": EngineItem(
+                "key",
+                "Value %s",
+                "Value [#0#]",
+                {"[#0#]": "%s"},
+            )
+        }
+
+        result = engine.translate_batch(items, TARGET_LANG, callbacks())
+
+        self.assertEqual(result["key"], "Значение %s")
+
+    def test_accepts_spaced_placeholder_syntax_used_by_unmasking(self) -> None:
+        engine = BatchLlmEngine(
+            call_api=lambda _prompt, _limit: json.dumps(
+                {"key": "Значение [ # 0 # ]"},
+                ensure_ascii=False,
+            )
+        )
+        items = {
+            "key": EngineItem(
+                "key",
+                "Value %s",
+                "Value [#0#]",
+                {"[#0#]": "%s"},
+            )
+        }
+
+        result = engine.translate_batch(items, TARGET_LANG, callbacks())
+
+        self.assertEqual(result["key"], "Значение %s")
+
+    def test_preserves_a_literal_numbered_placeholder(self) -> None:
+        engine = BatchLlmEngine(
+            call_api=lambda _prompt, _limit: json.dumps(
+                {"key": "Литерал [#7#]"},
+                ensure_ascii=False,
+            )
+        )
+        items = {"key": EngineItem("key", "Literal [#7#]", "Literal [#7#]")}
+
+        result = engine.translate_batch(items, TARGET_LANG, callbacks())
+
+        self.assertEqual(result["key"], "Литерал [#7#]")
+
+    def test_masking_avoids_collision_with_a_literal_placeholder(self) -> None:
+        source = "Literal [#0#] and %s"
+        masked, mapping = mask_protected_fragments(source)
+        self.assertEqual(masked, "Literal [#0#] and [#1#]")
+        self.assertEqual(mapping, {"[#1#]": "%s"})
+
+        engine = BatchLlmEngine(
+            call_api=lambda _prompt, _limit: json.dumps(
+                {"key": "Литерал [#0#] и [#1#]"},
+                ensure_ascii=False,
+            )
+        )
+        items = {"key": EngineItem("key", source, masked, mapping)}
+
+        result = engine.translate_batch(items, TARGET_LANG, callbacks())
+
+        self.assertEqual(result["key"], "Литерал [#0#] и %s")
+
+    def test_real_mask_unmask_pipeline_preserves_protected_fragments(self) -> None:
+        source = "Power §a%s§r\n[docs](guide.md)"
+        masked, mapping = mask_protected_fragments(source)
+        translated_masked = masked.replace("Power", "Мощность").replace(
+            "docs", "справка"
+        )
+        engine = BatchLlmEngine(
+            call_api=lambda _prompt, _limit: json.dumps(
+                {"key": translated_masked},
+                ensure_ascii=False,
+            )
+        )
+        items = {"key": EngineItem("key", source, masked, mapping)}
+
+        result = engine.translate_batch(items, TARGET_LANG, callbacks())
+
+        self.assertEqual(result["key"], "Мощность §a%s§r\n[справка](guide.md)")
+
+    def test_invalid_json_retries_the_whole_chunk(self) -> None:
+        calls: list[set[str]] = []
+
+        def call_api(prompt: str, _limit: int) -> str:
+            calls.append(set(prompt_payload(prompt)))
+            if len(calls) == 1:
+                return "not-json"
+            return json.dumps(
+                {"first": "Первый", "second": "Второй"},
+                ensure_ascii=False,
+            )
+
+        engine = BatchLlmEngine(call_api=call_api)
+        items = {
+            "first": EngineItem("first", "First", "First"),
+            "second": EngineItem("second", "Second", "Second"),
+        }
+
+        result = engine.translate_batch(items, TARGET_LANG, callbacks())
+
+        self.assertEqual(result, {"first": "Первый", "second": "Второй"})
+        self.assertEqual(calls, [{"first", "second"}, {"first", "second"}])
+
+    def test_network_error_retries_the_whole_chunk(self) -> None:
+        calls = 0
+
+        def call_api(_prompt: str, _limit: int) -> str:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise requests.ConnectionError("offline")
+            return json.dumps({"key": "Перевод"}, ensure_ascii=False)
+
+        engine = BatchLlmEngine(call_api=call_api)
+        items = {"key": EngineItem("key", "Original", "Original")}
+
+        result = engine.translate_batch(items, TARGET_LANG, callbacks())
+
+        self.assertEqual(result, {"key": "Перевод"})
+        self.assertEqual(calls, 2)
+
+    def test_partial_invalid_response_caches_only_the_valid_translation(self) -> None:
+        calls = 0
+
+        def call_api(_prompt: str, _limit: int) -> str:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return json.dumps(
+                    {"good": "Хорошо", "bad": None},
+                    ensure_ascii=False,
+                )
+            return json.dumps({"bad": None}, ensure_ascii=False)
+
+        engine = BatchLlmEngine(call_api=call_api)
+        cache = MemoryCache()
+        service = ServiceWithEngine(cache, engine)
+
+        result = service.translate_dict(
+            {"good": "Good", "bad": "Bad"},
+            TARGET_LANG,
+            callbacks(),
+        )
+
+        self.assertEqual(result, {"good": "Хорошо", "bad": "Bad"})
+        self.assertEqual(cache.values, {("ru", "Good"): "Хорошо"})
+
+    def test_stop_while_paused_prevents_the_initial_request(self) -> None:
+        running = True
+        calls = 0
+
+        def should_run() -> bool:
+            return running
+
+        def wait_if_paused() -> None:
+            nonlocal running
+            running = False
+
+        def call_api(_prompt: str, _limit: int) -> str:
+            nonlocal calls
+            calls += 1
+            return json.dumps({"key": "Перевод"}, ensure_ascii=False)
+
+        engine = BatchLlmEngine(call_api=call_api)
+        items = {"key": EngineItem("key", "Original", "Original")}
+
+        result = engine.translate_batch(
+            items,
+            TARGET_LANG,
+            callbacks(should_run=should_run, wait_if_paused=wait_if_paused),
+        )
+
+        self.assertEqual(result, {})
+        self.assertEqual(calls, 0)
+
+    def test_stop_while_paused_prevents_a_retry_request(self) -> None:
+        running = True
+        wait_calls = 0
+        api_calls = 0
+
+        def should_run() -> bool:
+            return running
+
+        def wait_if_paused() -> None:
+            nonlocal running, wait_calls
+            wait_calls += 1
+            if wait_calls == 2:
+                running = False
+
+        def call_api(_prompt: str, _limit: int) -> str:
+            nonlocal api_calls
+            api_calls += 1
+            return json.dumps({"key": None})
+
+        engine = BatchLlmEngine(call_api=call_api)
+        items = {"key": EngineItem("key", "Original", "Original")}
+
+        result = engine.translate_batch(
+            items,
+            TARGET_LANG,
+            callbacks(should_run=should_run, wait_if_paused=wait_if_paused),
+        )
+
+        self.assertEqual(result, {})
+        self.assertEqual(api_calls, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Hi! This PR proposes a reliability improvement for batched LLM translations.

It validates each returned JSON entry before accepting it, keeps valid entries from partially valid responses, and retries only missing or invalid entries. The goal is to avoid silently writing malformed LLM output or caching a failed translation as if it were successful.

## What changed

- accept only string values for requested translation keys;
- verify that numbered `[#N#]` placeholders are preserved by identity and multiplicity;
- retry only missing or invalid entries, in groups of up to 10;
- keep valid entries from partial responses and ignore unexpected keys;
- after a second validation failure, omit that entry so the existing service fallback returns the source text without caching it;
- avoid generated placeholder IDs colliding with literal `[#N#]` text in the source;
- re-check the stop state after pause waits;
- clarify placeholder-preservation requirements in both LLM prompts;
- add 18 focused unit tests.

## Verification performed

The following checks were run locally on the branch:

```text
python3 -B -m unittest discover -s tests -v
Ran 18 tests
OK

python3 -m compileall -q mineai tests
OK

git diff --check
OK
```

The tests cover partial retries, malformed JSON, network errors, non-string values, missing/extra/duplicated placeholders, literal placeholder collisions, cache isolation after repeated failures, the real mask/validate/unmask path, and stopping while paused.

## What has not been fully tested

This has **not** yet been tested end-to-end on a real modpack translation run against a live KoboldCPP or OpenRouter model. In particular, I have not measured translation quality, provider-specific behavior, retry frequency, token usage, or cost on a representative real workload.

So this PR is offered as a tested validation/retry implementation, not as a claim that the complete real-world translation workflow has been fully validated. A live smoke test before merge would be welcome.

## Trade-offs

- A malformed or structurally unsafe response can cause one additional request.
- Entries that fail validation twice remain untranslated for that run rather than accepting unsafe output.
- Partial retries contain less neighboring-string context than the initial batch, while retaining the configured mod/book context.
- Placeholder order is intentionally not enforced because target-language grammar may require moving protected fragments.

Feedback on the retry policy and validation strictness is very welcome.
