### PR TITLE
Сохранность данных: изоляция ошибок файлов и безопасная запись

### DIFF
--- a/mineai/runtime/job.py
+++ b/mineai/runtime/job.py
@@ -1,4 +1,3 @@
-import time
 import traceback
 from dataclasses import dataclass
 
@@ -63,7 +62,10 @@ class TranslationJob:
             should_run=self.state.should_run,
             wait_if_paused=self.state.wait_if_paused,
             on_log=self.on_log,
-            on_status=lambda msg: self.on_status(self.state.get_full_status(msg), None),
+            on_status=lambda msg: self.on_status(
+                self.state.get_full_status(msg),
+                None,
+            ),
             on_progress=self.state.increment_translated,
         )
 
@@ -153,120 +155,173 @@ class TranslationJob:
             self.on_log(f"🌐 OpenRouter: {model}", "cyan")
 
         pack_writer: PackWriter | None = None
-        if options.output_mode == "resourcepack":
-            pack_writer = PackWriter(
-                options.mc_dir,
-                options.pack_name,
-                options.mc_version,
-                lang["name"],
-            )
-            self.on_log(f"📦 Ресурспак: {pack_writer.rp_zip_path}", "cyan")
-            self.on_log(f"📂 Датапак: {pack_writer.dp_zip_path}", "magenta")
-
-        service = TranslationService(
-            options.engine,
-            cache,
-            self.config,
-            google_mode=options.google_mode,
-            ai_mode=options.ai_mode,
-            ai_batch=options.ai_batch,
-            ai_provider=options.ai_provider,
-        )
-        callbacks = self._callbacks()
-        jar_proc = JarProcessor(service, self.state, callbacks)
-        loose_proc = LooseJsonProcessor(service, self.state, callbacks)
-        snbt_proc = SnbtProcessor(service, self.state, callbacks)
-        bq_proc = BQProcessor(service, self.state, callbacks)
-
-        self.state.begin_progress()
-        self.on_log(f"🚀 ЗАПУСК ПЕРЕВОДА ({lang['name']})...\n", "yellow")
-
+        failed = False
+        failed_files = 0
         total_items = len(jars) + len(loose) + len(snbt) + len(bq_files)
         done = 0
 
-        failed = False
+        def process_file(path: str, file_type: str, action) -> None:
+            nonlocal done, failed_files
+            try:
+                action()
+            except Exception:
+                failed_files += 1
+                self.on_log(
+                    f"\n❌ Ошибка файла {path}:\n{traceback.format_exc()}",
+                    "red",
+                )
+            finally:
+                done += 1
+                self.state.update_file_progress(file_type, done, total_items)
+                self.on_status(
+                    self.state.get_full_status(),
+                    self.state.line_progress(),
+                )
+
         try:
+            if options.output_mode == "resourcepack":
+                pack_writer = PackWriter(
+                    options.mc_dir,
+                    options.pack_name,
+                    options.mc_version,
+                    lang["name"],
+                )
+                self.on_log(f"📦 Ресурспак: {pack_writer.rp_zip_path}", "cyan")
+                self.on_log(f"📂 Датапак: {pack_writer.dp_zip_path}", "magenta")
+
+            service = TranslationService(
+                options.engine,
+                cache,
+                self.config,
+                google_mode=options.google_mode,
+                ai_mode=options.ai_mode,
+                ai_batch=options.ai_batch,
+                ai_provider=options.ai_provider,
+            )
+            callbacks = self._callbacks()
+            jar_proc = JarProcessor(service, self.state, callbacks)
+            loose_proc = LooseJsonProcessor(service, self.state, callbacks)
+            snbt_proc = SnbtProcessor(service, self.state, callbacks)
+            bq_proc = BQProcessor(service, self.state, callbacks)
+
+            self.state.begin_progress()
+            self.on_log(f"🚀 ЗАПУСК ПЕРЕВОДА ({lang['name']})...\n", "yellow")
+
             for path in jars:
                 if not self.state.should_run():
                     break
                 self.state.wait_if_paused()
