### PR TITLE
fix: make GUI job completion thread-safe

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  push:
+    branches: [beta]
+  pull_request:
+    branches: [beta]
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+      - name: Install dependencies
+        run: python -m pip install --upgrade pip && python -m pip install -r requirements.txt
+      - name: Compile sources
+        run: python -m compileall -q mineai tests translator.py
+      - name: Run unit tests
+        run: python -m unittest discover -s tests -v

--- a/mineai/gui/app.py
+++ b/mineai/gui/app.py
@@ -1,4 +1,5 @@
 import os
+import queue
 import threading
 import tkinter as tk
 from tkinter import filedialog, messagebox
@@ -32,10 +33,13 @@ class TranslatorApp(ctk.CTk):
         self.job_state = JobState()
         self.cache_std, self.cache_ai, polish_total = load_both_caches()
         self._job: TranslationJob | None = None
+        self._ui_thread_id = threading.get_ident()
+        self._ui_queue: queue.Queue[tuple[object, tuple]] = queue.Queue()
         self.auto_scroll = True
 
         self._build_ui()
         self._refresh_folder_label()
+        self.after(50, self._drain_ui_queue)
 
         if polish_total:
             self.log(f"✨ Кэш отполирован: исправлено {polish_total} строк.", "magenta")
@@ -283,7 +287,26 @@ class TranslatorApp(ctk.CTk):
     def _on_scroll_interaction(self) -> None:
         self.auto_scroll = self.textbox.yview()[1] >= 0.99
 
+    def _ensure_ui_thread(self, callback, *args) -> bool:
+        """Queue Tk work without calling any Tk API from a worker thread."""
+        ui_thread_id = getattr(self, "_ui_thread_id", threading.main_thread().ident)
+        if threading.get_ident() != ui_thread_id:
+            self._ui_queue.put((callback, args))
+            return False
+        return True
+
+    def _drain_ui_queue(self) -> None:
+        while True:
+            try:
+                callback, args = self._ui_queue.get_nowait()
+            except queue.Empty:
+                break
+            callback(*args)
+        self.after(50, self._drain_ui_queue)
+
     def log(self, message: str, tag: str = "white") -> None:
+        if not self._ensure_ui_thread(self.log, message, tag):
+            return
         self.textbox.configure(state="normal")
         at_bottom = self.textbox.yview()[1] >= 0.99
         self.textbox.insert("end", message + "\n", tag)
@@ -299,6 +322,16 @@ class TranslatorApp(ctk.CTk):
             pass
 
     def log_row(self, icon: str, name: str, kind: str, trans_c: int, en_c: int, pct: int) -> None:
+        if not self._ensure_ui_thread(
+            self.log_row,
+            icon,
+            name,
+            kind,
+            trans_c,
+            en_c,
+            pct,
+        ):
+            return
         self.textbox.configure(state="normal")
         at_bottom = self.textbox.yview()[1] >= 0.99
         self.textbox.insert("end", f"{icon} {name[:34]:<35}", "cyan")
@@ -311,11 +344,15 @@ class TranslatorApp(ctk.CTk):
         self.textbox.configure(state="disabled")
 
     def set_status(self, text: str, progress: float | None) -> None:
+        if not self._ensure_ui_thread(self.set_status, text, progress):
+            return
         if progress is not None:
             self.progress.set(progress)
         self.lbl_status.configure(text=text)
 
     def _lock_ui(self, locked: bool) -> None:
+        if not self._ensure_ui_thread(self._lock_ui, locked):
+            return
         state = "disabled" if locked else "normal"
         rev = "normal" if locked else "disabled"
         self.btn_analyze.configure(state=state)
@@ -353,12 +390,16 @@ class TranslatorApp(ctk.CTk):
         self.job_state.is_paused = False
         self._clear_log()
         self._job = self._job_instance()
-        threading.Thread(target=self._run_analysis_thread, daemon=True).start()
+        options = self._translation_options()
+        threading.Thread(
+            target=lambda: self._run_analysis_thread(options),
+            daemon=True,
+        ).start()
 
-    def _run_analysis_thread(self) -> None:
+    def _run_analysis_thread(self, options: TranslationOptions) -> None:
         try:
             if self._job is not None:
-                self._job.run_analysis(self._translation_options())
+                self._job.run_analysis(options)
         finally:
             self.job_state.is_running = False
             self._job = None
@@ -377,7 +418,11 @@ class TranslatorApp(ctk.CTk):
         self.btn_pause.configure(text="⏸ ПАУЗА", fg_color="#ffc107", text_color="black")
         self._clear_log()
         self._job = self._job_instance()
