### PR TITLE
fix: make persistent writes failure-safe

### DIFF
--- a/mineai/cache.py
+++ b/mineai/cache.py
@@ -1,9 +1,11 @@
 import json
 import os
+import shutil
 import threading
 from typing import Callable
 
 from mineai.constants import CACHE_FILE_AI, CACHE_FILE_STD
+from mineai.io_utils import atomic_write_text
 from mineai.text_processing import polish_translation
 
 
@@ -26,7 +28,11 @@ class TranslationCache:
             try:
                 with open(self.filepath, encoding="utf-8") as f:
                     self._data = json.load(f)
-            except (json.JSONDecodeError, OSError):
+            except json.JSONDecodeError:
+                self._backup_corrupt_file()
+                self._data = {}
+                return 0
+            except OSError:
                 self._data = {}
                 return 0
 
@@ -69,9 +75,20 @@ class TranslationCache:
                 self._flush_unlocked()
 
     def _flush_unlocked(self) -> None:
-        with open(self.filepath, "w", encoding="utf-8") as f:
-            json.dump(self._data, f, ensure_ascii=False, indent=2)
+        payload = json.dumps(self._data, ensure_ascii=False, indent=2)
+        atomic_write_text(self.filepath, payload)
         self._dirty = False
+
+    def _backup_corrupt_file(self) -> None:
+        backup = self.filepath + ".corrupt"
+        counter = 1
+        while os.path.exists(backup):
+            backup = f"{self.filepath}.corrupt.{counter}"
+            counter += 1
+        try:
+            shutil.copy2(self.filepath, backup)
+        except OSError:
+            pass
 
 
 def load_both_caches() -> tuple[TranslationCache, TranslationCache, int]:

--- a/mineai/config.py
+++ b/mineai/config.py
@@ -1,7 +1,9 @@
 import configparser
+import io
 import os
 
 from mineai.constants import SETTINGS_FILE
+from mineai.io_utils import atomic_write_text
 
 
 class ConfigManager:
@@ -52,8 +54,9 @@ class ConfigManager:
             self.save()
 
     def save(self) -> None:
-        with open(SETTINGS_FILE, "w", encoding="utf-8") as f:
-            self._config.write(f)
+        buffer = io.StringIO()
+        self._config.write(buffer)
+        atomic_write_text(SETTINGS_FILE, buffer.getvalue())
 
     def get(self, section: str, key: str) -> str:
         return self._config.get(section, key)

--- a/mineai/engines/llm_common.py
+++ b/mineai/engines/llm_common.py
@@ -7,6 +7,7 @@ from typing import Callable
 import requests
 
 from mineai.engines.base import EngineCallbacks, EngineItem, TranslationEngine
