### PR TITLE
Retry unresolved LLM translations individually

### DIFF
--- a/mineai/engines/llm_common.py
+++ b/mineai/engines/llm_common.py
@@ -13,7 +13,7 @@ from mineai.text_processing import (
 )
 
 
-RETRY_BATCH_SIZE = 10
+RETRY_BATCH_SIZES = (10, 5, 1)
 
 
 def build_translation_prompt(
@@ -102,26 +102,44 @@ class BatchLlmEngine(TranslationEngine):
                 result,
                 callbacks,
             )
-            if failed and callbacks.should_run():
+            for retry_number, retry_batch_size in enumerate(
+                RETRY_BATCH_SIZES,
+                start=1,
+            ):
+                if not failed or not callbacks.should_run():
+                    break
+
                 callbacks.on_log(
-                    f"❌ Ошибка {self.label}. Повторяем проблемные строки...",
+                    f"🔁 {self.label}: повтор {retry_number}/"
+                    f"{len(RETRY_BATCH_SIZES)} — {len(failed)} строк",
                     "yellow",
                 )
-                for j in range(0, len(failed), RETRY_BATCH_SIZE):
+                retry_failed: list[str] = []
+                for j in range(0, len(failed), retry_batch_size):
                     if not callbacks.should_run():
                         break
                     callbacks.wait_if_paused()
                     if not callbacks.should_run():
                         break
 
-                    sub = failed[j : j + RETRY_BATCH_SIZE]
-                    self._translate_chunk(
-                        sub,
-                        items,
-                        target_lang,
-                        result,
-                        callbacks,
+                    sub = failed[j : j + retry_batch_size]
+                    retry_failed.extend(
+                        self._translate_chunk(
+                            sub,
+                            items,
+                            target_lang,
+                            result,
+                            callbacks,
+                        )
                     )
+                failed = retry_failed
+
+            if failed and callbacks.should_run():
+                callbacks.on_log(
+                    f"⚠️ {self.label}: не удалось перевести после повторов — "
+                    f"{len(failed)} строк; сохранён исходный текст",
+                    "yellow",
+                )
             i += self.batch_size
         return result
 

--- a/tests/test_llm_common.py
+++ b/tests/test_llm_common.py
@@ -27,11 +27,12 @@ def callbacks(
     *,
     should_run=lambda: True,
     wait_if_paused=lambda: None,
+    on_log=lambda _message, _tag: None,
 ) -> EngineCallbacks:
     return EngineCallbacks(
         should_run=should_run,
         wait_if_paused=wait_if_paused,
-        on_log=lambda _message, _tag: None,
+        on_log=on_log,
         on_status=lambda _message: None,
     )
 
@@ -190,15 +191,65 @@ class BatchLlmEngineTests(unittest.TestCase):
         self.assertEqual(result, {"key": "Перевод"})
         self.assertEqual(calls, 1)
 
-    def test_omits_value_after_two_invalid_responses(self) -> None:
-        engine = BatchLlmEngine(
-            call_api=lambda _prompt, _limit: json.dumps({"key": None})
-        )
-        items = {"key": EngineItem("key", "Original", "Original")}
+    def test_retries_until_a_remaining_value_becomes_valid(self) -> None:
+        calls: list[set[str]] = []
+
+        def call_api(prompt: str, _limit: int) -> str:
+            payload = prompt_payload(prompt)
+            calls.append(set(payload))
+            if len(calls) == 1:
+                response = {"first": "Первый", "second": None, "third": None}
+            elif len(calls) == 2:
+                response = {"second": "Второй", "third": None}
+            else:
+                response = {"third": "Третий"}
+            return json.dumps(response, ensure_ascii=False)
+
+        engine = BatchLlmEngine(call_api=call_api)
+        items = {
+            "first": EngineItem("first", "First", "First"),
+            "second": EngineItem("second", "Second", "Second"),
+            "third": EngineItem("third", "Third", "Third"),
+        }
 
         result = engine.translate_batch(items, TARGET_LANG, callbacks())
 
+        self.assertEqual(
+            result,
+            {"first": "Первый", "second": "Второй", "third": "Третий"},
+        )
+        self.assertEqual(
+            calls,
+            [
+                {"first", "second", "third"},
+                {"second", "third"},
+                {"third"},
+            ],
+        )
+
+    def test_stops_retrying_and_reports_persistent_failures(self) -> None:
+        calls = 0
+        logs: list[str] = []
+
+        def call_api(_prompt: str, _limit: int) -> str:
+            nonlocal calls
+            calls += 1
+            return json.dumps({"key": None})
+
+        engine = BatchLlmEngine(call_api=call_api)
+        items = {"key": EngineItem("key", "Original", "Original")}
+
+        result = engine.translate_batch(
+            items,
+            TARGET_LANG,
+            callbacks(on_log=lambda message, _tag: logs.append(message)),
+        )
+
         self.assertNotIn("key", result)
+        self.assertEqual(calls, 4)
+        self.assertTrue(
+            any("не удалось перевести после повторов — 1 строк" in log for log in logs)
+        )
 
     def test_rejects_an_added_placeholder(self) -> None:
         responses = iter(


### PR DESCRIPTION
## Что исправлено

Закрывает сценарий из #17: раньше после исходного LLM-запроса выполнялся только один повтор, а строки, которые снова не прошли JSON/placeholder-валидацию, молча оставались непереведёнными.

Теперь:
- выполняются до трёх ограниченных раундов только для оставшихся проблемных строк;
- размер повторных пачек последовательно уменьшается `10 → 5 → 1`, чтобы на последнем раунде изолировать каждую строку;
- успешно исправленные строки исключаются из следующих повторов;
- после исчерпания попыток лог явно сообщает число строк, для которых сохранён исходный текст;
- остановка/пауза по-прежнему проверяются перед каждым запросом.

## Проверки

- `python3 -m unittest discover -s tests -v` — 22/22 passed
- AST parse всех Python-файлов — OK
- `git diff --check` — OK

Добавлены регрессионные тесты для успешного восстановления строки на позднем retry и для ограниченного завершения при постоянной ошибке.

Closes #17
