### PR TITLE
Стабильность прогресса: точный учёт строк и корректный ETA

### DIFF
--- a/mineai/processors/bq_json.py
+++ b/mineai/processors/bq_json.py
@@ -61,8 +61,6 @@ class BQProcessor:
         for key, value in translated.items():
              bq_data[key] = value
              
-        self.state.increment_translated(len(translated))
-
         # Сохраняем файл обратно
         payload = json.dumps(data, indent=2, ensure_ascii=False)
         atomic_write_text(file_path, payload)

--- a/mineai/processors/jar.py
+++ b/mineai/processors/jar.py
@@ -218,7 +218,6 @@ class JarProcessor:
         translated = self.service.translate_dict(pending, target_lang, self.callbacks, context=mod_name)
         for key, value in translated.items():
             merged[key] = value
-        self.state.increment_translated(len(translated))
         return self._write_lang_output(merged, tr_path, output_mode, pack_writer, zout, written_inplace, item, en_data)
 
     def _write_lang_output(self, data, tr_path, output_mode, pack_writer, zout, written_inplace, item, en_data) -> bool:
@@ -295,7 +294,6 @@ class JarProcessor:
             self.callbacks.on_log(f"⚡ Перевод {mod_name} [Книга JSON] — {len(pending)} строк", "magenta")
             translated = self.service.translate_dict(pending, target_lang, self.callbacks, context=mod_name)
             apply_translations_by_path(en_data, translated)
-            self.state.increment_translated(len(translated))
 
         payload = json.dumps(en_data, ensure_ascii=False, indent=2).encode("utf-8")
         if output_mode == "resourcepack" and pack_writer:
@@ -424,7 +422,6 @@ class JarProcessor:
                 lines_out[idx] = prefix + value + suffix
             else:
                 lines_out[idx] = value
-        self.state.increment_translated(len(translated))
 
         payload = "\n".join(lines_out).encode("utf-8")
         if output_mode == "resourcepack" and pack_writer:

--- a/mineai/processors/loose_json.py
+++ b/mineai/processors/loose_json.py
@@ -70,7 +70,6 @@ class LooseJsonProcessor:
             # -----------------------------
             
             merged.update(translated)
-            self.state.increment_translated(len(translated))
 
         payload = json.dumps(merged, ensure_ascii=False, indent=2).encode("utf-8")
         if output_mode == "resourcepack" and pack_writer:

--- a/mineai/processors/snbt.py
+++ b/mineai/processors/snbt.py
@@ -93,7 +93,6 @@ class SnbtProcessor:
         
         mapping = {strings[i]: translated.get(str(i), strings[i]) for i in range(len(strings))}
         
-        self.state.increment_translated(len(mapping))
         new_content = apply_snbt_translations(content, mapping)
         
         # Шаг 3. Сохраняем в целевой файл (заменяя авторский ru_ru.snbt)

--- a/mineai/runtime/job.py
+++ b/mineai/runtime/job.py
@@ -1,3 +1,5 @@
+import threading
+import time
 import traceback
 from dataclasses import dataclass
 
@@ -37,6 +39,8 @@ class TranslationOptions:
 
 
 class TranslationJob:
+    PROGRESS_STATUS_INTERVAL_SECONDS = 0.4
+
     def __init__(
         self,
         config: ConfigManager,
@@ -56,6 +60,30 @@ class TranslationJob:
         self.on_status = on_status
         self.on_row = on_row
         self.ai_launcher = AiLauncher(config)
+        self._progress_status_lock = threading.Lock()
+        self._last_progress_status_at = 0.0
+
+    def _reset_progress_status_throttle(self) -> None:
+        with self._progress_status_lock:
+            self._last_progress_status_at = 0.0
+
+    def _on_progress(self, count: int = 1) -> None:
+        self.state.increment_translated(count)
+        now = time.monotonic()
+
+        with self._progress_status_lock:
+            if (
+                self._last_progress_status_at > 0
+                and now - self._last_progress_status_at
+                < self.PROGRESS_STATUS_INTERVAL_SECONDS
+            ):
+                return
+            self._last_progress_status_at = now
+
+        self.on_status(
+            self.state.get_full_status(),
+            self.state.line_progress(),
+        )
 
     def _callbacks(self) -> EngineCallbacks:
         return EngineCallbacks(
@@ -66,7 +94,7 @@ class TranslationJob:
                 self.state.get_full_status(msg),
                 None,
             ),
-            on_progress=self.state.increment_translated,
+            on_progress=self._on_progress,
         )
 
     def run_analysis(self, options: TranslationOptions) -> None:
