### PR TITLE
Стабилизация сетевых движков: retries и изоляция ошибок батчей

### DIFF
--- a/mineai/engines/deepl.py
+++ b/mineai/engines/deepl.py
@@ -45,6 +45,7 @@ class DeepLEngine(TranslationEngine):
                         timeout=60,
                     ),
                     operation="DeepL request",
+                    on_retry=lambda message: callbacks.on_log(f"⚠️ {message}", "yellow"),
                 )
                 translations = response.json()["translations"]
                 for idx, key in enumerate(chunk_keys):

--- a/mineai/engines/deepl.py
+++ b/mineai/engines/deepl.py
@@ -1,9 +1,14 @@
+import logging
 import time
 
 import requests
 
 from mineai.engines.base import EngineCallbacks, EngineItem, TranslationEngine
+from mineai.engines.http_retry import request_with_retry
 from mineai.text_processing import polish_translation, unmask_translation
+
+
+logger = logging.getLogger(__name__)
 
 
 class DeepLEngine(TranslationEngine):
@@ -29,22 +34,25 @@ class DeepLEngine(TranslationEngine):
                 break
             chunk_keys = keys[i : i + 40]
             try:
-                response = requests.post(
-                    self.url,
-                    headers={"Authorization": f"DeepL-Auth-Key {self.api_key}"},
-                    json={
-                        "text": [items[k].masked for k in chunk_keys],
-                        "target_lang": target_lang["deepl"],
-                    },
-                    timeout=60,
+                response = request_with_retry(
+                    lambda: requests.post(
+                        self.url,
+                        headers={"Authorization": f"DeepL-Auth-Key {self.api_key}"},
+                        json={
+                            "text": [items[k].masked for k in chunk_keys],
+                            "target_lang": target_lang["deepl"],
+                        },
+                        timeout=60,
+                    ),
+                    operation="DeepL request",
                 )
-                response.raise_for_status()
                 translations = response.json()["translations"]
                 for idx, key in enumerate(chunk_keys):
                     raw = translations[idx]["text"]
                     raw = unmask_translation(raw, items[key].mapping)
                     result[key] = polish_translation(raw)
-            except (requests.RequestException, KeyError, IndexError) as exc:
+            except (requests.RequestException, KeyError, IndexError, TypeError, ValueError) as exc:
+                logger.exception("DeepL batch failed")
                 callbacks.on_log(f"❌ Ошибка DeepL: {exc}", "red")
                 for key in chunk_keys:
                     result[key] = items[key].original

--- a/mineai/engines/google.py
+++ b/mineai/engines/google.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import time
 
@@ -5,7 +6,11 @@ import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from mineai.engines.base import EngineCallbacks, EngineItem, TranslationEngine
+from mineai.engines.http_retry import request_with_retry
 from mineai.text_processing import polish_translation, unmask_translation
+
+
+logger = logging.getLogger(__name__)
 
 
 class GoogleEngine(TranslationEngine):
@@ -17,21 +22,19 @@ class GoogleEngine(TranslationEngine):
         self.mode = mode
 
     def _request(self, text: str, api_code: str, timeout: int = 10) -> str | None:
-        for _ in range(3):
-            try:
-                r = requests.get(
-                    self.API_URL,
-                    params={"client": "gtx", "sl": "en", "tl": api_code, "dt": "t", "q": text},
-                    timeout=timeout,
-                )
-                if r.status_code == 429:
-                    time.sleep(3)
-                    continue
-                if r.ok:
-                    return "".join(part[0] for part in r.json()[0] if part[0])
-            except (requests.RequestException, KeyError, IndexError, ValueError):
-                time.sleep(1)
-        return None
+        response = request_with_retry(
+            lambda: requests.get(
+                self.API_URL,
+                params={"client": "gtx", "sl": "en", "tl": api_code, "dt": "t", "q": text},
+                timeout=timeout,
+            ),
+            operation="Google Translate request",
+        )
+        try:
+            return "".join(part[0] for part in response.json()[0] if part[0])
+        except (KeyError, IndexError, TypeError, ValueError) as exc:
+            logger.error("Google Translate returned an invalid response: %s", exc)
+            return None
 
     def _finalize(self, raw: str, item: EngineItem) -> str:
         text = unmask_translation(raw, item.mapping)

--- a/mineai/engines/google.py
+++ b/mineai/engines/google.py
@@ -69,10 +69,16 @@ class GoogleEngine(TranslationEngine):
                 callbacks.wait_if_paused()
                 if not callbacks.should_run():
                     break
-                key, raw = fut.result()
-                if raw:
-                    result[key] = self._finalize(raw, items[key])
-                else:
+                key = futures[fut]
+                try:
+                    _, raw = fut.result()
+                    if raw:
+                        result[key] = self._finalize(raw, items[key])
+                    else:
+                        result[key] = items[key].original
+                except Exception as exc:
+                    logger.exception("Google Translate item failed: %s", key)
+                    callbacks.on_log(f"❌ Ошибка Google для строки {key}: {exc}", "red")
                     result[key] = items[key].original
         return result
 
@@ -108,20 +114,44 @@ class GoogleEngine(TranslationEngine):
             return chunk_keys, None
 
         with ThreadPoolExecutor(max_workers=self.workers) as pool:
-            futures = [pool.submit(translate_chunk, ck, ct) for ck, ct in chunks]
+            futures = {
+                pool.submit(translate_chunk, chunk_keys, text): chunk_keys
+                for chunk_keys, text in chunks
+            }
             for fut in as_completed(futures):
                 callbacks.wait_if_paused()
                 if not callbacks.should_run():
                     break
-                chunk_keys, parts = fut.result()
+                chunk_keys = futures[fut]
+                try:
+                    _, parts = fut.result()
+                except Exception as exc:
+                    logger.exception("Google Translate batch failed")
+                    callbacks.on_log(
+                        f"❌ Ошибка пакета Google ({len(chunk_keys)} строк): {exc}",
+                        "red",
+                    )
+                    parts = None
+
                 if parts:
                     for idx, key in enumerate(chunk_keys):
                         result[key] = self._finalize(parts[idx].strip(), items[key])
-                else:
-                    for key in chunk_keys:
+                    continue
+
+                for key in chunk_keys:
+                    try:
                         single = self._request(items[key].masked, api_code, timeout=5)
                         result[key] = (
-                            self._finalize(single, items[key]) if single else items[key].original
+                            self._finalize(single, items[key])
+                            if single
+                            else items[key].original
                         )
-                        time.sleep(0.3)
+                    except Exception as exc:
+                        logger.exception("Google Translate fallback item failed: %s", key)
+                        callbacks.on_log(
+                            f"❌ Ошибка Google для строки {key}: {exc}",
+                            "red",
+                        )
+                        result[key] = items[key].original
+                    time.sleep(0.3)
         return result

--- a/mineai/engines/google.py
+++ b/mineai/engines/google.py
@@ -20,6 +20,8 @@ class GoogleEngine(TranslationEngine):
     def __init__(self, workers: int = 5, mode: str = "single") -> None:
         self.workers = max(1, min(workers, 10))
         self.mode = mode
+        self._on_retry = None
+        self._on_log = None
 
     def _request(self, text: str, api_code: str, timeout: int = 10) -> str | None:
         response = request_with_retry(
@@ -29,11 +31,14 @@ class GoogleEngine(TranslationEngine):
                 timeout=timeout,
             ),
             operation="Google Translate request",
+            on_retry=self._on_retry,
         )
         try:
             return "".join(part[0] for part in response.json()[0] if part[0])
         except (KeyError, IndexError, TypeError, ValueError) as exc:
             logger.error("Google Translate returned an invalid response: %s", exc)
