### PR TITLE
fix: preserve BetterQuesting and SNBT data integrity

### DIFF
--- a/mineai/processors/bq_json.py
+++ b/mineai/processors/bq_json.py
@@ -43,7 +43,7 @@ class BQProcessor:
                     actual_key = next((k for k in bq_data if k.startswith(key_prefix)), None)
                     if actual_key and isinstance(bq_data[actual_key], str):
                         text = bq_data[actual_key].strip()
-                        if text and not already_translated(text, target_regex):
+                        if text and (mode == "force" or not already_translated(text, target_regex)):
                             strings_to_translate[actual_key] = text
 
         if not strings_to_translate:
@@ -52,9 +52,14 @@ class BQProcessor:
         name = os.path.basename(os.path.dirname(file_path)) + "/" + os.path.basename(file_path)
         self.callbacks.on_log(f"⚡ Перевод BQ [{name}] — {len(strings_to_translate)} строк", "yellow")
         
-        translated = self.service.translate_dict(strings_to_translate, target_lang, self.callbacks, context=name)
+        translated = self.service.translate_dict(
+            strings_to_translate,
+            target_lang,
+            self.callbacks,
+            context=name,
+        )
         
-        if not translated:
+        if not self.state.should_run() or not translated:
             return
 
         # Применяем перевод

--- a/mineai/processors/snbt.py
+++ b/mineai/processors/snbt.py
@@ -20,9 +20,7 @@ class SnbtProcessor:
         
         # Шаг 1. Определяем, куда сохранять и откуда читать
         if is_lang_file:
-            # Превращаем код API (ru) в код майнкрафта (ru_ru)
-            api_code = target_lang.get("api", "ru").lower()
-            mc_code = target_lang.get("code", f"{api_code}_{api_code}")
+            mc_code = target_lang["file"]
             target_file_path = os.path.join(os.path.dirname(file_path), f"{mc_code}.snbt")
             
             # Для en_us мы всегда берем оригинал как шаблон, он не должен меняться

--- a/mineai/processors/snbt_extract.py
+++ b/mineai/processors/snbt_extract.py
@@ -3,9 +3,36 @@ import re
 from mineai.text_processing import is_translation_key, looks_like_source_language
 
 
-SNBT_STRING_RE = r'"((?:[^"\\]|\\.)*)"'
+SNBT_VALUE_RE = r'(?:[^"\\]|\\.)*'
+SNBT_STRING_RE = rf'"({SNBT_VALUE_RE})"'
 SINGLE_FIELDS = ("title", "subtitle", "text", "desc", "description")
 ARRAY_FIELDS = ("description", "text", "desc")
+
+
+def _escape_snbt_value(value: str) -> str:
+    """Escape new quotes without double-escaping existing SNBT sequences."""
+    escaped: list[str] = []
+    i = 0
+    while i < len(value):
+        char = value[i]
+        if char == "\\":
+            if i + 1 < len(value):
+                escaped.append(value[i : i + 2])
+                i += 2
+                continue
+            escaped.append("\\\\")
+        elif char == '"':
+            escaped.append('\\"')
+        elif char == "\n":
+            escaped.append("\\n")
+        elif char == "\r":
+            escaped.append("\\r")
+        elif char == "\t":
+            escaped.append("\\t")
+        else:
+            escaped.append(char)
+        i += 1
+    return "".join(escaped)
 
 
 def extract_snbt_strings(content: str, *, skip_translated_regex: str | None = None) -> list[str]:
@@ -47,12 +74,11 @@ def apply_snbt_translations(content: str, mapping: dict[str, str]) -> str:
     def replace_single(match: re.Match) -> str:
         original = match.group(2)
         translated = mapping.get(original, original)