-                jar_proc.process(
+                if not self.state.should_run():
+                    break
+                process_file(
                     path,
-                    target_lang=lang,
-                    mode=options.process_mode,
-                    output_mode=options.output_mode,
-                    translate_mods=options.translate_mods,
-                    translate_books=options.translate_books,
-                    pack_writer=pack_writer,
-                )
-                done += 1
-                self.state.update_file_progress("Моды", done, total_items)
-                self.on_status(
-                    self.state.get_full_status(),
-                    self.state.line_progress(),
+                    "Моды",
+                    lambda path=path: jar_proc.process(
+                        path,
+                        target_lang=lang,
+                        mode=options.process_mode,
+                        output_mode=options.output_mode,
+                        translate_mods=options.translate_mods,
+                        translate_books=options.translate_books,
+                        pack_writer=pack_writer,
+                    ),
                 )
 
             for path in loose:
                 if not self.state.should_run():
                     break
                 self.state.wait_if_paused()
-                loose_proc.process(
+                if not self.state.should_run():
+                    break
+                process_file(
                     path,
-                    options.mc_dir,
-                    target_lang=lang,
-                    mode=options.process_mode,
-                    output_mode=options.output_mode,
-                    pack_writer=pack_writer,
-                )
-                done += 1
-                self.state.update_file_progress("Словари", done, total_items)
-                self.on_status(
-                    self.state.get_full_status(),
-                    self.state.line_progress(),
+                    "Словари",
+                    lambda path=path: loose_proc.process(
+                        path,
+                        options.mc_dir,
+                        target_lang=lang,
+                        mode=options.process_mode,
+                        output_mode=options.output_mode,
+                        pack_writer=pack_writer,
+                    ),
                 )
 
             for path in snbt:
                 if not self.state.should_run():
                     break
                 self.state.wait_if_paused()
-                snbt_proc.process(path, target_lang=lang, mode=options.process_mode)
-                done += 1
-                self.state.update_file_progress("Квесты", done, total_items)
-                self.on_status(
-                    self.state.get_full_status(),
-                    self.state.line_progress(),
+                if not self.state.should_run():
+                    break
+                process_file(
+                    path,
+                    "Квесты",
+                    lambda path=path: snbt_proc.process(
+                        path,
+                        target_lang=lang,
+                        mode=options.process_mode,
+                    ),
                 )
 
             for path in bq_files:
                 if not self.state.should_run():
                     break
                 self.state.wait_if_paused()
-                bq_proc.process(path, target_lang=lang, mode=options.process_mode)
-                done += 1
-                self.state.update_file_progress("BQ", done, total_items)
-                self.on_status(
-                    self.state.get_full_status(),
-                    self.state.line_progress(),
+                if not self.state.should_run():
+                    break
+                process_file(
+                    path,
+                    "BQ",
+                    lambda path=path: bq_proc.process(
+                        path,
+                        target_lang=lang,
+                        mode=options.process_mode,
+                    ),
                 )
-
-            cache.save()
         except Exception:
             failed = True
-            self.on_log(f"\n❌ КРИТИЧЕСКАЯ ОШИБКА:\n{traceback.format_exc()}", "red")
+            self.on_log(
+                f"\n❌ КРИТИЧЕСКАЯ ОШИБКА:\n{traceback.format_exc()}",
+                "red",
+            )
         finally:
+            try:
+                cache.save()
+            except Exception:
+                failed = True
+                self.on_log(
+                    f"\n❌ Не удалось сохранить кэш:\n{traceback.format_exc()}",
+                    "red",
+                )
+
             if pack_writer:
-                pack_writer.close()
+                try:
+                    pack_writer.close()
+                except Exception:
+                    failed = True
+                    self.on_log(
+                        f"\n❌ Не удалось завершить выходные архивы:\n"
+                        f"{traceback.format_exc()}",
+                        "red",
+                    )
+            # AI-сервер (KoboldCPP) остаётся запущенным для последующих задач.
 
         if failed:
             self.on_status("Ошибка перевода", 1.0)
         elif not self.state.should_run():
             self.on_log("\n🛑 ОСТАНОВЛЕНО.", "red")
             self.on_status("Остановлено", 1.0)
+        elif failed_files:
+            self.on_log(
+                f"\n⚠️ ЗАВЕРШЕНО С ОШИБКАМИ: пропущено файлов — {failed_files}.",
+                "yellow",
+            )
+            self.on_status("Завершено с ошибками", 1.0)
         else:
             self.on_log("\n✅ ПЕРЕВОД УСПЕШНО ЗАВЕРШЕН!", "green")
             if options.output_mode == "resourcepack":
                 self.on_log("💡 Включите ресурспак и датапак в игре.", "yellow")
             self.on_status("Все задачи выполнены!", 1.0)
+
 
     def stop(self) -> None:
         self.state.stop()

--- a/tests/test_00_language_fixture.py
+++ b/tests/test_00_language_fixture.py
@@ -1,0 +1,11 @@
+"""Keep legacy test fixtures compatible with the current language schema.
+
+The production language definitions include a ``regex`` field. The older
+``test_llm_common`` fixture predates that field, so importing and extending it
+here prevents the test from exercising an invalid schema.
+"""
+
+import test_llm_common
+
+
+test_llm_common.TARGET_LANG.setdefault("regex", r"[А-Яа-яЁё]")

--- a/tests/test_file_isolation.py
+++ b/tests/test_file_isolation.py
@@ -1,0 +1,137 @@
+import unittest
+from unittest import mock
+
+from mineai.cache import TranslationCache
+from mineai.runtime.job import TranslationJob, TranslationOptions
+from mineai.runtime.state import JobState
+
+
+class _Config:
+    def get(self, _section, _key):
+        return ""
+
+    def getboolean(self, _section, _key):
+        return False
+
+
+def _options(*, output_mode="inplace") -> TranslationOptions:
+    return TranslationOptions(
+        mc_dir="/modpack",
+        language_label="Русский",
+        mc_version="1.20.1",
+        output_mode=output_mode,
+        pack_name="MineAI_Pack",
+        engine="google",
+        google_mode="single",
+        ai_mode="safe",
+        ai_batch=20,
+        ai_provider="local",
+        process_mode="append",
+        translate_mods=True,
+        translate_books=False,
+        translate_quests=False,
+    )
+
+
+class FileIsolationTests(unittest.TestCase):
+    @staticmethod
+    def _job(state, cache, logs, statuses):
+        return TranslationJob(
+            _Config(),
+            cache,
+            cache,
+            state,
+            on_log=lambda message, _tag: logs.append(message),
+            on_status=lambda *args: statuses.append(args),
+            on_row=lambda *_args: None,
+        )
+
+    def test_failed_file_is_isolated_and_next_file_is_processed(self):
+        state = JobState(is_running=True)
+        logs = []
+        statuses = []
+        cache = mock.Mock(spec=TranslationCache)
+        job = self._job(state, cache, logs, statuses)
+        processed = []
+
+        def process(path, *_args, **_kwargs):
+            processed.append(path)
+            if path == "broken.json":
+                raise RuntimeError("disk failure")
+
+        with (
+            mock.patch("mineai.runtime.job.discover_jar_files", return_value=[]),
+            mock.patch(
+                "mineai.runtime.job.discover_loose_lang_files",
+                return_value=["broken.json", "good.json"],
+            ),
+            mock.patch("mineai.runtime.job.StringEstimator.estimate", return_value=2),
+            mock.patch(
+                "mineai.runtime.job.LooseJsonProcessor.process",
+                side_effect=process,
+            ),
+        ):
+            job.run_translation(_options())
+
+        self.assertEqual(processed, ["broken.json", "good.json"])
+        cache.save.assert_called_once_with()
+        self.assertTrue(any("broken.json" in message for message in logs))
+        self.assertTrue(any("ЗАВЕРШЕНО С ОШИБКАМИ" in message for message in logs))
+        self.assertFalse(any("УСПЕШНО ЗАВЕРШЕН" in message for message in logs))
+        self.assertEqual(statuses[-1], ("Завершено с ошибками", 1.0))
+
+    def test_pack_writer_is_closed_after_file_failure(self):
+        state = JobState(is_running=True)
+        logs = []
+        statuses = []
+        cache = mock.Mock(spec=TranslationCache)
+        job = self._job(state, cache, logs, statuses)
+        writer = mock.Mock()
+        writer.rp_zip_path = "/tmp/rp.zip"
+        writer.dp_zip_path = "/tmp/dp.zip"
+
+        with (
+            mock.patch("mineai.runtime.job.discover_jar_files", return_value=[]),
+            mock.patch(
+                "mineai.runtime.job.discover_loose_lang_files",
+                return_value=["broken.json"],
+            ),
+            mock.patch("mineai.runtime.job.StringEstimator.estimate", return_value=1),
+            mock.patch("mineai.runtime.job.PackWriter", return_value=writer),
+            mock.patch(
+                "mineai.runtime.job.LooseJsonProcessor.process",
+                side_effect=RuntimeError("write failure"),
+            ),
+        ):
+            job.run_translation(_options(output_mode="resourcepack"))
+
+        writer.close.assert_called_once_with()
+        cache.save.assert_called_once_with()
+        self.assertEqual(statuses[-1], ("Завершено с ошибками", 1.0))
+
+    def test_cache_save_failure_is_reported_as_critical(self):
+        state = JobState(is_running=True)
+        logs = []
+        statuses = []
+        cache = mock.Mock(spec=TranslationCache)
+        cache.save.side_effect = OSError("cache locked")
+        job = self._job(state, cache, logs, statuses)
+
+        with (
+            mock.patch("mineai.runtime.job.discover_jar_files", return_value=[]),
+            mock.patch(
+                "mineai.runtime.job.discover_loose_lang_files",
+                return_value=["good.json"],
+            ),
+            mock.patch("mineai.runtime.job.StringEstimator.estimate", return_value=1),
+            mock.patch("mineai.runtime.job.LooseJsonProcessor.process"),
+        ):
+            job.run_translation(_options())
+
+        self.assertTrue(any("Не удалось сохранить кэш" in message for message in logs))
+        self.assertFalse(any("УСПЕШНО ЗАВЕРШЕН" in message for message in logs))
+        self.assertEqual(statuses[-1], ("Ошибка перевода", 1.0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gui_active_job.py
+++ b/tests/test_gui_active_job.py
@@ -55,11 +55,27 @@ class TranslatorAppJobLifecycleTests(unittest.TestCase):
     def _bare_app():
         app = object.__new__(gui_app.TranslatorApp)
         app._job = None
-        app.job_state = SimpleNamespace(
-            is_running=False,
-            is_paused=False,
-            stop=mock.Mock(),
-        )
+        state = SimpleNamespace(is_running=False, is_paused=False)
+
+        def start() -> None:
+            state.is_running = True
+            state.is_paused = False
+
+        def finish() -> None:
+            state.is_running = False
+            state.is_paused = False
+
+        def toggle_pause() -> bool:
+            if not state.is_running:
+                return False
+            state.is_paused = not state.is_paused
+            return state.is_paused
+
+        state.start = mock.Mock(side_effect=start)
+        state.finish = mock.Mock(side_effect=finish)
+        state.stop = mock.Mock(side_effect=finish)
+        state.toggle_pause = mock.Mock(side_effect=toggle_pause)
+        app.job_state = state
         app._lock_ui = mock.Mock()
         app._clear_log = mock.Mock()
         app._translation_options = mock.Mock(return_value=object())

--- a/tests/test_jar_inplace_safety.py
+++ b/tests/test_jar_inplace_safety.py
@@ -1,0 +1,138 @@
+import json
+import os
+import stat
+import tempfile
+import unittest
+from unittest import mock
+import zipfile
+
+from mineai.engines.base import EngineCallbacks
+from mineai.processors.jar import JarProcessor
+from mineai.runtime.state import JobState
+
+
+TARGET_LANG = {
+    "api": "ru",
+    "file": "ru_ru",
+    "name": "Russian",
+    "regex": r"[А-Яа-я]",
+}
+
+
+class _Service:
+    def translate_dict(self, strings, _target_lang, _callbacks, **_kwargs):
+        return {key: "Привет" for key in strings}
+
+
+def _callbacks(logs):
+    return EngineCallbacks(
+        should_run=lambda: True,
+        wait_if_paused=lambda: None,
+        on_log=lambda message, tag: logs.append((message, tag)),
+        on_status=lambda *_args: None,
+    )
+
+
+def _write_jar(path):
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(
+            "assets/example/lang/en_us.json",
+            json.dumps({"example.hello": "Hello"}),
+        )
+        archive.writestr("assets/example/data.txt", "unchanged")
+
+
+class JarInplaceSafetyTests(unittest.TestCase):
+    def test_valid_temp_archive_atomically_replaces_original(self):
+        state = JobState(is_running=True)
+        logs = []
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "example.jar")
+            _write_jar(path)
+            os.chmod(path, 0o640)
+
+            JarProcessor(_Service(), state, _callbacks(logs)).process(
+                path,
+                target_lang=TARGET_LANG,
+                mode="force",
+                output_mode="inplace",
+                translate_mods=True,
+                translate_books=False,
+                pack_writer=None,
+            )
+
+            with zipfile.ZipFile(path) as archive:
+                self.assertEqual(archive.testzip(), None)
+                self.assertIn("assets/example/lang/ru_ru.json", archive.namelist())
+                translated = json.loads(
+                    archive.read("assets/example/lang/ru_ru.json").decode("utf-8")
+                )
+                self.assertEqual(translated["example.hello"], "Привет")
+            self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), 0o640)
+            self.assertFalse(os.path.exists(path + ".temp"))
+
+    def test_validation_failure_preserves_original_jar(self):
+        state = JobState(is_running=True)
+        logs = []
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "example.jar")
+            _write_jar(path)
+            with open(path, "rb") as handle:
+                original = handle.read()
+            processor = JarProcessor(_Service(), state, _callbacks(logs))
+
+            with mock.patch.object(
+                processor,
+                "_validate_inplace_archive",
+                side_effect=zipfile.BadZipFile("invalid temp archive"),
+            ):
+                with self.assertRaisesRegex(
+                    zipfile.BadZipFile, "invalid temp archive"
+                ):
+                    processor.process(
+                        path,
+                        target_lang=TARGET_LANG,
+                        mode="force",
+                        output_mode="inplace",
+                        translate_mods=True,
+                        translate_books=False,
+                        pack_writer=None,
+                    )
+
+            with open(path, "rb") as handle:
+                self.assertEqual(handle.read(), original)
+            self.assertFalse(os.path.exists(path + ".temp"))
+
+    def test_unexpected_processing_error_cleans_temp_and_propagates(self):
+        state = JobState(is_running=True)
+        logs = []
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "example.jar")
+            _write_jar(path)
+            with open(path, "rb") as handle:
+                original = handle.read()
+            processor = JarProcessor(_Service(), state, _callbacks(logs))
+
+            with mock.patch.object(
+                processor,
+                "_process_lang_entry",
+                side_effect=RuntimeError("translation failure"),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "translation failure"):
+                    processor.process(
+                        path,
+                        target_lang=TARGET_LANG,
+                        mode="force",
+                        output_mode="inplace",
+                        translate_mods=True,
+                        translate_books=False,
+                        pack_writer=None,
+                    )
+
+            with open(path, "rb") as handle:
+                self.assertEqual(handle.read(), original)
+            self.assertFalse(os.path.exists(path + ".temp"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_safety.py
+++ b/tests/test_runtime_safety.py
@@ -75,9 +75,10 @@ class RuntimeSafetyTests(unittest.TestCase):
         ):
             job.run_translation(options)
 
-        self.assertTrue(any("КРИТИЧЕСКАЯ ОШИБКА" in message for message in logs))
+        self.assertTrue(any("broken.json" in message for message in logs))
+        self.assertTrue(any("ЗАВЕРШЕНО С ОШИБКАМИ" in message for message in logs))
         self.assertFalse(any("УСПЕШНО ЗАВЕРШЕН" in message for message in logs))
-        self.assertEqual(statuses[-1], ("Ошибка перевода", 1.0))
+        self.assertEqual(statuses[-1], ("Завершено с ошибками", 1.0))
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime_shutdown.py
+++ b/tests/test_runtime_shutdown.py
@@ -1,0 +1,114 @@
+import subprocess
+import threading
+import time
+import unittest
+from unittest import mock
+
+from mineai.runtime.ai_launcher import AiLauncher
+from mineai.runtime.state import JobState
+
+
+class JobStateShutdownTests(unittest.TestCase):
+    def test_stop_wakes_worker_waiting_on_pause(self) -> None:
+        state = JobState()
+        state.start()
+        self.assertTrue(state.pause())
+
+        returned = threading.Event()
+
+        def wait() -> None:
+            state.wait_if_paused()
+            returned.set()
+
+        worker = threading.Thread(target=wait)
+        worker.start()
+        time.sleep(0.02)
+        self.assertFalse(returned.is_set())
+
+        state.stop()
+        worker.join(timeout=1)
+
+        self.assertFalse(worker.is_alive())
+        self.assertTrue(returned.is_set())
+        self.assertFalse(state.should_run())
+
+    def test_resume_wakes_worker_waiting_on_pause(self) -> None:
+        state = JobState()
+        state.start()
+        state.pause()
+        returned = threading.Event()
+
+        worker = threading.Thread(
+            target=lambda: (state.wait_if_paused(), returned.set())
+        )
+        worker.start()
+        time.sleep(0.02)
+
+        self.assertTrue(state.resume())
+        worker.join(timeout=1)
+
+        self.assertTrue(returned.is_set())
+        self.assertTrue(state.should_run())
+
+    def test_stop_is_idempotent(self) -> None:
+        state = JobState()
+        state.start()
+        state.stop()
+        state.stop()
+
+        snapshot = state.snapshot()
+        self.assertFalse(snapshot.is_running)
+        self.assertFalse(snapshot.is_paused)
+
+
+class AiLauncherShutdownTests(unittest.TestCase):
+    @staticmethod
+    def _launcher() -> AiLauncher:
+        return AiLauncher(mock.Mock())
+
+    def test_terminate_clears_already_exited_process(self) -> None:
+        launcher = self._launcher()
+        process = mock.Mock()
+        process.poll.return_value = 0
+        launcher.process = process
+
+        self.assertTrue(launcher.terminate())
+        self.assertIsNone(launcher.process)
+        process.terminate.assert_not_called()
+
+    def test_terminate_timeout_falls_back_to_kill(self) -> None:
+        launcher = self._launcher()
+        process = mock.Mock()
+        process.poll.side_effect = [None, 0]
+        process.wait.side_effect = [
+            subprocess.TimeoutExpired(cmd="kobold", timeout=2),
+            0,
+        ]
+        launcher.process = process
+
+        self.assertTrue(launcher.terminate())
+
+        process.terminate.assert_called_once_with()
+        process.kill.assert_called_once_with()
+        self.assertEqual(process.wait.call_count, 2)
+        self.assertIsNone(launcher.process)
+
+    def test_failed_kill_keeps_process_reference(self) -> None:
+        launcher = self._launcher()
+        process = mock.Mock()
+        process.poll.return_value = None
+        process.wait.side_effect = [
+            subprocess.TimeoutExpired(cmd="kobold", timeout=2),
+            subprocess.TimeoutExpired(cmd="kobold", timeout=2),
+        ]
+        launcher.process = process
+
+        self.assertFalse(launcher.terminate())
+
+        process.terminate.assert_called_once_with()
+        process.kill.assert_called_once_with()
+        self.assertIs(launcher.process, process)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Описание

Этот PR повышает сохранность данных при обработке больших модпаков. Ошибка одного входного файла больше не прекращает всю задачу, а кэш и выходные архивы закрываются через гарантированный cleanup.

Изменения не добавляют пользовательских функций и не меняют правила выбора или перевода строк.

Что изменено

Изоляция ошибок отдельных файлов

* каждый JAR, loose JSON, SNBT и BetterQuesting JSON обрабатывается в собственной защитной границе;
* необратимая ошибка одного файла фиксируется в логе, после чего обработка продолжается;
* прогресс обновляется и после успешного файла, и после ошибки;
* итоговый статус различает полное завершение, остановку, частичные ошибки и критический cleanup-сбой;
* ошибки чтения и разбора файлов больше не скрываются внутри процессоров.

Кэш

* cache.save() вызывается в finally;
* проверяется, что загруженный кэш является словарём строк;
* структурно повреждённый кэш сохраняется как .corrupt и не используется;
* корректно поддерживается счётчик последнего сохранения.

Resource pack и datapack

* оба ZIP-handle закрываются даже при ошибке закрытия первого;
* готовые архивы проверяются через ZipFile.testzip();
* частичные или невалидные выходные архивы удаляются;
* ошибка создания второго архива очищает уже созданный первый.

In-place JAR и файлы квестов

* временный JAR проверяется до замены оригинала;
* оригинальный режим доступа сохраняется;
* замена выполняется атомарно через os.replace();
* временный JAR удаляется при отмене и исключении;
* запись SNBT и BetterQuesting JSON переведена на атомарную замену.

Причина изменений

Ранее исключение одного процессора могло остановить весь модпак, а авария между записью временного файла и заменой могла оставить повреждённый JAR, JSON или незавершённый ZIP.

После изменений ошибка ограничивается конкретным входным файлом. Остальные файлы продолжают обрабатываться, а оригиналы не заменяются непроверенными временными результатами.

Проверка

python -m compileall -q mineai tests
python -m unittest discover -s tests -v

Добавлены тесты для следующих сценариев:

* продолжение после ошибки одного файла;
* обязательное сохранение кэша через cleanup;
* проверка структуры загруженного кэша;
* закрытие обоих выходных ZIP;
* удаление частичных и повреждённых архивов;
* атомарная замена JAR;
* сохранение оригинального JAR при невалидном временном архиве;
* атомарная запись SNBT и BetterQuesting JSON.

Область PR

PR содержит только стабилизацию обработки и записи данных.

Новые режимы перевода, движки, элементы GUI и пользовательские функции не добавлялись.