+            if self._on_log is not None:
+                self._on_log(f"⚠️ Google вернул некорректный ответ ({exc})", "yellow")
             return None
 
     def _finalize(self, raw: str, item: EngineItem) -> str:
@@ -48,10 +53,16 @@ class GoogleEngine(TranslationEngine):
     ) -> dict[str, str]:
         if not items:
             return {}
-        api_code = target_lang["api"]
-        if self.mode == "batch":
-            return self._translate_batch_mode(items, api_code, callbacks)
-        return self._translate_single_mode(items, api_code, callbacks)
+        self._on_retry = lambda message: callbacks.on_log(f"⚠️ {message}", "yellow")
+        self._on_log = callbacks.on_log
+        try:
+            api_code = target_lang["api"]
+            if self.mode == "batch":
+                return self._translate_batch_mode(items, api_code, callbacks)
+            return self._translate_single_mode(items, api_code, callbacks)
+        finally:
+            self._on_retry = None
+            self._on_log = None
 
     def _translate_single_mode(
         self, items: dict[str, EngineItem], api_code: str, callbacks: EngineCallbacks

--- a/mineai/engines/http_retry.py
+++ b/mineai/engines/http_retry.py
@@ -1,6 +1,8 @@
 """Shared HTTP retry helpers for translation engines."""
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 import logging
 import time
 
@@ -22,22 +24,54 @@ def _is_retryable(exc: requests.RequestException) -> bool:
     return False
 
 
+def _retry_after_seconds(exc: requests.RequestException) -> float | None:
+    if not isinstance(exc, requests.HTTPError) or exc.response is None:
+        return None
+    if exc.response.status_code != 429:
+        return None
+    headers = getattr(exc.response, "headers", {}) or {}
+    raw = headers.get("Retry-After")
+    if not raw:
+        return None
+    try:
+        return max(0.0, float(raw))
+    except (TypeError, ValueError):
+        pass
+    try:
+        retry_at = parsedate_to_datetime(str(raw))
+        if retry_at.tzinfo is None:
+            retry_at = retry_at.replace(tzinfo=timezone.utc)
+        return max(0.0, (retry_at - datetime.now(timezone.utc)).total_seconds())
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def _retry_delay(exc, retry_index, base_delay, rate_limit_delays):
+    retry_after = _retry_after_seconds(exc)
+    if retry_after is not None:
+        return retry_after
+    if (rate_limit_delays and isinstance(exc, requests.HTTPError)
+            and exc.response is not None and exc.response.status_code == 429):
+        return float(rate_limit_delays[min(retry_index, len(rate_limit_delays) - 1)])
+    return base_delay * (2 ** retry_index)
+
+
 def request_with_retry(
     request: Callable[[], requests.Response],
     *,
     operation: str,
     attempts: int = DEFAULT_ATTEMPTS,
     base_delay: float = DEFAULT_BASE_DELAY,
+    rate_limit_delays: Sequence[float] | None = None,
+    on_retry: Callable[[str], None] | None = None,
 ) -> requests.Response:
-    """Execute an HTTP request with bounded exponential backoff.
-
-    Timeouts, connection failures, HTTP 429 and HTTP 5xx responses are retried.
-    Other HTTP and request errors are raised immediately.
-    """
+    """Execute an HTTP request with configurable retry delays."""
     if attempts < 1:
         raise ValueError("attempts must be at least 1")
     if base_delay < 0:
         raise ValueError("base_delay must be non-negative")
+    if rate_limit_delays is not None and (not rate_limit_delays or any(d < 0 for d in rate_limit_delays)):
+        raise ValueError("rate_limit_delays must contain non-negative values")
 
     for attempt in range(1, attempts + 1):
         try:
@@ -47,16 +81,16 @@ def request_with_retry(
         except requests.RequestException as exc:
             if not _is_retryable(exc) or attempt >= attempts:
                 raise
-
-            delay = base_delay * (2 ** (attempt - 1))
-            logger.warning(
-                "%s failed on attempt %s/%s: %s; retrying in %.1f seconds",
-                operation,
-                attempt,
-                attempts,
-                exc,
-                delay,
+            delay = _retry_delay(exc, attempt - 1, base_delay, rate_limit_delays)
+            message = (
+                f"{operation}: попытка {attempt}/{attempts} завершилась ошибкой {exc}; "
+                f"повтор через {delay:.1f} сек."
             )
+            logger.warning(message)
+            if on_retry is not None:
+                try:
+                    on_retry(message)
+                except Exception:
+                    logger.exception("Retry notification callback failed")
             time.sleep(delay)
-
     raise RuntimeError("unreachable retry state")

--- a/mineai/engines/http_retry.py
+++ b/mineai/engines/http_retry.py
@@ -1,0 +1,62 @@
+"""Shared HTTP retry helpers for translation engines."""
+
+from collections.abc import Callable
+import logging
+import time
+
+import requests
+
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ATTEMPTS = 4
+DEFAULT_BASE_DELAY = 1.0
+
+
+def _is_retryable(exc: requests.RequestException) -> bool:
+    if isinstance(exc, (requests.Timeout, requests.ConnectionError)):
+        return True
+    if isinstance(exc, requests.HTTPError) and exc.response is not None:
+        status_code = exc.response.status_code
+        return status_code == 429 or 500 <= status_code <= 599
+    return False
+
+
+def request_with_retry(
+    request: Callable[[], requests.Response],
+    *,
+    operation: str,
+    attempts: int = DEFAULT_ATTEMPTS,
+    base_delay: float = DEFAULT_BASE_DELAY,
+) -> requests.Response:
+    """Execute an HTTP request with bounded exponential backoff.
+
+    Timeouts, connection failures, HTTP 429 and HTTP 5xx responses are retried.
+    Other HTTP and request errors are raised immediately.
+    """
+    if attempts < 1:
+        raise ValueError("attempts must be at least 1")
+    if base_delay < 0:
+        raise ValueError("base_delay must be non-negative")
+
+    for attempt in range(1, attempts + 1):
+        try:
+            response = request()
+            response.raise_for_status()
+            return response
+        except requests.RequestException as exc:
+            if not _is_retryable(exc) or attempt >= attempts:
+                raise
+
+            delay = base_delay * (2 ** (attempt - 1))
+            logger.warning(
+                "%s failed on attempt %s/%s: %s; retrying in %.1f seconds",
+                operation,
+                attempt,
+                attempts,
+                exc,
+                delay,
+            )
+            time.sleep(delay)
+
+    raise RuntimeError("unreachable retry state")

--- a/mineai/engines/kobold.py
+++ b/mineai/engines/kobold.py
@@ -1,29 +1,51 @@
+import logging
+
 import requests
 
 from mineai.constants import KOBOLD_API
+from mineai.engines.http_retry import request_with_retry
 from mineai.engines.llm_common import BatchLlmEngine
 
 
+logger = logging.getLogger(__name__)
+
+
 class KoboldEngine(BatchLlmEngine):
-    def __init__(self, mode: str = "safe", context: str = "", prompt_type: str = "mods", retries: int = 3) -> None:  # <--- ДОБАВИЛИ retries: int = 3
+    def __init__(
+        self,
+        mode: str = "safe",
+        context: str = "",
+        prompt_type: str = "mods",
+        retries: int = 3,
+    ) -> None:
         super().__init__(
             mode=mode,
             context=context,
             prompt_type=prompt_type,
             call_api=self._request,
             label="KoboldCPP",
-            retries=retries,  # <--- НОВАЯ СТРОКА
+            retries=retries,
         )
 
     def _request(self, prompt: str, max_tokens: int) -> str | None:
-        response = requests.post(
-            KOBOLD_API,
-            json={
-                "messages": [{"role": "user", "content": prompt}],
-                "temperature": 0.1,
-                "max_tokens": max_tokens,
-            },
-            timeout=300,
+        response = request_with_retry(
+            lambda: requests.post(
+                KOBOLD_API,
+                json={
+                    "messages": [{"role": "user", "content": prompt}],
+                    "temperature": 0.1,
+                    "max_tokens": max_tokens,
+                },
+                timeout=300,
+            ),
+            operation="KoboldCPP request",
         )
-        response.raise_for_status()
-        return response.json()["choices"][0]["message"]["content"].strip()
+        try:
+            content = response.json()["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError, ValueError) as exc:
+            logger.error("KoboldCPP returned an invalid response: %s", exc)
+            return None
+        if not isinstance(content, str) or not content.strip():
+            logger.warning("KoboldCPP returned an empty response")
+            return None
+        return content.strip()

--- a/mineai/engines/kobold.py
+++ b/mineai/engines/kobold.py
@@ -3,6 +3,7 @@ import logging
 import requests
 
 from mineai.constants import KOBOLD_API
+from mineai.engines.base import EngineCallbacks, EngineItem
 from mineai.engines.http_retry import request_with_retry
 from mineai.engines.llm_common import BatchLlmEngine
 
@@ -18,6 +19,7 @@ class KoboldEngine(BatchLlmEngine):
         prompt_type: str = "mods",
         retries: int = 3,
     ) -> None:
+        self._on_log = None
         super().__init__(
             mode=mode,
             context=context,
@@ -26,6 +28,17 @@ class KoboldEngine(BatchLlmEngine):
             label="KoboldCPP",
             retries=retries,
         )
+
+    def translate_batch(self, items: dict[str, EngineItem], target_lang: dict, callbacks: EngineCallbacks) -> dict[str, str]:
+        self._on_log = callbacks.on_log
+        try:
+            return super().translate_batch(items, target_lang, callbacks)
+        finally:
+            self._on_log = None
+
+    def _notify(self, message: str, tag: str) -> None:
+        if self._on_log is not None:
+            self._on_log(message, tag)
 
     def _request(self, prompt: str, max_tokens: int) -> str | None:
         response = request_with_retry(
@@ -39,13 +52,16 @@ class KoboldEngine(BatchLlmEngine):
                 timeout=300,
             ),
             operation="KoboldCPP request",
+            on_retry=lambda message: self._notify(f"⚠️ {message}", "yellow"),
         )
         try:
             content = response.json()["choices"][0]["message"]["content"]
         except (KeyError, IndexError, TypeError, ValueError) as exc:
             logger.error("KoboldCPP returned an invalid response: %s", exc)
+            self._notify(f"❌ KoboldCPP: некорректный ответ API ({exc})", "red")
             return None
         if not isinstance(content, str) or not content.strip():
             logger.warning("KoboldCPP returned an empty response")
+            self._notify("⚠️ KoboldCPP вернул пустой ответ", "yellow")
             return None
         return content.strip()

--- a/mineai/engines/openrouter.py
+++ b/mineai/engines/openrouter.py
@@ -1,8 +1,13 @@
-import time
+import logging
+
 import requests
 
 from mineai.constants import OPENROUTER_API
+from mineai.engines.http_retry import request_with_retry
 from mineai.engines.llm_common import BatchLlmEngine
+
+
+logger = logging.getLogger(__name__)
 
 
 class OpenRouterEngine(BatchLlmEngine):
@@ -45,13 +50,8 @@ class OpenRouterEngine(BatchLlmEngine):
         return headers
 
     def _request(self, prompt: str, max_tokens: int) -> str | None:
-        max_retries = 3
-        base_delay = 4  # Базовая пауза в 4 секунды между запросами для бесплатных ИИ
-
-        for attempt in range(max_retries):
-            if attempt > 0:
-                time.sleep(base_delay)
-            response = requests.post(
+        response = request_with_retry(
+            lambda: requests.post(
                 self.api_url,
                 headers=self._headers(),
                 json={
@@ -61,27 +61,15 @@ class OpenRouterEngine(BatchLlmEngine):
                     "max_tokens": max_tokens,
                 },
                 timeout=300,
-            )
-            
-            # Если словили лимит (429), ждем дольше и пробуем снова
-            if response.status_code == 429:
-                wait_time = 15 * (attempt + 1)
-                print(f"\n[OpenRouter] Поймали лимит 429. Ждем {wait_time} сек. (Попытка {attempt + 1}/{max_retries})...")
-                time.sleep(wait_time)
-                continue
-
-            if not response.ok:
-                detail = response.text[:200] if response.text else response.reason
-                raise requests.HTTPError(f"{response.status_code}: {detail}", response=response)
-            
-            data = response.json()
-            content = data.get("choices", [{}])[0].get("message", {}).get("content")
-            
-            if content is None:
-                print("\n[Предупреждение] OpenRouter вернул пустой ответ (возможно, сработал фильтр модели).")
-                return None
-                
-            return content.strip()
-            
-        print("\n[Ошибка] Не удалось получить ответ: бесплатная модель слишком перегружена.")
-        return None
+            ),
+            operation="OpenRouter request",
+        )
+        try:
+            content = response.json()["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError, ValueError) as exc:
+            logger.error("OpenRouter returned an invalid response: %s", exc)
+            return None
+        if not isinstance(content, str) or not content.strip():
+            logger.warning("OpenRouter returned an empty response")
+            return None
+        return content.strip()

--- a/mineai/engines/openrouter.py
+++ b/mineai/engines/openrouter.py
@@ -3,6 +3,7 @@ import logging
 import requests
 
 from mineai.constants import OPENROUTER_API
+from mineai.engines.base import EngineCallbacks, EngineItem
 from mineai.engines.http_retry import request_with_retry
 from mineai.engines.llm_common import BatchLlmEngine
 
@@ -29,6 +30,7 @@ class OpenRouterEngine(BatchLlmEngine):
         self.model = model.strip()
         self.site_url = site_url.strip()
         self.app_name = app_name.strip() or "MineAI Translator"
+        self._on_log = None
         super().__init__(
             mode=mode,
             context=context,
@@ -37,6 +39,17 @@ class OpenRouterEngine(BatchLlmEngine):
             label="OpenRouter",
             retries=retries,
         )
+
+    def translate_batch(self, items: dict[str, EngineItem], target_lang: dict, callbacks: EngineCallbacks) -> dict[str, str]:
+        self._on_log = callbacks.on_log
+        try:
+            return super().translate_batch(items, target_lang, callbacks)
+        finally:
+            self._on_log = None
+
+    def _notify(self, message: str, tag: str) -> None:
+        if self._on_log is not None:
+            self._on_log(message, tag)
 
     def _headers(self) -> dict[str, str]:
         headers = {
@@ -63,13 +76,18 @@ class OpenRouterEngine(BatchLlmEngine):
                 timeout=300,
             ),
             operation="OpenRouter request",
+            attempts=4,
+            rate_limit_delays=(15.0, 30.0, 45.0),
+            on_retry=lambda message: self._notify(f"⚠️ {message}", "yellow"),
         )
         try:
             content = response.json()["choices"][0]["message"]["content"]
         except (KeyError, IndexError, TypeError, ValueError) as exc:
             logger.error("OpenRouter returned an invalid response: %s", exc)
+            self._notify(f"❌ OpenRouter: некорректный ответ API ({exc})", "red")
             return None
         if not isinstance(content, str) or not content.strip():
             logger.warning("OpenRouter returned an empty response")
+            self._notify("⚠️ OpenRouter вернул пустой ответ", "yellow")
             return None
         return content.strip()

--- a/tests/test_engine_batch_isolation.py
+++ b/tests/test_engine_batch_isolation.py
@@ -1,0 +1,66 @@
+import unittest
+from unittest import mock
+
+import requests
+
+from mineai.engines.base import EngineCallbacks, EngineItem
+from mineai.engines.google import GoogleEngine
+
+
+def callbacks(logs=None) -> EngineCallbacks:
+    logs = logs if logs is not None else []
+    return EngineCallbacks(
+        should_run=lambda: True,
+        wait_if_paused=lambda: None,
+        on_log=lambda message, tag: logs.append((message, tag)),
+        on_status=lambda _message: None,
+    )
+
+
+class GoogleBatchIsolationTests(unittest.TestCase):
+    def test_single_mode_isolates_failed_future(self) -> None:
+        logs = []
+        engine = GoogleEngine(workers=1, mode="single")
+        items = {
+            "bad": EngineItem("bad", "Bad", "Bad"),
+            "good": EngineItem("good", "Good", "Good"),
+        }
+
+        def request(text: str, _api_code: str, timeout: int = 10):
+            del timeout
+            if text == "Bad":
+                raise requests.ConnectionError("temporary failure")
+            return "Хорошо"
+
+        with mock.patch.object(engine, "_request", side_effect=request):
+            result = engine.translate_batch(items, {"api": "ru"}, callbacks(logs))
+
+        self.assertEqual(result["bad"], "Bad")
+        self.assertEqual(result["good"], "Хорошо")
+        self.assertTrue(any("Ошибка Google" in message for message, _tag in logs))
+
+    def test_batch_mode_continues_with_single_fallback(self) -> None:
+        logs = []
+        engine = GoogleEngine(workers=1, mode="batch")
+        items = {
+            "first": EngineItem("first", "First", "First"),
+            "second": EngineItem("second", "Second", "Second"),
+        }
+        calls = []
+
+        def request(text: str, _api_code: str, timeout: int = 10):
+            calls.append((text, timeout))
+            if timeout == 10:
+                raise requests.ConnectionError("batch failed")
+            return {"First": "Первый", "Second": "Второй"}[text]
+
+        with mock.patch.object(engine, "_request", side_effect=request):
+            result = engine.translate_batch(items, {"api": "ru"}, callbacks(logs))
+
+        self.assertEqual(result, {"first": "Первый", "second": "Второй"})
+        self.assertTrue(any("Ошибка пакета Google" in message for message, _tag in logs))
+        self.assertEqual(sum(timeout == 5 for _text, timeout in calls), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_engine_network_resilience.py
+++ b/tests/test_engine_network_resilience.py
@@ -1,0 +1,170 @@
+import unittest
+from unittest import mock
+
+import requests
+
+from mineai.engines.base import EngineCallbacks, EngineItem
+from mineai.engines.deepl import DeepLEngine
+from mineai.engines.google import GoogleEngine
+from mineai.engines.http_retry import request_with_retry
+from mineai.engines.kobold import KoboldEngine
+from mineai.engines.openrouter import OpenRouterEngine
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, payload=None, text: str = "") -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+        self.reason = text or f"HTTP {status_code}"
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            error = requests.HTTPError(
+                f"{self.status_code}: {self.reason}",
+                response=self,
+            )
+            raise error
+
+    def json(self):
+        return self._payload
+
+
+def callbacks(logs=None) -> EngineCallbacks:
+    logs = logs if logs is not None else []
+    return EngineCallbacks(
+        should_run=lambda: True,
+        wait_if_paused=lambda: None,
+        on_log=lambda message, tag: logs.append((message, tag)),
+        on_status=lambda _message: None,
+    )
+
+
+class HttpRetryTests(unittest.TestCase):
+    def test_retries_429_and_5xx_with_exponential_backoff(self) -> None:
+        responses = iter(
+            [
+                FakeResponse(429, text="rate limited"),
+                FakeResponse(503, text="unavailable"),
+                FakeResponse(200, payload={"ok": True}),
+            ]
+        )
+
+        with mock.patch("mineai.engines.http_retry.time.sleep") as sleep:
+            response = request_with_retry(
+                lambda: next(responses),
+                operation="test request",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual([call.args[0] for call in sleep.call_args_list], [1.0, 2.0])
+
+    def test_retries_timeouts_using_delays_one_two_four(self) -> None:
+        request = mock.Mock(
+            side_effect=[
+                requests.Timeout("first"),
+                requests.Timeout("second"),
+                requests.Timeout("third"),
+                FakeResponse(200),
+            ]
+        )
+
+        with mock.patch("mineai.engines.http_retry.time.sleep") as sleep:
+            response = request_with_retry(request, operation="test request")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual([call.args[0] for call in sleep.call_args_list], [1.0, 2.0, 4.0])
+
+    def test_does_not_retry_non_retryable_4xx(self) -> None:
+        request = mock.Mock(return_value=FakeResponse(401, text="unauthorized"))
+
+        with mock.patch("mineai.engines.http_retry.time.sleep") as sleep:
+            with self.assertRaises(requests.HTTPError):
+                request_with_retry(request, operation="test request")
+
+        request.assert_called_once_with()
+        sleep.assert_not_called()
+
+
+class EngineRetryIntegrationTests(unittest.TestCase):
+    def test_google_retries_timeout(self) -> None:
+        engine = GoogleEngine(workers=1)
+        success = FakeResponse(200, payload=[[['Привет']]])
+
+        with (
+            mock.patch(
+                "mineai.engines.google.requests.get",
+                side_effect=[requests.Timeout("temporary"), success],
+            ),
+            mock.patch("mineai.engines.http_retry.time.sleep") as sleep,
+        ):
+            result = engine._request("Hello", "ru")
+
+        self.assertEqual(result, "Привет")
+        sleep.assert_called_once_with(1.0)
+
+    def test_deepl_retries_5xx(self) -> None:
+        engine = DeepLEngine("secret:fx")
+        items = {"key": EngineItem("key", "Hello", "Hello")}
+        success = FakeResponse(
+            200,
+            payload={"translations": [{"text": "Привет"}]},
+        )
+
+        with (
+            mock.patch(
+                "mineai.engines.deepl.requests.post",
+                side_effect=[FakeResponse(503), success],
+            ),
+            mock.patch("mineai.engines.deepl.time.sleep") as sleep,
+        ):
+            result = engine.translate_batch(
+                items,
+                {"api": "ru", "deepl": "RU"},
+                callbacks(),
+            )
+
+        self.assertEqual(result, {"key": "Привет"})
+        self.assertEqual([call.args[0] for call in sleep.call_args_list], [1.0, 0.5])
+
+    def test_openrouter_retries_429(self) -> None:
+        engine = OpenRouterEngine(api_key="secret", model="model")
+        success = FakeResponse(
+            200,
+            payload={"choices": [{"message": {"content": "translated"}}]},
+        )
+
+        with (
+            mock.patch(
+                "mineai.engines.openrouter.requests.post",
+                side_effect=[FakeResponse(429), success],
+            ),
+            mock.patch("mineai.engines.http_retry.time.sleep") as sleep,
+        ):
+            result = engine._request("prompt", 100)
+
+        self.assertEqual(result, "translated")
+        sleep.assert_called_once_with(1.0)
+
+    def test_kobold_retries_5xx(self) -> None:
+        engine = KoboldEngine()
+        success = FakeResponse(
+            200,
+            payload={"choices": [{"message": {"content": "translated"}}]},
+        )
+
+        with (
+            mock.patch(
+                "mineai.engines.kobold.requests.post",
+                side_effect=[FakeResponse(500), success],
+            ),
+            mock.patch("mineai.engines.http_retry.time.sleep") as sleep,
+        ):
+            result = engine._request("prompt", 100)
+
+        self.assertEqual(result, "translated")
+        sleep.assert_called_once_with(1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_engine_network_resilience.py
+++ b/tests/test_engine_network_resilience.py
@@ -12,11 +12,12 @@ from mineai.engines.openrouter import OpenRouterEngine
 
 
 class FakeResponse:
-    def __init__(self, status_code: int, payload=None, text: str = "") -> None:
+    def __init__(self, status_code: int, payload=None, text: str = "", headers=None) -> None:
         self.status_code = status_code
         self._payload = payload
         self.text = text
         self.reason = text or f"HTTP {status_code}"
+        self.headers = headers or {}
 
     def raise_for_status(self) -> None:
         if self.status_code >= 400:
@@ -85,6 +86,20 @@ class HttpRetryTests(unittest.TestCase):
         request.assert_called_once_with()
         sleep.assert_not_called()
 
+    def test_respects_retry_after_header(self) -> None:
+        responses = iter([FakeResponse(429, headers={"Retry-After": "12"}), FakeResponse(200)])
+        notices = []
+        with mock.patch("mineai.engines.http_retry.time.sleep") as sleep:
+            response = request_with_retry(
+                lambda: next(responses),
+                operation="test request",
+                rate_limit_delays=(15.0, 30.0, 45.0),
+                on_retry=notices.append,
+            )
+        self.assertEqual(response.status_code, 200)
+        sleep.assert_called_once_with(12.0)
+        self.assertTrue(any("повтор через 12.0" in message for message in notices))
+
 
 class EngineRetryIntegrationTests(unittest.TestCase):
     def test_google_retries_timeout(self) -> None:
@@ -144,7 +159,22 @@ class EngineRetryIntegrationTests(unittest.TestCase):
             result = engine._request("prompt", 100)
 
         self.assertEqual(result, "translated")
-        sleep.assert_called_once_with(1.0)
+        sleep.assert_called_once_with(15.0)
+
+    def test_openrouter_uses_long_backoff_for_repeated_429(self) -> None:
+        engine = OpenRouterEngine(api_key="secret", model="model")
+        success = FakeResponse(200, payload={"choices": [{"message": {"content": "translated"}}]})
+        notices = []
+        engine._on_log = lambda message, tag: notices.append((message, tag))
+        with (
+            mock.patch("mineai.engines.openrouter.requests.post", side_effect=[FakeResponse(429), FakeResponse(429), FakeResponse(429), success]),
+            mock.patch("mineai.engines.http_retry.time.sleep") as sleep,
+        ):
+            result = engine._request("prompt", 100)
+        self.assertEqual(result, "translated")
+        self.assertEqual([call.args[0] for call in sleep.call_args_list], [15.0, 30.0, 45.0])
+        self.assertEqual(len(notices), 3)
+        self.assertTrue(all(tag == "yellow" for _message, tag in notices))
 
     def test_kobold_retries_5xx(self) -> None:
         engine = KoboldEngine()


### PR DESCRIPTION
---

## Описание

### Что изменено

Этот PR повышает отказоустойчивость сетевых движков перевода без добавления новых пользовательских функций.

Основные изменения:

* добавлен единый механизм повторных HTTP-запросов с экспоненциальной задержкой;
* задержки между попытками составляют 1, 2 и 4 секунды;
* повторные запросы выполняются при:

  * сетевых таймаутах;
  * ошибках подключения;
  * HTTP 429 Too Many Requests;
  * HTTP 5xx;
* механизм подключён к Google Translate, DeepL, OpenRouter и KoboldCPP;
* ошибки отдельных батчей и параллельных запросов теперь изолируются;
* сбой одного батча больше не завершает всю задачу перевода;
* при ошибке проблемные строки сохраняются в исходном виде, а обработка следующих батчей продолжается;
* диагностические сообщения переведены на стандартный модуль `logging`;
* добавлены регрессионные тесты для retry-механизма и изоляции батчей.

### Причина изменений

Ранее временный сетевой сбой, ограничение API или ошибка одного параллельного запроса могли привести к пропуску большого количества строк либо прерыванию всей операции перевода.

После этих изменений кратковременные проблемы API обрабатываются автоматически, а необратимая ошибка ограничивается только затронутым батчем.

### Затронутые движки

* Google Translate
* DeepL
* OpenRouter
* KoboldCPP

### Проверка

Выполнены проверки:

```bash
python -m compileall -q mineai tests
python -m unittest discover -s tests -v
```

Добавлены отдельные тесты для следующих сценариев:

* timeout с последующим успешным ответом;
* HTTP 429;
* HTTP 5xx;
* неповторяемые HTTP 4xx;
* последовательность задержек 1 → 2 → 4 секунды;
* ошибка одного Google future;
* ошибка одного Google-батча;
* продолжение обработки после неудачного батча.

### Область PR

PR содержит только стабилизацию существующей сетевой логики.

Новые режимы перевода, элементы GUI и пользовательские функции не добавлялись.