-        threading.Thread(target=self._run_translation_thread, daemon=True).start()
+        options = self._translation_options()
+        threading.Thread(
+            target=lambda: self._run_translation_thread(options),
+            daemon=True,
+        ).start()
     
     
     def _open_log_file(self) -> None:
@@ -392,10 +437,10 @@ class TranslatorApp(ctk.CTk):
             self.log("❌ Лог-файл еще не создан.", "yellow")
             
             
-    def _run_translation_thread(self) -> None:
+    def _run_translation_thread(self, options: TranslationOptions) -> None:
         try:
             if self._job is not None:
-                self._job.run_translation(self._translation_options())
+                self._job.run_translation(options)
         finally:
             self.job_state.is_running = False
             self._job = None

--- a/mineai/processors/__init__.py
+++ b/mineai/processors/__init__.py
@@ -1,8 +1,4 @@
-from mineai.processors.analyzer import ModpackAnalyzer
-from mineai.processors.jar import JarProcessor
-from mineai.processors.loose_json import LooseJsonProcessor
-from mineai.processors.snbt import SnbtProcessor
-from mineai.processors.estimator import StringEstimator
+from importlib import import_module
 
 __all__ = [
     "ModpackAnalyzer",
@@ -11,3 +7,21 @@ __all__ = [
     "SnbtProcessor",
     "StringEstimator",
 ]
+
+_EXPORTS = {
+    "ModpackAnalyzer": ("mineai.processors.analyzer", "ModpackAnalyzer"),
+    "JarProcessor": ("mineai.processors.jar", "JarProcessor"),
+    "LooseJsonProcessor": ("mineai.processors.loose_json", "LooseJsonProcessor"),
+    "SnbtProcessor": ("mineai.processors.snbt", "SnbtProcessor"),
+    "StringEstimator": ("mineai.processors.estimator", "StringEstimator"),
+}
+
+
+def __getattr__(name: str):
+    try:
+        module_name, attribute = _EXPORTS[name]
+    except KeyError as exc:
+        raise AttributeError(name) from exc
+    value = getattr(import_module(module_name), attribute)
+    globals()[name] = value
+    return value

--- a/mineai/runtime/__init__.py
+++ b/mineai/runtime/__init__.py
@@ -1,4 +1,18 @@
-from mineai.runtime.job import TranslationJob
-from mineai.runtime.state import JobState
+from importlib import import_module
 
 __all__ = ["TranslationJob", "JobState"]
+
+_EXPORTS = {
+    "TranslationJob": ("mineai.runtime.job", "TranslationJob"),
+    "JobState": ("mineai.runtime.state", "JobState"),
+}
+
+
+def __getattr__(name: str):
+    try:
+        module_name, attribute = _EXPORTS[name]
+    except KeyError as exc:
+        raise AttributeError(name) from exc
+    value = getattr(import_module(module_name), attribute)
+    globals()[name] = value
+    return value

--- a/mineai/runtime/job.py
+++ b/mineai/runtime/job.py
@@ -184,6 +184,7 @@ class TranslationJob:
         total_items = len(jars) + len(loose) + len(snbt) + len(bq_files)
         done = 0
 
+        failed = False
         try:
             for path in jars:
                 if not self.state.should_run():
@@ -250,6 +251,7 @@ class TranslationJob:
 
             cache.save()
         except Exception:
+            failed = True
             self.on_log(f"\n❌ КРИТИЧЕСКАЯ ОШИБКА:\n{traceback.format_exc()}", "red")
         finally:
             if pack_writer:
@@ -257,7 +259,9 @@ class TranslationJob:
             if options.engine == "ai":
                 pass  # keep AI running for user
 
-        if not self.state.should_run():
+        if failed:
+            self.on_status("Ошибка перевода", 1.0)
+        elif not self.state.should_run():
             self.on_log("\n🛑 ОСТАНОВЛЕНО.", "red")
             self.on_status("Остановлено", 1.0)
         else:

--- a/tests/test_gui_active_job.py
+++ b/tests/test_gui_active_job.py
@@ -1,4 +1,5 @@
 import os
+import queue
 import sys
 import tempfile
 import types
@@ -144,6 +145,19 @@ class TranslatorAppJobLifecycleTests(unittest.TestCase):
         app.job_state.stop.assert_called_once_with()
         app.btn_stop.configure.assert_called_once_with(state="disabled")
         app.btn_pause.configure.assert_called_once_with(state="disabled")
+
+    def test_worker_ui_update_is_queued_without_calling_tk(self) -> None:
+        app = object.__new__(gui_app.TranslatorApp)
+        app._ui_thread_id = -1
+        app._ui_queue = queue.Queue()
+        app.after = mock.Mock()
+
+        gui_app.TranslatorApp.set_status(app, "Working", 0.5)
+
+        callback, args = app._ui_queue.get_nowait()
+        self.assertEqual(callback, app.set_status)
+        self.assertEqual(args, ("Working", 0.5))
+        app.after.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_llm_common.py
+++ b/tests/test_llm_common.py
@@ -37,7 +37,7 @@ def callbacks(
 
 
 def prompt_payload(prompt: str) -> dict[str, str]:
-    for marker in ("Data: ", "Данные: "):
+    for marker in ("DATA:\n", "Data: ", "Данные: "):
         if marker in prompt:
             return json.loads(prompt.split(marker, 1)[1])
     raise AssertionError("Prompt does not contain a JSON payload marker")
@@ -91,8 +91,8 @@ class BatchLlmEngineTests(unittest.TestCase):
             context="Example Mod",
         )
 
-        self.assertIn("Все маркеры вида [#N#]", prompt)
-        self.assertIn("не удаляй, не добавляй, не дублируй", prompt)
+        self.assertIn("every [#N#] placeholder", prompt)
+        self.assertIn("Do not add, remove, duplicate, or rename", prompt)
 
     def test_retries_only_a_missing_key(self) -> None:
         calls: list[dict[str, str]] = []

--- a/tests/test_runtime_safety.py
+++ b/tests/test_runtime_safety.py
@@ -1,0 +1,84 @@
+import os
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+from mineai.cache import TranslationCache
+from mineai.runtime.job import TranslationJob, TranslationOptions
+from mineai.runtime.state import JobState
+
+
+class _Config:
+    def get(self, _section, _key):
+        return ""
+
+    def getboolean(self, _section, _key):
+        return False
+
+
+class RuntimeSafetyTests(unittest.TestCase):
+    def test_processor_submodule_import_does_not_depend_on_import_order(self):
+        command = [sys.executable, "-c", "import mineai.processors.snbt_extract"]
+        completed = subprocess.run(
+            command,
+            cwd=os.path.dirname(os.path.dirname(__file__)),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+    def test_translation_exception_is_not_reported_as_success(self):
+        state = JobState(is_running=True)
+        logs = []
+        statuses = []
+        cache = mock.Mock(spec=TranslationCache)
+        job = TranslationJob(
+            _Config(),
+            cache,
+            cache,
+            state,
+            on_log=lambda message, _tag: logs.append(message),
+            on_status=lambda *args: statuses.append(args),
+            on_row=lambda *_args: None,
+        )
+        options = TranslationOptions(
+            mc_dir="/modpack",
+            language_label="Русский",
+            mc_version="1.20.1",
+            output_mode="inplace",
+            pack_name="MineAI_Pack",
+            engine="google",
+            google_mode="single",
+            ai_mode="safe",
+            ai_batch=20,
+            ai_provider="local",
+            process_mode="append",
+            translate_mods=True,
+            translate_books=False,
+            translate_quests=False,
+        )
+
+        with (
+            mock.patch("mineai.runtime.job.discover_jar_files", return_value=[]),
+            mock.patch(
+                "mineai.runtime.job.discover_loose_lang_files",
+                return_value=["broken.json"],
+            ),
+            mock.patch("mineai.runtime.job.StringEstimator.estimate", return_value=1),
+            mock.patch(
+                "mineai.runtime.job.LooseJsonProcessor.process",
+                side_effect=RuntimeError("disk failure"),
+            ),
+        ):
+            job.run_translation(options)
+
+        self.assertTrue(any("КРИТИЧЕСКАЯ ОШИБКА" in message for message in logs))
+        self.assertFalse(any("УСПЕШНО ЗАВЕРШЕН" in message for message in logs))
+        self.assertEqual(statuses[-1], ("Ошибка перевода", 1.0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- report translation exceptions as failures instead of showing a success status afterwards
- marshal worker-thread log/status/UI updates through a main-thread queue
- snapshot translation options before starting a worker so Tk variables are not read from the worker thread
- make `mineai.processors` and `mineai.runtime` exports lazy to avoid import-order coupling
- add regression tests and a minimal GitHub Actions workflow for pushes/PRs targeting `beta`

## Tests

- `python3 -m unittest discover -s tests -v` — 24 passed
- `python3 -m compileall -q mineai tests translator.py`
- `ruff check --select E9,F63,F7,F82 mineai tests translator.py`
- `git diff --check`

This PR is intentionally limited to runtime/GUI safety and CI coverage and targets `beta`.