@@ -204,6 +232,7 @@ class TranslationJob:
             snbt_proc = SnbtProcessor(service, self.state, callbacks)
             bq_proc = BQProcessor(service, self.state, callbacks)
 
+            self._reset_progress_status_throttle()
             self.state.begin_progress()
             self.on_log(f"🚀 ЗАПУСК ПЕРЕВОДА ({lang['name']})...\n", "yellow")
 
@@ -303,7 +332,6 @@ class TranslationJob:
                         f"{traceback.format_exc()}",
                         "red",
                     )
-            # AI-сервер (KoboldCPP) остаётся запущенным для последующих задач.
 
         if failed:
             self.on_status("Ошибка перевода", 1.0)
@@ -321,7 +349,6 @@ class TranslationJob:
             if options.output_mode == "resourcepack":
                 self.on_log("💡 Включите ресурспак и датапак в игре.", "yellow")
             self.on_status("Все задачи выполнены!", 1.0)
-
 
     def stop(self) -> None:
         self.state.stop()

--- a/mineai/runtime/state.py
+++ b/mineai/runtime/state.py
@@ -34,8 +34,21 @@ class JobState:
     def __post_init__(self) -> None:
         self._condition = threading.Condition(self._lock)
 
+    def _reset_progress_unlocked(self) -> None:
+        self.total_strings = 0
+        self.translated_strings = 0
+        self.current_file_type = ""
+        self.current_file_done = 0
+        self.total_files = 0
+        self.start_time = None
+
+    def reset_progress(self) -> None:
+        with self._lock:
+            self._reset_progress_unlocked()
+
     def start(self) -> None:
         with self._condition:
+            self._reset_progress_unlocked()
             self.is_running = True
             self.is_paused = False
             self._condition.notify_all()
@@ -105,11 +118,10 @@ class JobState:
             self.total_files = total
 
     def line_progress(self) -> float:
-        """Прогресс 0..1 по строкам — для шкалы."""
         snapshot = self.snapshot()
         if snapshot.total_strings <= 0:
             return 0.0
-        return min(snapshot.translated_strings / snapshot.total_strings, 1.0) 
+        return min(snapshot.translated_strings / snapshot.total_strings, 1.0)
 
     def snapshot(self) -> JobSnapshot:
         with self._lock:
@@ -126,17 +138,21 @@ class JobState:
 
     @staticmethod
     def _eta_text(snapshot: JobSnapshot, now: float | None = None) -> str:
-        if not snapshot.start_time or snapshot.translated_strings == 0:
+        if snapshot.translated_strings <= 0 or not snapshot.start_time:
             return "расчёт..."
+
         elapsed = (time.time() if now is None else now) - snapshot.start_time
         if elapsed < 5:
             return "расчёт..."
+
         remaining = snapshot.total_strings - snapshot.translated_strings
         if remaining <= 0:
-            return "готово"
+            return "завершается..." if snapshot.is_running else "готово"
+
         rate = snapshot.translated_strings / elapsed
         if rate <= 0:
             return "расчёт..."
+
         seconds = remaining / rate
         if seconds < 60:
             return f"{int(seconds)} сек"
@@ -159,8 +175,12 @@ class JobState:
 
         string_info = ""
         if snapshot.total_strings > 0:
+            display_translated = min(
+                snapshot.translated_strings,
+                snapshot.total_strings,
+            )
             string_info = (
-                f"Строки: {snapshot.translated_strings}/"
+                f"Строки: {display_translated}/"
                 f"{snapshot.total_strings} | "
             )
 

--- a/tests/test_llm_common.py
+++ b/tests/test_llm_common.py
@@ -20,7 +20,7 @@ with tempfile.TemporaryDirectory() as _import_cwd:
         os.chdir(_original_cwd)
 
 
