### PR TITLE
Skip loose JSON and SNBT writes after cancellation

### DIFF
--- a/mineai/processors/loose_json.py
+++ b/mineai/processors/loose_json.py
@@ -65,6 +65,8 @@ class LooseJsonProcessor:
             translated = self.service.translate_dict(
                 pending, target_lang, self.callbacks, context="Локализация Квестов/Скриптов"
             )
+            if not self.state.should_run():
+                return
             merged.update(translated)
             self.state.increment_translated(len(translated))
 

--- a/mineai/processors/snbt.py
+++ b/mineai/processors/snbt.py
@@ -43,6 +43,8 @@ class SnbtProcessor:
         self.callbacks.on_log(f"⚡ Перевод {name} [Квесты] — {len(strings)} строк", "yellow")
         chunk = {str(i): s for i, s in enumerate(strings)}
         translated = self.service.translate_dict(chunk, target_lang, self.callbacks, context=name)
+        if not self.state.should_run():
+            return
         mapping = {strings[i]: translated.get(str(i), strings[i]) for i in range(len(strings))}
         self.state.increment_translated(len(mapping))
 

--- a/tests/test_cancelled_processor_writes.py
+++ b/tests/test_cancelled_processor_writes.py
@@ -1,0 +1,112 @@
+import json
+import os
+import tempfile
+import unittest
+
+
+# Initialize packages in the same order as the application while keeping
+# settings/dictionary import-time side effects outside the repository.
+_original_cwd = os.getcwd()
+with tempfile.TemporaryDirectory() as _import_cwd:
+    os.chdir(_import_cwd)
+    try:
+        from mineai.engines.base import EngineCallbacks
+        from mineai.runtime.job import TranslationJob as _TranslationJob
+        from mineai.processors.loose_json import LooseJsonProcessor
+        from mineai.processors.snbt import SnbtProcessor
+        from mineai.runtime.state import JobState
+    finally:
+        os.chdir(_original_cwd)
+
+
+TARGET_LANG = {
+    "api": "ru",
+    "file": "ru_ru",
+    "name": "Russian",
+    "regex": r"[А-Яа-яЁё]",
+}
+
+
+def callbacks(state: JobState) -> EngineCallbacks:
+    return EngineCallbacks(
+        should_run=state.should_run,
+        wait_if_paused=state.wait_if_paused,
+        on_log=lambda _message, _tag: None,
+        on_status=lambda _message: None,
+    )
+
+
+class StopDuringTranslationService:
+    def __init__(self, state: JobState) -> None:
+        self.state = state
+
+    def translate_dict(
+        self,
+        strings: dict[str, str],
+        _target_lang: dict,
+        _callbacks: EngineCallbacks,
+        *,
+        context: str = "",
+    ) -> dict[str, str]:
+        del context
+        self.state.stop()
+        return {key: f"Перевод: {value}" for key, value in strings.items()}
+
+
+class CancelledProcessorWriteTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.state = JobState(is_running=True)
+        self.service = StopDuringTranslationService(self.state)
+        self.callbacks = callbacks(self.state)
+
+    def test_loose_json_does_not_create_output_after_stop(self) -> None:
+        with tempfile.TemporaryDirectory() as mc_dir:
+            lang_dir = os.path.join(mc_dir, "kubejs", "assets", "test", "lang")
+            os.makedirs(lang_dir)
+            source_path = os.path.join(lang_dir, "en_us.json")
+            target_path = os.path.join(lang_dir, "ru_ru.json")
+            with open(source_path, "w", encoding="utf-8") as handle:
+                json.dump({"item.test": "Test item"}, handle)
+
+            processor = LooseJsonProcessor(
+                self.service,
+                self.state,
+                self.callbacks,
+            )
+            processor.process(
+                source_path,
+                mc_dir,
+                target_lang=TARGET_LANG,
+                mode="force",
+                output_mode="inplace",
+                pack_writer=None,
+            )
+
+            self.assertFalse(os.path.exists(target_path))
+            self.assertEqual(self.state.translated_strings, 0)
+
+    def test_snbt_keeps_source_unchanged_after_stop(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            source_path = os.path.join(directory, "chapter.snbt")
+            original = 'title: "Quest title"\n'
+            with open(source_path, "w", encoding="utf-8") as handle:
+                handle.write(original)
+
+            processor = SnbtProcessor(
+                self.service,
+                self.state,
+                self.callbacks,
+            )
+            processor.process(
+                source_path,
+                target_lang=TARGET_LANG,
+                mode="append",
+            )
+
+            with open(source_path, encoding="utf-8") as handle:
+                self.assertEqual(handle.read(), original)
+            self.assertEqual(self.state.translated_strings, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Что исправлено

Если пользователь нажимал Stop во время перевода loose JSON или SNBT, `TranslationService` завершал текущую работу, но процессор после возврата всё равно собирал и записывал частичный результат.

Теперь оба процессора повторно проверяют состояние задания сразу после перевода и до изменения счётчика/записи файла:
- loose JSON не создаёт и не перезаписывает целевой словарь после Stop;
- SNBT не применяет частичный mapping и не заменяет исходный файл после Stop;
- уже существующая резервная `.bak` для SNBT сохраняется как раньше.

Изменение независимо от #19 и основано напрямую на актуальной `beta`.

## Проверки

- `python3 -m unittest discover -s tests -v` — 23/23 passed
- AST parse всех Python-файлов — OK
- `git diff --check` — OK

Добавлены два регрессионных теста, которые останавливают JobState внутри `translate_dict()` и подтверждают отсутствие последующей записи loose JSON/SNBT.