+from mineai.io_utils import atomic_write_text
 from mineai.text_processing import (
     PLACEHOLDER_PATTERN,
     polish_translation,
@@ -37,8 +38,8 @@ def load_prompts() -> dict[str, str]:
         return get_default_prompts()
 
 def save_prompts(prompts_dict: dict[str, str]) -> None:
-    with open(PROMPTS_FILE, "w", encoding="utf-8") as f:
-        json.dump(prompts_dict, f, ensure_ascii=False, indent=4)
+    payload = json.dumps(prompts_dict, ensure_ascii=False, indent=4)
+    atomic_write_text(PROMPTS_FILE, payload)
 
 
 def dump_ai_error(prompt: str, response: str, error_msg: str) -> None:

--- a/mineai/io_utils.py
+++ b/mineai/io_utils.py
@@ -1,0 +1,36 @@
+import os
+import tempfile
+
+
+def atomic_write_bytes(path: str, data: bytes) -> None:
+    """Replace a file only after its complete payload is safely written."""
+    directory = os.path.dirname(os.path.abspath(path))
+    os.makedirs(directory, exist_ok=True)
+    fd, temp_path = tempfile.mkstemp(
+        dir=directory,
+        prefix=f".{os.path.basename(path)}.",
+        suffix=".tmp",
+    )
+    try:
+        existing_mode = os.stat(path).st_mode if os.path.exists(path) else None
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if existing_mode is not None:
+            os.chmod(temp_path, existing_mode)
+        os.replace(temp_path, path)
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.remove(temp_path)
+        except OSError:
+            pass
+        raise
+
+
+def atomic_write_text(path: str, text: str, *, encoding: str = "utf-8") -> None:
+    atomic_write_bytes(path, text.encode(encoding))

--- a/mineai/output/pack_writer.py
+++ b/mineai/output/pack_writer.py
@@ -43,11 +43,7 @@ class PackWriter:
 
         dp_name = os.path.basename(self.rp_zip_path).replace(".zip", "_Datapack.zip")
         self.dp_zip_path = os.path.join(dp_dir, dp_name)
-        if os.path.exists(self.dp_zip_path):
-            try:
-                os.remove(self.dp_zip_path)
-            except OSError:
-                pass
+        self.dp_zip_path = self._unique_path(dp_dir, dp_name)
         self._create_zip(self.dp_zip_path, fmt["dp"], f"{dp_name} - MineAI")
         self.dp_handle = zipfile.ZipFile(self.dp_zip_path, "a", compression=zipfile.ZIP_DEFLATED)
 
@@ -56,17 +52,13 @@ class PackWriter:
         path = os.path.join(directory, filename)
         if not os.path.exists(path):
             return path
-        try:
-            os.remove(path)
-            return path
-        except OSError:
-            base, ext = os.path.splitext(filename)
-            counter = 1
-            while True:
-                candidate = os.path.join(directory, f"{base}_{counter}{ext}")
-                if not os.path.exists(candidate):
-                    return candidate
-                counter += 1
+        base, ext = os.path.splitext(filename)
+        counter = 1
+        while True:
+            candidate = os.path.join(directory, f"{base}_{counter}{ext}")
+            if not os.path.exists(candidate):
+                return candidate
+            counter += 1
 
     @staticmethod
     def _create_zip(path: str, pack_format: int, description: str) -> None:

--- a/mineai/processors/loose_json.py
+++ b/mineai/processors/loose_json.py
@@ -3,6 +3,7 @@ import os
 
 from mineai.engines.base import EngineCallbacks
 from mineai.engines.service import TranslationService
+from mineai.io_utils import atomic_write_bytes
 from mineai.json_utils import load_lenient_json
 from mineai.output.pack_writer import PackWriter
 from mineai.processors.locale_keys import collect_lang_keys_to_translate, count_translatable_lang_entries
@@ -79,5 +80,4 @@ class LooseJsonProcessor:
         if output_mode == "resourcepack" and pack_writer:
             pack_writer.write(tr_internal, payload)
         elif output_mode == "inplace":
-            with open(tr_disk, "wb") as f:
-                f.write(payload)
+            atomic_write_bytes(tr_disk, payload)

--- a/mineai/text_processing.py
+++ b/mineai/text_processing.py
@@ -3,6 +3,7 @@ import re
 from functools import lru_cache
 
 from mineai.constants import DICT_FILE, IGNORE_TERMS
+from mineai.io_utils import atomic_write_text
 
 
 PLACEHOLDER_PATTERN = re.compile(r"\[\s*#\s*(\d+)\s*#\s*\]")
@@ -42,8 +43,10 @@ def apply_smart_glue(text: str) -> str:
 def load_dictionary() -> dict[str, str]:
     if not __import__("os").path.exists(DICT_FILE):
         default = {"полуслой": "плита", "сыромятная медь": "сырая медь"}
-        with open(DICT_FILE, "w", encoding="utf-8") as f:
-            json.dump(default, f, ensure_ascii=False, indent=4)
+        atomic_write_text(
+            DICT_FILE,
+            json.dumps(default, ensure_ascii=False, indent=4),
+        )
         return default
     try:
         with open(DICT_FILE, encoding="utf-8") as f:

--- a/tests/test_safe_writes.py
+++ b/tests/test_safe_writes.py
@@ -1,0 +1,67 @@
+import json
+import os
+import tempfile
+import unittest
+from unittest import mock
+import zipfile
+
+from mineai.cache import TranslationCache
+from mineai.io_utils import atomic_write_bytes
+from mineai.output.pack_writer import PackWriter
+
+
+class AtomicWriteTests(unittest.TestCase):
+    def test_failed_replace_preserves_original_and_removes_temp_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "data.json")
+            with open(path, "wb") as handle:
+                handle.write(b"original")
+
+            with mock.patch("mineai.io_utils.os.replace", side_effect=OSError("locked")):
+                with self.assertRaisesRegex(OSError, "locked"):
+                    atomic_write_bytes(path, b"replacement")
+
+            with open(path, "rb") as handle:
+                self.assertEqual(handle.read(), b"original")
+            self.assertEqual(os.listdir(directory), ["data.json"])
+
+    def test_corrupt_cache_is_backed_up_before_next_save(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "cache.json")
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write("{not-json")
+
+            cache = TranslationCache(path)
+            cache.set("ru", "Hello", "Привет")
+            cache.save()
+
+            with open(path + ".corrupt", encoding="utf-8") as handle:
+                self.assertEqual(handle.read(), "{not-json")
+            with open(path, encoding="utf-8") as handle:
+                self.assertEqual(json.load(handle)["ru_Hello"], "Привет")
+
+
+class PackWriterTests(unittest.TestCase):
+    def test_existing_pack_is_preserved_and_new_pack_gets_unique_name(self):
+        with tempfile.TemporaryDirectory() as directory:
+            resourcepacks = os.path.join(directory, "resourcepacks")
+            os.makedirs(resourcepacks)
+            existing = os.path.join(resourcepacks, "MineAI_Pack.zip")
+            with open(existing, "wb") as handle:
+                handle.write(b"existing-pack")
+
+            writer = PackWriter(directory, "MineAI_Pack", "1.20.1", "Russian")
+            writer.close()
+
+            with open(existing, "rb") as handle:
+                self.assertEqual(handle.read(), b"existing-pack")
+            self.assertEqual(
+                writer.rp_zip_path,
+                os.path.join(resourcepacks, "MineAI_Pack_1.zip"),
+            )
+            with zipfile.ZipFile(writer.rp_zip_path) as archive:
+                self.assertIn("pack.mcmeta", archive.namelist())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add reusable atomic text/byte write helpers using a temporary file and `os.replace`
- use atomic writes for cache, settings, prompts, dictionary, and loose JSON output
- preserve a corrupt cache as `.corrupt` before rebuilding it
- never delete an existing resource-pack/datapack ZIP before a replacement has been created; select a unique output path instead
- add regression tests for failed replacement, corrupt-cache recovery, and existing-pack preservation

## Tests

- `python3 -m unittest -v tests.test_safe_writes` — 3 passed
- `python3 -m compileall -q mineai tests translator.py`
- `ruff check --select E9,F63,F7,F82 mineai tests translator.py`
- `git diff --check`

This PR is intentionally limited to persistent-write safety and targets `beta`.