-        escaped = translated.replace("\\", "\\\\").replace('"', '\\"')
-        return f'{match.group(1)}: "{escaped}"'
+        return f'{match.group(1)}{_escape_snbt_value(translated)}{match.group(3)}'
 
     field_pattern = "|".join(SINGLE_FIELDS)
     content = re.sub(
-        rf'(?:"|)({field_pattern})(?:"|)\s*:\s*{SNBT_STRING_RE}',
+        rf'((?:"|)(?:{field_pattern})(?:"|)\s*:\s*")({SNBT_VALUE_RE})(")',
         replace_single,
         content,
         flags=re.IGNORECASE,
@@ -65,15 +91,14 @@ def apply_snbt_translations(content: str, mapping: dict[str, str]) -> str:
         def replace_item(sm: re.Match) -> str:
             original = sm.group(1)
             translated = mapping.get(original, original)
-            escaped = translated.replace("\\", "\\\\").replace('"', '\\"')
-            return f'"{escaped}"'
+            return f'"{_escape_snbt_value(translated)}"'
 
         new_body = re.sub(SNBT_STRING_RE, replace_item, array_body)
-        return f'{key}: {new_body}'
+        return f'{key}{new_body}'
 
     array_fields = "|".join(ARRAY_FIELDS)
     content = re.sub(
-        rf'(?:"|)({array_fields})(?:"|)\s*:\s*(\[\s*(?:"(?:[^"\\]|\\.)*"\s*,?\s*)*\])',
+        rf'((?:"|)(?:{array_fields})(?:"|)\s*:\s*)(\[\s*(?:"(?:[^"\\]|\\.)*"\s*,?\s*)*\])',
         replace_array,
         content,
         flags=re.IGNORECASE,

--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -1,0 +1,119 @@
+import json
+import os
+import tempfile
+import unittest
+
+from mineai.engines.base import EngineCallbacks
+from mineai.runtime.state import JobState
+from mineai.processors.bq_json import BQProcessor
+from mineai.processors.snbt import SnbtProcessor
+from mineai.processors.snbt_extract import apply_snbt_translations, extract_snbt_strings
+
+
+TARGET_LANG = {
+    "api": "en",
+    "file": "en_gb",
+    "name": "English",
+    "regex": r"[A-Za-z]",
+}
+
+
+class _Service:
+    def __init__(self, state=None):
+        self.state = state
+        self.calls = []
+
+    def translate_dict(self, strings, _target_lang, _callbacks, **kwargs):
+        self.calls.append((strings, kwargs))
+        if self.state is not None:
+            self.state.stop()
+        return {key: f"translated:{value}" for key, value in strings.items()}
+
+
+def _callbacks(state):
+    return EngineCallbacks(
+        should_run=state.should_run,
+        wait_if_paused=state.wait_if_paused,
+        on_log=lambda *_args: None,
+        on_status=lambda *_args: None,
+    )
+
+
+class SnbtIntegrityTests(unittest.TestCase):
+    def test_identity_translation_preserves_snbt_escaping_and_formatting(self):
+        content = (
+            '"title": "Line\\nNext"\n'
+            'description: ["Say \\"hi\\"", "C\\\\D"]'
+        )
+        strings = extract_snbt_strings(content)
+
+        result = apply_snbt_translations(content, {value: value for value in strings})
+
+        self.assertEqual(result, content)
+
+    def test_lang_file_uses_minecraft_locale_code(self):
+        state = JobState(is_running=True)
+        service = _Service()
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "en_us.snbt")
+            with open(source, "w", encoding="utf-8") as handle:
+                handle.write('title: "Hello world"')
+
+            SnbtProcessor(service, state, _callbacks(state)).process(
+                source,
+                target_lang=TARGET_LANG,
+                mode="force",
+            )
+
+            self.assertTrue(os.path.exists(os.path.join(directory, "en_gb.snbt")))
+            self.assertFalse(os.path.exists(os.path.join(directory, "en_en.snbt")))
+
+
+class BetterQuestingIntegrityTests(unittest.TestCase):
+    @staticmethod
+    def _write_quest(path, text):
+        data = {"properties:10": {"betterquesting:10": {"name:8": text}}}
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, ensure_ascii=False)
+
+    @staticmethod
+    def _quest_name(path):
+        with open(path, encoding="utf-8") as handle:
+            return json.load(handle)["properties:10"]["betterquesting:10"]["name:8"]
+
+    def test_force_mode_retranslates_existing_target_text(self):
+        state = JobState(is_running=True)
+        service = _Service()
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "Quest.json")
+            self._write_quest(path, "Existing English text")
+
+            BQProcessor(service, state, _callbacks(state)).process(
+                path,
+                target_lang=TARGET_LANG,
+                mode="force",
+            )
+
+            self.assertEqual(self._quest_name(path), "translated:Existing English text")
+
+    def test_cancellation_after_translation_does_not_write_file(self):
+        state = JobState(is_running=True)
+        service = _Service(state)
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "Quest.json")
+            self._write_quest(path, "Original text")
+            with open(path, "rb") as handle:
+                original = handle.read()
+
+            BQProcessor(service, state, _callbacks(state)).process(
+                path,
+                target_lang={**TARGET_LANG, "regex": r"[А-Яа-я]"},
+                mode="append",
+            )
+
+            with open(path, "rb") as handle:
+                self.assertEqual(handle.read(), original)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- honor BetterQuesting `force` mode instead of skipping text that already matches the target language
- stop before writing a BetterQuesting file when translation is cancelled
- use the configured Minecraft locale filename for SNBT output
- preserve existing SNBT escapes and formatting while escaping only newly introduced characters

## Tests

- `python3 -m unittest -v tests.test_data_integrity` — 4 passed
- `python3 -m compileall -q mineai tests translator.py`
- `ruff check --select E9,F63,F7,F82 mineai tests translator.py`
- `git diff --check`

This PR is intentionally limited to BetterQuesting/SNBT data integrity and targets `beta`.