-TARGET_LANG = {"api": "ru", "name": "Russian"}
+TARGET_LANG = {"api": "ru", "name": "Russian", "regex": r"[А-Яа-яЁё]"}
 
 
 def callbacks(
@@ -47,8 +47,8 @@ class MemoryCache:
     def __init__(self) -> None:
         self.values: dict[tuple[str, str], str] = {}
 
-    def get(self, api_code: str, source: str) -> str | None:
-        return self.values.get((api_code, source))
+    def get(self, api_code: str, source: str) -> tuple[str | None, bool]:
+        return self.values.get((api_code, source)), False
 
     def set(self, api_code: str, source: str, translated: str) -> None:
         self.values[(api_code, source)] = translated

--- a/tests/test_progress_accounting.py
+++ b/tests/test_progress_accounting.py
@@ -1,0 +1,131 @@
+import json
+import os
+import tempfile
+import unittest
+import zipfile
+
+from mineai.engines.base import EngineCallbacks
+from mineai.processors.bq_json import BQProcessor
+from mineai.processors.jar import JarProcessor
+from mineai.processors.loose_json import LooseJsonProcessor
+from mineai.processors.snbt import SnbtProcessor
+from mineai.runtime.state import JobState
+
+
+TARGET_LANG = {
+    "api": "ru",
+    "file": "ru_ru",
+    "name": "Russian",
+    "regex": r"[А-Яа-яЁё]",
+}
+
+
+class _Config:
+    def getboolean(self, _section, _key):
+        return False
+
+
+class _ProgressService:
+    def __init__(self):
+        self.config = _Config()
+
+    def translate_dict(self, strings, _target_lang, callbacks, **_kwargs):
+        if callbacks.on_progress:
+            callbacks.on_progress(len(strings))
+        return {key: "Перевод" for key in strings}
+
+
+def _callbacks(state: JobState) -> EngineCallbacks:
+    return EngineCallbacks(
+        should_run=state.should_run,
+        wait_if_paused=state.wait_if_paused,
+        on_log=lambda *_args: None,
+        on_status=lambda *_args: None,
+        on_progress=state.increment_translated,
+    )
+
+
+class ProgressAccountingTests(unittest.TestCase):
+    def test_loose_json_counts_each_translation_once(self):
+        state = JobState(is_running=True)
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "en_us.json")
+            with open(source, "w", encoding="utf-8") as handle:
+                json.dump({"one": "Hello", "two": "World"}, handle)
+
+            LooseJsonProcessor(
+                _ProgressService(), state, _callbacks(state)
+            ).process(
+                source,
+                directory,
+                target_lang=TARGET_LANG,
+                mode="force",
+                output_mode="inplace",
+                pack_writer=None,
+            )
+
+        self.assertEqual(state.snapshot().translated_strings, 2)
+
+    def test_snbt_counts_each_translation_once(self):
+        state = JobState(is_running=True)
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "en_us.snbt")
+            with open(source, "w", encoding="utf-8") as handle:
+                handle.write('title: "Hello"\ndescription: "World"')
+
+            SnbtProcessor(_ProgressService(), state, _callbacks(state)).process(
+                source,
+                target_lang=TARGET_LANG,
+                mode="force",
+            )
+
+        self.assertEqual(state.snapshot().translated_strings, 2)
+
+    def test_betterquesting_counts_each_translation_once(self):
+        state = JobState(is_running=True)
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "Quest.json")
+            payload = {
+                "properties:10": {
+                    "betterquesting:10": {
+                        "name:8": "Hello",
+                        "desc:8": "World",
+                    }
+                }
+            }
+            with open(source, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle)
+
+            BQProcessor(_ProgressService(), state, _callbacks(state)).process(
+                source,
+                target_lang=TARGET_LANG,
+                mode="force",
+            )
+
+        self.assertEqual(state.snapshot().translated_strings, 2)
+
+    def test_jar_locale_counts_each_translation_once(self):
+        state = JobState(is_running=True)
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "example.jar")
+            with zipfile.ZipFile(source, "w") as archive:
+                archive.writestr(
+                    "assets/example/lang/en_us.json",
+                    json.dumps({"one": "Hello", "two": "World"}),
+                )
+
+            JarProcessor(_ProgressService(), state, _callbacks(state)).process(
+                source,
+                target_lang=TARGET_LANG,
+                mode="force",
+                output_mode="inplace",
+                translate_mods=True,
+                translate_books=False,
+                pack_writer=None,
+            )
+
+        self.assertEqual(state.snapshot().translated_strings, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_progress_state.py
+++ b/tests/test_progress_state.py
@@ -1,0 +1,126 @@
+import unittest
+
+from mineai.runtime.state import JobSnapshot, JobState
+
+
+class JobStateProgressTests(unittest.TestCase):
+    def test_start_resets_all_progress_counters(self):
+        state = JobState(
+            total_strings=100,
+            translated_strings=80,
+            current_file_type="Моды",
+            current_file_done=4,
+            total_files=5,
+            start_time=123.0,
+        )
+
+        state.start()
+
+        snapshot = state.snapshot()
+        self.assertTrue(snapshot.is_running)
+        self.assertFalse(snapshot.is_paused)
+        self.assertEqual(snapshot.total_strings, 0)
+        self.assertEqual(snapshot.translated_strings, 0)
+        self.assertEqual(snapshot.current_file_type, "")
+        self.assertEqual(snapshot.current_file_done, 0)
+        self.assertEqual(snapshot.total_files, 0)
+        self.assertIsNone(snapshot.start_time)
+
+    def test_finish_preserves_final_progress(self):
+        state = JobState(
+            is_running=True,
+            total_strings=10,
+            translated_strings=10,
+            current_file_type="Моды",
+            current_file_done=2,
+            total_files=2,
+            start_time=100.0,
+        )
+
+        state.finish()
+
+        snapshot = state.snapshot()
+        self.assertFalse(snapshot.is_running)
+        self.assertEqual(snapshot.total_strings, 10)
+        self.assertEqual(snapshot.translated_strings, 10)
+        self.assertEqual(snapshot.current_file_type, "Моды")
+        self.assertEqual(snapshot.current_file_done, 2)
+        self.assertEqual(snapshot.total_files, 2)
+        self.assertEqual(snapshot.start_time, 100.0)
+
+    def test_begin_progress_preserves_estimated_total(self):
+        state = JobState(
+            total_strings=25,
+            translated_strings=20,
+            current_file_type="BQ",
+            current_file_done=3,
+            total_files=4,
+        )
+
+        state.begin_progress()
+
+        snapshot = state.snapshot()
+        self.assertEqual(snapshot.total_strings, 25)
+        self.assertEqual(snapshot.translated_strings, 0)
+        self.assertEqual(snapshot.current_file_type, "")
+        self.assertEqual(snapshot.current_file_done, 0)
+        self.assertEqual(snapshot.total_files, 0)
+        self.assertIsNotNone(snapshot.start_time)
+
+    def test_display_and_line_progress_are_capped_at_one_hundred_percent(self):
+        state = JobState(
+            is_running=True,
+            total_strings=5,
+            translated_strings=8,
+            start_time=100.0,
+        )
+
+        self.assertEqual(state.line_progress(), 1.0)
+        self.assertIn("Строки: 5/5", state.get_full_status())
+        self.assertNotIn("Строки: 8/5", state.get_full_status())
+
+    def test_eta_reports_finishing_while_job_is_still_running(self):
+        snapshot = JobSnapshot(
+            is_running=True,
+            is_paused=False,
+            total_strings=10,
+            translated_strings=10,
+            current_file_type="",
+            current_file_done=0,
+            total_files=0,
+            start_time=100.0,
+        )
+
+        self.assertEqual(JobState._eta_text(snapshot, now=110.0), "завершается...")
+
+    def test_eta_reports_ready_only_after_job_has_finished(self):
+        snapshot = JobSnapshot(
+            is_running=False,
+            is_paused=False,
+            total_strings=10,
+            translated_strings=12,
+            current_file_type="",
+            current_file_done=0,
+            total_files=0,
+            start_time=100.0,
+        )
+
+        self.assertEqual(JobState._eta_text(snapshot, now=110.0), "готово")
+
+    def test_eta_keeps_calculating_during_warmup(self):
+        snapshot = JobSnapshot(
+            is_running=True,
+            is_paused=False,
+            total_strings=10,
+            translated_strings=1,
+            current_file_type="",
+            current_file_done=0,
+            total_files=0,
+            start_time=100.0,
+        )
+
+        self.assertEqual(JobState._eta_text(snapshot, now=104.9), "расчёт...")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_progress_throttle.py
+++ b/tests/test_progress_throttle.py
@@ -1,0 +1,70 @@
+import unittest
+from unittest import mock
+
+from mineai.runtime.job import TranslationJob
+from mineai.runtime.state import JobState
+
+
+class ProgressThrottleTests(unittest.TestCase):
+    @staticmethod
+    def _job(state, statuses):
+        return TranslationJob(
+            mock.Mock(),
+            mock.Mock(),
+            mock.Mock(),
+            state,
+            on_log=lambda *_args: None,
+            on_status=lambda *args: statuses.append(args),
+            on_row=lambda *_args: None,
+        )
+
+    def test_progress_count_is_never_dropped_by_throttling(self):
+        state = JobState(is_running=True, total_strings=10)
+        state.begin_progress()
+        statuses = []
+        job = self._job(state, statuses)
+
+        with mock.patch(
+            "mineai.runtime.job.time.monotonic",
+            side_effect=[10.0, 10.1, 10.2],
+        ):
+            job._on_progress(2)
+            job._on_progress(3)
+            job._on_progress(1)
+
+        self.assertEqual(state.snapshot().translated_strings, 6)
+        self.assertEqual(len(statuses), 1)
+
+    def test_status_is_published_again_after_throttle_interval(self):
+        state = JobState(is_running=True, total_strings=10)
+        state.begin_progress()
+        statuses = []
+        job = self._job(state, statuses)
+
+        with mock.patch(
+            "mineai.runtime.job.time.monotonic",
+            side_effect=[10.0, 10.2, 10.4],
+        ):
+            job._on_progress()
+            job._on_progress()
+            job._on_progress()
+
+        self.assertEqual(state.snapshot().translated_strings, 3)
+        self.assertEqual(len(statuses), 2)
+        self.assertEqual(statuses[-1][1], 0.3)
+
+    def test_callbacks_use_the_throttled_progress_handler(self):
+        state = JobState(is_running=True, total_strings=2)
+        statuses = []
+        job = self._job(state, statuses)
+        callbacks = job._callbacks()
+
+        with mock.patch("mineai.runtime.job.time.monotonic", return_value=10.0):
+            callbacks.on_progress(1)
+
+        self.assertEqual(state.snapshot().translated_strings, 1)
+        self.assertEqual(len(statuses), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Описание

Этот PR исправляет двойной учёт переведённых строк, сброс состояния между задачами и преждевременное отображение готовности ETA. Новых пользовательских функций не добавляет.

Что изменено

Единственный источник прогресса

* TranslationService.translate_dict() остаётся единственным источником callbacks.on_progress;
* удалены дополнительные вызовы increment_translated() из JAR, loose JSON, SNBT и BetterQuesting-процессоров;
* строки из обычного кэша, импортированного кэша, движка и fallback учитываются ровно один раз.

Сброс состояния новой задачи

* добавлен потокобезопасный JobState.reset_progress();
* JobState.start() атомарно очищает счётчики предыдущей задачи;
* finish() сохраняет финальные значения для отображения;
* begin_progress() сбрасывает текущий прогресс и время, но сохраняет уже рассчитанный total_strings.

Ограничение 100% и ETA

* текстовый статус не показывает переведённых строк больше общего количества;
* line_progress() ограничен значением 1.0;
* во время прогрева ETA показывает расчёт...;
* при заполненном счётчике активная задача показывает завершается...;
* готово отображается только после завершения состояния задачи.

Обновление во время длинных пакетов

* каждый progress callback обновляет потокобезопасное состояние;
* публикация UI-статуса ограничена интервалом 0,4 секунды;
* инкременты не теряются при throttling;
* Tk не вызывается напрямую из рабочего потока — используется существующий callback on_status, передающий событие через UI-очередь.

Проверка

После каждой группы изменений выполнялись:

python -m compileall mineai tests translator.py
python -m unittest discover -s tests -v

Итог:

Ran 45 tests
OK

Добавлены регрессионные тесты для:

* однократного учёта прогресса JAR, loose JSON, SNBT и BetterQuesting;
* полного сброса при старте новой задачи;
* сохранения итоговых счётчиков после finish();
* сохранения total_strings при begin_progress();
* ограничения текста и progress bar до 100%;
* состояний ETA расчёт..., завершается... и готово;
* throttled-обновлений без потери прогресса.

PR построен одним commit поверх актуальной ветки beta.