### PR TITLE
Стабильность режимов: синхронизация estimator и процессоров

### DIFF
--- a/mineai/processors/bq_json.py
+++ b/mineai/processors/bq_json.py
@@ -5,62 +5,81 @@ import shutil
 from mineai.engines.base import EngineCallbacks
 from mineai.engines.service import TranslationService
 from mineai.io_utils import atomic_write_text
+from mineai.processors.selection import (
+    collect_bq_selection,
+    skip_threshold_reached,
+)
 from mineai.runtime.state import JobState
-from mineai.text_processing import already_translated
+
 
 class BQProcessor:
-    def __init__(self, service: TranslationService, state: JobState, callbacks: EngineCallbacks) -> None:
+    def __init__(
+        self,
+        service: TranslationService,
+        state: JobState,
+        callbacks: EngineCallbacks,
+    ) -> None:
         self.service = service
         self.state = state
         self.callbacks = callbacks
 
     def process(self, file_path: str, *, target_lang: dict, mode: str) -> None:
         backup = file_path + ".bak"
-        source_path = backup if (mode == "force" and os.path.exists(backup)) else file_path
-        target_regex = target_lang["regex"]
+        source_path = (
+            backup
+            if mode == "force" and os.path.exists(backup)
+            else file_path
+        )
 
-        with open(source_path, "r", encoding="utf-8") as f:
-            data = json.load(f)
+        with open(source_path, "r", encoding="utf-8") as source_file:
+            data = json.load(source_file)
 
-        # Ищем строки для перевода...
-        strings_to_translate = {}
-        props_key = next((k for k in data if k.startswith("properties")), None)
-        if props_key and isinstance(data[props_key], dict):
-            bq_key = next((k for k in data[props_key] if k.startswith("betterquesting")), None)
-            if bq_key and isinstance(data[props_key][bq_key], dict):
-                bq_data = data[props_key][bq_key]
-                for key_prefix in ["name", "desc"]:
-                    actual_key = next((k for k in bq_data if k.startswith(key_prefix)), None)
-                    if actual_key and isinstance(bq_data[actual_key], str):
-                        text = bq_data[actual_key].strip()
-                        if text and (mode == "force" or not already_translated(text, target_regex)):
-                            strings_to_translate[actual_key] = text
-
-        if not strings_to_translate:
+        selection = collect_bq_selection(
+            data,
+            mode,
+            target_lang["regex"],
+        )
+        if not selection.pending:
+            return
+        if mode == "skip" and skip_threshold_reached(
+            selection.total_translatable,
+            len(selection.pending),
+        ):
+            self.callbacks.on_log(
+                f"⏩ Пропуск {os.path.basename(file_path)}: "
+                "готово не менее 90% строк",
+                "dim",
+            )
             return
 
-        # Бэкап создаётся ТОЛЬКО когда перевод действительно нужен
         if not os.path.exists(backup):
             shutil.copy2(file_path, backup)
 
-        name = os.path.basename(os.path.dirname(file_path)) + "/" + os.path.basename(file_path)
-        self.callbacks.on_log(f"⚡ Перевод BQ [{name}] — {len(strings_to_translate)} строк", "yellow")
-        
+        name = (
+            os.path.basename(os.path.dirname(file_path))
+            + "/"
+            + os.path.basename(file_path)
+        )
+        self.callbacks.on_log(
+            f"⚡ Перевод BQ [{name}] — {len(selection.pending)} строк",
+            "yellow",
+        )
         translated = self.service.translate_dict(
-            strings_to_translate,
+            selection.pending,
             target_lang,
             self.callbacks,
             context=name,
+            prompt_type="quests",
         )
-        
+
         if not self.state.should_run() or not translated:
             return
+        if not selection.properties_key or not selection.betterquesting_key:
+            return
 
-        # Применяем перевод
-        bq_data = data[props_key][bq_key]
+        bq_data = data[selection.properties_key][selection.betterquesting_key]
         for key, value in translated.items():
-             bq_data[key] = value
-             
-        # Сохраняем файл обратно
+            bq_data[key] = value
+
         payload = json.dumps(data, indent=2, ensure_ascii=False)
         atomic_write_text(file_path, payload)

--- a/mineai/processors/estimator.py
+++ b/mineai/processors/estimator.py
@@ -3,11 +3,28 @@ import os
 import re
 import zipfile
 
-from mineai.constants import BOOK_PATH_MARKERS, MD_PATH_MARKERS, RESEARCH_PATH_MARKERS
-from mineai.json_utils import iter_translatable_strings, load_lenient_json
-from mineai.processors.snbt_extract import extract_snbt_strings
+from mineai.constants import (
+    BOOK_PATH_MARKERS,
+    MD_PATH_MARKERS,
+    RESEARCH_PATH_MARKERS,
+)
+from mineai.json_utils import load_lenient_json
+from mineai.processors.locale_keys import (
+    collect_lang_keys_to_translate,
+    count_translatable_lang_entries,
+)
+from mineai.processors.selection import (
+    collect_book_json_selection,
+    collect_book_markdown_selection,
+    collect_bq_selection,
+    collect_snbt_selection,
+    skip_threshold_reached,
+)
+from mineai.processors.snbt import (
+    get_snbt_target_path,
+    should_ignore_snbt_source,
+)
 from mineai.runtime.state import JobState
-from mineai.text_processing import already_translated, apply_smart_glue, is_technical_term, looks_like_source_language
 
 
 class StringEstimator:
@@ -19,7 +36,7 @@ class StringEstimator:
         jar_files: list[str],
         loose_files: list[str],
         snbt_files: list[str],
-        bq_files: list[str], # <-- ДОБАВЛЕНО
+        bq_files: list[str],
         *,
         target_lang: dict,
         mode: str,
@@ -37,167 +54,365 @@ class StringEstimator:
                 return total
             self.state.wait_if_paused()
             total += self._estimate_jar(
-                path, target_file, target_lang, mode, translate_mods, translate_books, smart_glue
+                path,
+                target_file,
+                target_lang,
+                mode,
+                translate_mods,
+                translate_books,
+                smart_glue,
             )
 
         for path in loose_files:
             if not self.state.should_run():
                 return total
-            total += self._estimate_loose(path, target_file, mode)
+            self.state.wait_if_paused()
+            total += self._estimate_loose(
+                path,
+                target_file,
+                mode,
+                target_regex,
+            )
 
         if translate_quests:
             for path in snbt_files:
                 if not self.state.should_run():
                     return total
-                total += self._estimate_snbt(path, mode, target_regex)
-                
-            # <-- ДОБАВЛЕНО
+                self.state.wait_if_paused()
+                total += self._estimate_snbt(
+                    path,
+                    mode,
+                    target_regex,
+                    target_lang["file"],
+                )
+
             for path in bq_files:
                 if not self.state.should_run():
                     return total
+                self.state.wait_if_paused()
                 total += self._estimate_bq(path, mode, target_regex)
 
         return total
 
     def _estimate_jar(
-        self, path, target_file, target_lang, mode, translate_mods, translate_books, smart_glue
+        self,
+        path,
+        target_file,
+        target_lang,
+        mode,
+        translate_mods,
+        translate_books,
+        smart_glue,
     ) -> int:
         count = 0
         try:
-            with zipfile.ZipFile(path, "r") as zin:
+            with zipfile.ZipFile(path, "r") as archive:
                 locale = {
-                    i.filename.lower(): i
-                    for i in zin.infolist()
-                    if target_file in i.filename.lower()
-                    or f"/{target_lang['file']}/" in i.filename.lower()
+                    item.filename.lower(): item
+                    for item in archive.infolist()
+                    if target_file in item.filename.lower()
+                    or f"/{target_lang['file']}/" in item.filename.lower()
                 }
-                for item in zin.infolist():
-                    fl = item.filename.lower()
-                    is_book_json = fl.endswith(".json") and (
-                        ("/en_us/" in fl and any(m in fl for m in BOOK_PATH_MARKERS))
-                        or any(m in fl for m in RESEARCH_PATH_MARKERS)
+                for item in archive.infolist():
+                    file_lower = item.filename.lower()
+                    is_book_json = (
+                        file_lower.endswith(".json")
+                        and "/en_us/" in file_lower
+                        and (
+                            any(
+                                marker in file_lower
+                                for marker in BOOK_PATH_MARKERS
+                            )
+                            or any(
+                                marker in file_lower
+                                for marker in RESEARCH_PATH_MARKERS
+                            )
+                        )
                     )
-                    is_book_md = (fl.endswith(".md") or fl.endswith(".txt")) and any(
-                        m in fl for m in MD_PATH_MARKERS
+                    is_book_md = (
+                        (
+                            file_lower.endswith(".md")
+                            or file_lower.endswith(".txt")
+                        )
+                        and "/en_us/" in file_lower
+                        and any(
+                            marker in file_lower
+                            for marker in MD_PATH_MARKERS
+                        )
                     )
-                    is_lang = fl.endswith("en_us.json") and not is_book_json
+                    is_lang = (
+                        file_lower.endswith("en_us.json")
+                        and not is_book_json
+                    )
 
                     if translate_mods and is_lang:
-                        count += self._count_lang(zin, item, locale, target_file, mode)
+                        count += self._count_lang(
+                            archive,
+                            item,
+                            locale,
+                            target_file,
+                            mode,
+                            target_lang["regex"],
+                        )
                     elif translate_books and is_book_json:
-                        count += self._count_book_json(zin, item)
+                        count += self._count_book_json(
+                            archive,
+                            item,
+                            locale,
+                            target_lang,
+                            mode,
+                        )
                     elif translate_books and is_book_md:
-                        count += self._count_book_md(zin, item, smart_glue)
+                        count += self._count_book_md(
+                            archive,
+                            item,
+                            locale,
+                            target_lang,
+                            mode,
+                            smart_glue,
+                        )
         except (OSError, zipfile.BadZipFile):
-            pass
+            return 0
         return count
 
-    def _count_lang(self, zin, item, locale, target_file, mode) -> int:
+    def _count_lang(
+        self,
+        archive,
+        item,
+        locale,
+        target_file,
+        mode,
+        target_regex,
+    ) -> int:
         try:
-            en = load_lenient_json(zin.read(item))
+            source_data = load_lenient_json(archive.read(item))
         except (json.JSONDecodeError, OSError):
             return 0
-        tr_key = item.filename.lower().replace("en_us.json", target_file)
-        tr = {}
-        if tr_key in locale:
-            try:
-                tr = load_lenient_json(zin.read(locale[tr_key]))
-            except (json.JSONDecodeError, OSError):
-                pass
-        n = 0
-        for key, value in en.items():
-            if not isinstance(value, str) or not looks_like_source_language(value) or is_technical_term(value):
-                continue
-            if mode == "force" or not (key in tr and isinstance(tr[key], str) and tr[key].strip()):
-                n += 1
-        return n
 
-    def _count_book_json(self, zin, item) -> int:
-        try:
-            data = load_lenient_json(zin.read(item))
-        except (json.JSONDecodeError, OSError):
-            return 0
-        return sum(
-            1
-            for _, s in iter_translatable_strings(data)
-            if s.strip() and looks_like_source_language(s) and not is_technical_term(s)
+        target_path = re.sub(
+            r"en_us\.json$",
+            target_file,
+            item.filename,
+            flags=re.IGNORECASE,
         )
+        target_data = {}
+        target_key = target_path.lower()
+        if target_key in locale:
+            try:
+                target_data = load_lenient_json(
+                    archive.read(locale[target_key])
+                )
+            except (json.JSONDecodeError, OSError):
+                target_data = {}
 
-    def _count_book_md(self, zin, item, smart_glue) -> int:
-        try:
-            text = zin.read(item).decode("utf-8-sig", errors="ignore")
-        except OSError:
+        pending = collect_lang_keys_to_translate(
+            source_data,
+            target_data,
+            mode,
+            target_regex,
+        )
+        total_translatable = count_translatable_lang_entries(source_data)
+        if mode == "skip" and skip_threshold_reached(
+            total_translatable,
+            len(pending),
+        ):
             return 0
-        if smart_glue:
-            text = apply_smart_glue(text)
-        n = 0
-        in_yaml = False
-        for line in text.split("\n"):
-            s = line.strip()
-            if s == "---":
-                in_yaml = not in_yaml
-                continue
-            if in_yaml:
-                if s.lower().startswith("title:") and looks_like_source_language(line):
-                    n += 1
-                continue
-            if s.startswith("<") or s.startswith("!["):
-                continue
-            if line.strip() and looks_like_source_language(line) and not is_technical_term(line):
-                n += 1
-        return n
+        return len(pending)
 
-    def _estimate_loose(self, path, target_file, mode) -> int:
+    def _count_book_json(
+        self,
+        archive,
+        item,
+        locale,
+        target_lang,
+        mode,
+    ) -> int:
         try:
-            with open(path, encoding="utf-8") as f:
-                en = load_lenient_json(f.read().encode("utf-8"))
-            tr_path = path.replace("en_us.json", target_file)
-            tr = {}
-            if os.path.exists(tr_path):
-                with open(tr_path, encoding="utf-8") as f:
-                    tr = load_lenient_json(f.read().encode("utf-8"))
+            source_data = load_lenient_json(archive.read(item))
         except (json.JSONDecodeError, OSError):
             return 0
-        n = 0
-        for key, value in en.items():
-            if not isinstance(value, str) or not looks_like_source_language(value) or is_technical_term(value):
-                continue
-            if mode == "force" or not (key in tr and isinstance(tr[key], str) and tr[key].strip()):
-                n += 1
-        return n
 
-    def _estimate_snbt(self, path, mode, target_regex) -> int:
+        target_path = re.sub(
+            r"/en_us/",
+            f"/{target_lang['file']}/",
+            item.filename,
+            flags=re.IGNORECASE,
+        )
+        target_data = {}
+        target_key = target_path.lower()
+        if mode != "force" and target_key in locale:
+            try:
+                target_data = load_lenient_json(
+                    archive.read(locale[target_key])
+                )
+            except (json.JSONDecodeError, OSError):
+                target_data = {}
+
+        source_map, _preserved, pending = collect_book_json_selection(
+            source_data,
+            target_data,
+            mode,
+        )
+        if mode == "skip" and skip_threshold_reached(
+            len(source_map),
+            len(pending),
+        ):
+            return 0
+        return len(pending)
+
+    def _count_book_md(
+        self,
+        archive,
+        item,
+        locale,
+        target_lang,
+        mode,
+        smart_glue,
+    ) -> int:
         try:
-            with open(path, encoding="utf-8") as f:
-                content = f.read()
+            source_text = archive.read(item).decode(
+                "utf-8-sig",
+                errors="ignore",
+            )
         except OSError:
             return 0
-        strings = extract_snbt_strings(content)
-        if mode == "force":
-            return len(strings)
-        return sum(1 for s in strings if not re.search(target_regex, s))
 
+        target_path = re.sub(
+            r"/en_us/",
+            f"/{target_lang['file']}/",
+            item.filename,
+            flags=re.IGNORECASE,
+        )
+        target_text = ""
+        target_key = target_path.lower()
+        if mode != "force" and target_key in locale:
+            try:
+                target_text = archive.read(locale[target_key]).decode(
+                    "utf-8-sig",
+                    errors="ignore",
+                )
+            except OSError:
+                target_text = ""
 
-    def _estimate_bq(self, path: str, mode: str, target_regex: str) -> int:
+        selection = collect_book_markdown_selection(
+            source_text,
+            target_text,
+            mode,
+            smart_glue=smart_glue,
+        )
+        if mode == "skip" and skip_threshold_reached(
+            selection.total_translatable,
+            len(selection.pending),
+        ):
+            return 0
+        return len(selection.pending)
+
+    def _estimate_loose(
+        self,
+        path,
+        target_file,
+        mode,
+        target_regex,
+    ) -> int:
         try:
-            with open(path, "r", encoding="utf-8") as f:
-                data = json.load(f)
+            with open(path, encoding="utf-8") as source_file:
+                source_data = load_lenient_json(
+                    source_file.read().encode("utf-8")
+                )
+            target_path = path.replace("en_us.json", target_file)
+            target_data = {}
+            if os.path.exists(target_path):
+                with open(target_path, encoding="utf-8") as target_handle:
+                    target_data = load_lenient_json(
+                        target_handle.read().encode("utf-8")
+                    )
+        except (json.JSONDecodeError, OSError):
+            return 0
+
+        pending = collect_lang_keys_to_translate(
+            source_data,
+            target_data,
+            mode,
+            target_regex,
+        )
+        total_translatable = count_translatable_lang_entries(source_data)
+        if mode == "skip" and skip_threshold_reached(
+            total_translatable,
+            len(pending),
+        ):
+            return 0
+        return len(pending)
+
+    def _estimate_snbt(
+        self,
+        path,
+        mode,
+        target_regex,
+        target_code,
+    ) -> int:
+        if should_ignore_snbt_source(path):
+            return 0
+
+        target_path = get_snbt_target_path(path, target_code)
+        separate_target = target_path != path
+        if (
+            separate_target
+            and mode in ("append", "skip")
+            and os.path.exists(target_path)
+        ):
+            return 0
+
+        if separate_target:
+            original_path = path
+            current_path = path
+        else:
+            backup_path = path + ".bak"
+            original_path = backup_path if os.path.exists(backup_path) else path
+            current_path = original_path if mode == "force" else path
+
+        try:
+            with open(original_path, encoding="utf-8") as original_file:
+                original_content = original_file.read()
+            with open(current_path, encoding="utf-8") as current_file:
+                current_content = current_file.read()
+        except OSError:
+            return 0
+
+        selection = collect_snbt_selection(
+            original_content,
+            current_content,
+            mode,
+            target_regex,
+        )
+        if mode == "skip" and skip_threshold_reached(
+            selection.total_translatable,
+            len(selection.pending),
+        ):
+            return 0
+        return len(selection.pending)
+
+    def _estimate_bq(
+        self,
+        path: str,
+        mode: str,
+        target_regex: str,
+    ) -> int:
+        backup = path + ".bak"
+        source_path = (
+            backup
+            if mode == "force" and os.path.exists(backup)
+            else path
+        )
+        try:
+            with open(source_path, "r", encoding="utf-8") as source_file:
+                data = json.load(source_file)
         except (OSError, json.JSONDecodeError):
             return 0
 
-        n = 0
-        props_key = next((k for k in data if k.startswith("properties")), None)
-        if props_key and isinstance(data[props_key], dict):
-            bq_key = next((k for k in data[props_key] if k.startswith("betterquesting")), None)
-            if bq_key and isinstance(data[props_key][bq_key], dict):
-                bq_data = data[props_key][bq_key]
-                for key_prefix in ["name", "desc"]:
-                    actual_key = next((k for k in bq_data if k.startswith(key_prefix)), None)
-                    if actual_key and isinstance(bq_data[actual_key], str):
-                        text = bq_data[actual_key].strip()
-                        if not text:
-                            continue
-                        # Считаем строку, если режим "С нуля" ИЛИ если в тексте нет русских букв
-                        if mode == "force" or not already_translated(text, target_regex):
-                            n += 1
-        return n
+        selection = collect_bq_selection(data, mode, target_regex)
+        if mode == "skip" and skip_threshold_reached(
+            selection.total_translatable,
+            len(selection.pending),
+        ):
+            return 0
+        return len(selection.pending)

--- a/mineai/processors/jar.py
+++ b/mineai/processors/jar.py
@@ -14,14 +14,18 @@ from mineai.json_utils import (
 )
 from mineai.mod_names import get_mod_name
 from mineai.output.pack_writer import PackWriter
-from mineai.processors.locale_keys import collect_lang_keys_to_translate, count_translatable_lang_entries
-from mineai.runtime.state import JobState
-from mineai.text_processing import (
-    already_translated,
-    apply_smart_glue,
-    is_technical_term,
-    looks_like_source_language,
+from mineai.processors.locale_keys import (
+    collect_lang_keys_to_translate,
+    count_translatable_lang_entries,
 )
+from mineai.processors.selection import (
+    build_book_json_output,
+    collect_book_json_selection,
+    collect_book_markdown_selection,
+    skip_threshold_reached,
+)
+from mineai.runtime.state import JobState
+from mineai.text_processing import is_technical_term, looks_like_source_language
 
 
 class JarProcessor:
@@ -184,7 +188,12 @@ class JarProcessor:
         self, zin, zout, item, locale_files, target_file, target_lang, mode,
         output_mode, pack_writer, mod_name, written_inplace,
     ) -> bool:
-        tr_path = re.sub(r"en_us\.json$", target_file, item.filename, flags=re.IGNORECASE)
+        tr_path = re.sub(
+            r"en_us\.json$",
+            target_file,
+            item.filename,
+            flags=re.IGNORECASE,
+        )
         tr_key = tr_path.lower()
         try:
             en_data = load_lenient_json(zin.read(item))
@@ -198,27 +207,61 @@ class JarProcessor:
             except (json.JSONDecodeError, OSError):
                 tr_data = {}
 
-        pending = collect_lang_keys_to_translate(en_data, tr_data, mode, target_lang["regex"])
-        total = count_translatable_lang_entries(en_data)
-        if total == 0:
+        pending = collect_lang_keys_to_translate(
+            en_data,
+            tr_data,
+            mode,
+            target_lang["regex"],
+        )
+        total_translatable = count_translatable_lang_entries(en_data)
+        if total_translatable == 0:
             return False
 
-        if mode == "skip" and (total - len(pending)) >= total * 0.9:
-            return self._copy_existing(zin, locale_files, tr_key, tr_path, output_mode, pack_writer, en_data, tr_data, mode)
+        if mode == "skip" and skip_threshold_reached(
+            total_translatable,
+            len(pending),
+        ):
+            return self._copy_existing(
+                zin,
+                locale_files,
+                tr_key,
+                tr_path,
+                output_mode,
+                pack_writer,
+                en_data,
+                tr_data,
+                mode,
+            )
 
         merged = en_data.copy()
-        for k, v in tr_data.items():
-            if k in merged and isinstance(merged[k], str) and v:
-                merged[k] = v
+        for key, value in tr_data.items():
+            if key in merged and isinstance(merged[key], str) and value:
+                merged[key] = value
 
-        if not pending:
-            return self._write_lang_output(merged, tr_path, output_mode, pack_writer, zout, written_inplace, item, en_data)
+        if pending:
+            self.callbacks.on_log(
+                f"⚡ Перевод {mod_name} [Интерфейс] — {len(pending)} строк",
+                "cyan",
+            )
+            translated = self.service.translate_dict(
+                pending,
+                target_lang,
+                self.callbacks,
+                context=mod_name,
+            )
+            for key, value in translated.items():
+                merged[key] = value
 
-        self.callbacks.on_log(f"⚡ Перевод {mod_name} [Интерфейс] — {len(pending)} строк", "cyan")
-        translated = self.service.translate_dict(pending, target_lang, self.callbacks, context=mod_name)
-        for key, value in translated.items():
-            merged[key] = value
-        return self._write_lang_output(merged, tr_path, output_mode, pack_writer, zout, written_inplace, item, en_data)
+        return self._write_lang_output(
+            merged,
+            tr_path,
+            output_mode,
+            pack_writer,
+            zout,
+            written_inplace,
+            item,
+            en_data,
+        )
 
     def _write_lang_output(self, data, tr_path, output_mode, pack_writer, zout, written_inplace, item, en_data) -> bool:
         payload = json.dumps(data, ensure_ascii=False, indent=2).encode("utf-8")
@@ -244,58 +287,69 @@ class JarProcessor:
         self, zin, zout, item, locale_files, target_lang, mode,
         output_mode, pack_writer, mod_name, written_inplace,
     ) -> bool:
-        tr_path = re.sub(r"/en_us/", f"/{target_lang['file']}/", item.filename, flags=re.IGNORECASE)
+        tr_path = re.sub(
+            r"/en_us/",
+            f"/{target_lang['file']}/",
+            item.filename,
+            flags=re.IGNORECASE,
+        )
         tr_key = tr_path.lower()
-        # --- ФИКС ДЛЯ КНИГ PATCHOULI (Защита оригинального перевода) ---
-        if mode == "append" and tr_key in locale_files:
-            if output_mode == "resourcepack" and pack_writer:
-                pack_writer.write(tr_path, zin.read(locale_files[tr_key]))
-            elif output_mode == "inplace" and zout:
-                zout.writestr(tr_path, zin.read(locale_files[tr_key]))
-                written_inplace.add(tr_path)
-            return True
-        # ---------------------------------------------------------------
         try:
             en_data = load_lenient_json(zin.read(item))
         except (json.JSONDecodeError, OSError):
             return False
 
         tr_data = {}
-        if tr_key in locale_files:
+        if mode != "force" and tr_key in locale_files:
             try:
                 tr_data = load_lenient_json(zin.read(locale_files[tr_key]))
             except (json.JSONDecodeError, OSError):
-                pass
+                tr_data = {}
 
-        en_map = {path_to_key(p): s for p, s in iter_translatable_strings(en_data) if s.strip()}
-        tr_map = {path_to_key(p): s for p, s in iter_translatable_strings(tr_data)} if tr_data else {}
-
-        pending: dict[str, str] = {}
-        for path_key, source in en_map.items():
-            if is_technical_term(source):
-                continue
-            if not looks_like_source_language(source):
-                continue
-            existing = tr_map.get(path_key, "")
-            if mode == "append" and existing.strip() and existing != source:
-                continue
-            if mode == "append" and existing.strip() == source:
-                pending[path_key] = source
-            else:
-                pending[path_key] = source
-
-        if not en_map:
+        source_map, preserved, pending = collect_book_json_selection(
+            en_data,
+            tr_data,
+            mode,
+        )
+        total_translatable = len(source_map)
+        if total_translatable == 0:
             return False
 
-        if mode == "skip" and len(pending) <= len(en_map) * 0.1:
-            return self._copy_existing(zin, locale_files, tr_key, tr_path, output_mode, pack_writer, en_data, tr_data, mode)
+        if mode == "skip" and skip_threshold_reached(
+            total_translatable,
+            len(pending),
+        ):
+            return self._copy_existing(
+                zin,
+                locale_files,
+                tr_key,
+                tr_path,
+                output_mode,
+                pack_writer,
+                en_data,
+                tr_data,
+                mode,
+            )
 
+        translated: dict[str, str] = {}
         if pending:
-            self.callbacks.on_log(f"⚡ Перевод {mod_name} [Книга JSON] — {len(pending)} строк", "magenta")
-            translated = self.service.translate_dict(pending, target_lang, self.callbacks, context=mod_name)
-            apply_translations_by_path(en_data, translated)
+            self.callbacks.on_log(
+                f"⚡ Перевод {mod_name} [Книга JSON] — {len(pending)} строк",
+                "magenta",
+            )
+            translated = self.service.translate_dict(
+                pending,
+                target_lang,
+                self.callbacks,
+                context=mod_name,
+            )
 
-        payload = json.dumps(en_data, ensure_ascii=False, indent=2).encode("utf-8")
+        output_data = build_book_json_output(en_data, preserved, translated)
+        payload = json.dumps(
+            output_data,
+            ensure_ascii=False,
+            indent=2,
+        ).encode("utf-8")
         if output_mode == "resourcepack" and pack_writer:
             pack_writer.write(tr_path, payload)
             return True
@@ -311,123 +365,98 @@ class JarProcessor:
     ) -> bool:
         fl = item.filename.lower()
         tr_path = (
-            re.sub(r"/en_us/", f"/{target_lang['file']}/", item.filename, flags=re.IGNORECASE)
+            re.sub(
+                r"/en_us/",
+                f"/{target_lang['file']}/",
+                item.filename,
+                flags=re.IGNORECASE,
+            )
             if "/en_us/" in fl
             else item.filename
         )
         tr_key = tr_path.lower()
-        target_regex = target_lang["regex"]
-        # --- ФИКС ДЛЯ КНИГ MD (Защита оригинального перевода) ---
-        if mode == "append" and tr_key in locale_files:
-            if output_mode == "resourcepack" and pack_writer:
-                pack_writer.write(tr_path, zin.read(locale_files[tr_key]))
-            elif output_mode == "inplace" and zout:
-                zout.writestr(tr_path, zin.read(locale_files[tr_key]))
-                written_inplace.add(tr_path)
-            return True
-        # --------------------------------------------------------
         try:
             en_text = zin.read(item).decode("utf-8-sig", errors="ignore")
         except OSError:
             return False
 
-        if self.service.config.getboolean("GENERAL", "smart_glue"):
-            en_text = apply_smart_glue(en_text)
-
         tr_text = ""
-        if tr_key in locale_files:
-            tr_text = zin.read(locale_files[tr_key]).decode("utf-8-sig", errors="ignore")
-        tr_lines = tr_text.split("\n") if tr_text else []
+        if mode != "force" and tr_key in locale_files:
+            try:
+                tr_text = zin.read(locale_files[tr_key]).decode(
+                    "utf-8-sig",
+                    errors="ignore",
+                )
+            except OSError:
+                tr_text = ""
 
-        pending: dict[str, str] = {}
-        title_meta: dict[str, tuple[str, str]] = {}
-        lines_out: list[str] = []
-        in_yaml = False
-
-        for idx, line in enumerate(en_text.split("\n")):
-            stripped = line.strip()
-            if stripped == "---":
-                in_yaml = not in_yaml
-                lines_out.append(line)
-                continue
-
-            if in_yaml:
-                if stripped.lower().startswith("title:"):
-                    match = re.match(r'^(\s*title\s*:\s*[\'"]?)(.*?)([\'"]?)$', line, re.IGNORECASE)
-                    if match and looks_like_source_language(match.group(2)):
-                        prefix, title, suffix = match.groups()
-                        title_meta[str(idx)] = (prefix, suffix)
-                        if mode == "append" and idx < len(tr_lines) and already_translated(tr_lines[idx], target_regex):
-                            lines_out.append(tr_lines[idx])
-                        else:
-                            lines_out.append(line)
-                            pending[str(idx)] = title
-                    else:
-                        lines_out.append(line)
-                else:
-                    lines_out.append(line)
-                continue
-
-            if stripped.startswith("<") or stripped.startswith("!["):
-                lines_out.append(line)
-                continue
-            if not stripped or not looks_like_source_language(line) or is_technical_term(line):
-                lines_out.append(line)
-                continue
-
-            if mode == "append" and idx < len(tr_lines) and tr_lines[idx].strip() and already_translated(tr_lines[idx], target_regex):
-                lines_out.append(tr_lines[idx])
-            else:
-                lines_out.append(line)
-                pending[str(idx)] = line
-
-        # --- ФИКС 2: Режим пропуска (skip) ---
-        total_translatable = sum(
-            1 for line in en_text.split("\n")
-            if line.strip()
-            and not line.strip().startswith("<")
-            and not line.strip().startswith("![")
-            and looks_like_source_language(line)
-            and not is_technical_term(line)
+        selection = collect_book_markdown_selection(
+            en_text,
+            tr_text,
+            mode,
+            smart_glue=self.service.config.getboolean(
+                "GENERAL",
+                "smart_glue",
+            ),
         )
-        
-        if mode == "skip" and total_translatable > 0 and len(pending) <= total_translatable * 0.1:
-            if tr_key in locale_files:
-                raw = zin.read(locale_files[tr_key])
-                if output_mode == "resourcepack" and pack_writer:
-                    pack_writer.write(tr_path, raw)
-                    return True
-                elif zout:
-                    zout.writestr(tr_path, raw)
-                    written_inplace.add(tr_path)
-                    return True
+        if selection.total_translatable == 0:
+            if tr_key in locale_files and mode != "force":
+                return self._copy_existing(
+                    zin,
+                    locale_files,
+                    tr_key,
+                    tr_path,
+                    output_mode,
+                    pack_writer,
+                    {},
+                    {},
+                    mode,
+                )
             return False
-        # --------------------------------------
 
-        if not pending:
-            payload = "\n".join(lines_out).encode("utf-8")
-            if output_mode == "resourcepack" and pack_writer:
-                pack_writer.write(tr_path, payload)
-            elif zout:
-                zout.writestr(tr_path, payload)
-                written_inplace.add(tr_path)
-            return True  # <--- ФИКС 1: Возвращаем True вместо bool(pending)
+        if mode == "skip" and skip_threshold_reached(
+            selection.total_translatable,
+            len(selection.pending),
+        ):
+            return self._copy_existing(
+                zin,
+                locale_files,
+                tr_key,
+                tr_path,
+                output_mode,
+                pack_writer,
+                {},
+                {},
+                mode,
+            )
 
-        self.callbacks.on_log(f"⚡ Перевод {mod_name} [Книга MD] — {len(pending)} строк", "magenta")
-        translated = self.service.translate_dict(pending, target_lang, self.callbacks, context=mod_name)
-        for idx_s, value in translated.items():
-            idx = int(idx_s)
-            if idx_s in title_meta:
-                prefix, suffix = title_meta[idx_s]
-                lines_out[idx] = prefix + value + suffix
-            else:
-                lines_out[idx] = value
+        if selection.pending:
+            self.callbacks.on_log(
+                f"⚡ Перевод {mod_name} [Книга MD] — "
+                f"{len(selection.pending)} строк",
+                "magenta",
+            )
+            translated = self.service.translate_dict(
+                selection.pending,
+                target_lang,
+                self.callbacks,
+                context=mod_name,
+            )
+            for index_text, value in translated.items():
+                index = int(index_text)
+                if index_text in selection.title_meta:
+                    prefix, suffix = selection.title_meta[index_text]
+                    selection.lines_out[index] = prefix + value + suffix
+                else:
+                    selection.lines_out[index] = value
 
-        payload = "\n".join(lines_out).encode("utf-8")
+        payload = "\n".join(selection.lines_out).encode("utf-8")
         if output_mode == "resourcepack" and pack_writer:
             pack_writer.write(tr_path, payload)
             return True
         if zout:
             zout.writestr(tr_path, payload)
             written_inplace.add(tr_path)
-        return True
+            return True
+        return False
+

--- a/mineai/processors/locale_keys.py
+++ b/mineai/processors/locale_keys.py
@@ -1,5 +1,3 @@
-import re
-
 from mineai.text_processing import is_technical_term, looks_like_source_language
 
 
@@ -9,22 +7,19 @@ def collect_lang_keys_to_translate(
     mode: str,
     target_regex: str,
 ) -> dict[str, str]:
-    """Return lang file keys that still need translation."""
+    """Return filtered locale keys that need translation for the selected mode."""
+    _ = target_regex  # Kept in the public signature for call-site compatibility.
+
     pending: dict[str, str] = {}
     for key, value in en_data.items():
         if not isinstance(value, str) or not value.strip():
             continue
-        if is_technical_term(value):
-            continue
-        if not looks_like_source_language(value):
+        if is_technical_term(value) or not looks_like_source_language(value):
             continue
 
-        existing = tr_data.get(key) if isinstance(tr_data.get(key), str) else ""
-        if mode == "append" and existing.strip() and existing != value:
-            continue
-        if mode == "append" and existing.strip() == value:
-            pending[key] = value
-        elif mode != "append" or not existing.strip():
+        existing_value = tr_data.get(key)
+        existing = existing_value if isinstance(existing_value, str) else ""
+        if mode == "force" or not existing.strip() or existing == value:
             pending[key] = value
     return pending
 
@@ -32,6 +27,9 @@ def collect_lang_keys_to_translate(
 def count_translatable_lang_entries(en_data: dict) -> int:
     return sum(
         1
-        for v in en_data.values()
-        if isinstance(v, str) and looks_like_source_language(v) and not is_technical_term(v)
+        for value in en_data.values()
+        if isinstance(value, str)
+        and value.strip()
+        and looks_like_source_language(value)
+        and not is_technical_term(value)
     )

--- a/mineai/processors/loose_json.py
+++ b/mineai/processors/loose_json.py
@@ -6,7 +6,11 @@ from mineai.engines.service import TranslationService
 from mineai.io_utils import atomic_write_bytes
 from mineai.json_utils import load_lenient_json
 from mineai.output.pack_writer import PackWriter
-from mineai.processors.locale_keys import collect_lang_keys_to_translate, count_translatable_lang_entries
+from mineai.processors.locale_keys import (
+    collect_lang_keys_to_translate,
+    count_translatable_lang_entries,
+)
+from mineai.processors.selection import skip_threshold_reached
 from mineai.runtime.state import JobState
 
 
@@ -46,7 +50,7 @@ class LooseJsonProcessor:
         total = count_translatable_lang_entries(en_data)
         label = "Словарь: " + os.path.basename(os.path.dirname(os.path.dirname(file_path)))
 
-        if mode == "skip" and total and (total - len(pending)) >= total * 0.9:
+        if mode == "skip" and skip_threshold_reached(total, len(pending)):
             if output_mode == "resourcepack" and pack_writer and os.path.exists(tr_disk):
                 with open(tr_disk, "rb") as f:
                     pack_writer.write(tr_internal, f.read())
@@ -59,16 +63,17 @@ class LooseJsonProcessor:
 
         if pending:
             self.callbacks.on_log(f"⚡ Перевод {label} — {len(pending)} строк", "cyan")
-            # ДОБАВЛЕНО: prompt_type="books"
             translated = self.service.translate_dict(
-                pending, target_lang, self.callbacks, context="Локализация Квестов/Скриптов", prompt_type="books"
+                pending,
+                target_lang,
+                self.callbacks,
+                context="Локализация Квестов/Скриптов",
+                prompt_type="books",
             )
-            
-            # --- НОВАЯ ПРОВЕРКА ОТМЕНЫ ---
+
             if not self.state.should_run():
                 return
-            # -----------------------------
-            
+
             merged.update(translated)
 
         payload = json.dumps(merged, ensure_ascii=False, indent=2).encode("utf-8")

--- a/mineai/processors/selection.py
+++ b/mineai/processors/selection.py
@@ -1,0 +1,266 @@
+import copy
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from mineai.json_utils import (
+    apply_translations_by_path,
+    iter_translatable_strings,
+    path_to_key,
+)
+from mineai.text_processing import (
+    apply_smart_glue,
+    is_technical_term,
+    looks_like_source_language,
+)
+
+
+YAML_TITLE_RE = re.compile(
+    r'^(\s*title\s*:\s*[\'"]?)(.*?)([\'"]?)$',
+    re.IGNORECASE,
+)
+
+
+def skip_threshold_reached(total_translatable: int, pending_count: int) -> bool:
+    """Return True when at least 90% of translatable entries are complete."""
+    if total_translatable <= 0:
+        return False
+    translated_count = max(0, total_translatable - pending_count)
+    return translated_count / total_translatable >= 0.9
+
+
+def _needs_translation(source: str, existing: str, mode: str) -> bool:
+    if mode == "force":
+        return True
+    return not existing.strip() or existing == source
+
+
+def collect_book_json_selection(
+    source_data: Any,
+    target_data: Any,
+    mode: str,
+) -> tuple[dict[str, str], dict[str, str], dict[str, str]]:
+    """Return filtered source map, preserved target map and pending entries."""
+    all_source_map = {
+        path_to_key(path): text
+        for path, text in iter_translatable_strings(source_data)
+        if text.strip()
+    }
+    source_map = {
+        key: text
+        for key, text in all_source_map.items()
+        if looks_like_source_language(text)
+        and not is_technical_term(text)
+    }
+    target_map = (
+        {
+            path_to_key(path): text
+            for path, text in iter_translatable_strings(target_data)
+            if text.strip()
+        }
+        if target_data
+        else {}
+    )
+
+    preserved = {
+        key: existing
+        for key, existing in target_map.items()
+        if key in all_source_map
+        and existing != all_source_map[key]
+        and mode != "force"
+    }
+    pending = {
+        key: source
+        for key, source in source_map.items()
+        if _needs_translation(source, target_map.get(key, ""), mode)
+    }
+    return source_map, preserved, pending
+
+
+def build_book_json_output(
+    source_data: Any,
+    preserved: dict[str, str],
+    translated: dict[str, str],
+) -> Any:
+    output = copy.deepcopy(source_data)
+    apply_translations_by_path(output, preserved)
+    apply_translations_by_path(output, translated)
+    return output
+
+
+@dataclass
+class MarkdownSelection:
+    source_text: str
+    lines_out: list[str]
+    pending: dict[str, str]
+    title_meta: dict[str, tuple[str, str]]
+    total_translatable: int
+
+
+def _extract_yaml_title(line: str) -> tuple[str, str, str] | None:
+    match = YAML_TITLE_RE.match(line)
+    if not match:
+        return None
+    return match.group(1), match.group(2), match.group(3)
+
+
+def collect_book_markdown_selection(
+    source_text: str,
+    target_text: str,
+    mode: str,
+    *,
+    smart_glue: bool,
+) -> MarkdownSelection:
+    """Build one shared Markdown/YAML translation plan for estimator and writer."""
+    if smart_glue:
+        source_text = apply_smart_glue(source_text)
+
+    source_lines = source_text.split("\n")
+    target_lines = target_text.split("\n") if target_text else []
+    lines_out = list(source_lines)
+    pending: dict[str, str] = {}
+    title_meta: dict[str, tuple[str, str]] = {}
+    total_translatable = 0
+    in_yaml = False
+
+    for index, line in enumerate(source_lines):
+        stripped = line.strip()
+        if stripped == "---":
+            in_yaml = not in_yaml
+            continue
+
+        existing_line = target_lines[index] if index < len(target_lines) else ""
+
+        if in_yaml:
+            if not stripped.lower().startswith("title:"):
+                continue
+            source_title = _extract_yaml_title(line)
+            if not source_title:
+                continue
+            prefix, title, suffix = source_title
+            if (
+                not title.strip()
+                or not looks_like_source_language(title)
+                or is_technical_term(title)
+            ):
+                continue
+
+            total_translatable += 1
+            title_meta[str(index)] = (prefix, suffix)
+            existing_title_parts = _extract_yaml_title(existing_line)
+            existing_title = (
+                existing_title_parts[1] if existing_title_parts else ""
+            )
+            if _needs_translation(title, existing_title, mode):
+                pending[str(index)] = title
+            else:
+                lines_out[index] = existing_line
+            continue
+
+        if stripped.startswith("<") or stripped.startswith("!["):
+            continue
+        if (
+            not stripped
+            or not looks_like_source_language(line)
+            or is_technical_term(line)
+        ):
+            continue
+
+        total_translatable += 1
+        if _needs_translation(line, existing_line, mode):
+            pending[str(index)] = line
+        else:
+            lines_out[index] = existing_line
+
+    return MarkdownSelection(
+        source_text=source_text,
+        lines_out=lines_out,
+        pending=pending,
+        title_meta=title_meta,
+        total_translatable=total_translatable,
+    )
+
+
+@dataclass
+class BQSelection:
+    properties_key: str | None
+    betterquesting_key: str | None
+    total_translatable: int
+    pending: dict[str, str]
+
+
+def collect_bq_selection(
+    data: dict,
+    mode: str,
+    target_regex: str,
+) -> BQSelection:
+    from mineai.text_processing import already_translated
+
+    properties_key = next(
+        (key for key in data if key.startswith("properties")),
+        None,
+    )
+    betterquesting_key = None
+    fields: dict[str, str] = {}
+
+    if properties_key and isinstance(data.get(properties_key), dict):
+        properties = data[properties_key]
+        betterquesting_key = next(
+            (key for key in properties if key.startswith("betterquesting")),
+            None,
+        )
+        if betterquesting_key and isinstance(
+            properties.get(betterquesting_key),
+            dict,
+        ):
+            bq_data = properties[betterquesting_key]
+            for prefix in ("name", "desc"):
+                actual_key = next(
+                    (key for key in bq_data if key.startswith(prefix)),
+                    None,
+                )
+                if actual_key and isinstance(bq_data[actual_key], str):
+                    text = bq_data[actual_key].strip()
+                    if text:
+                        fields[actual_key] = text
+
+    pending = {
+        key: text
+        for key, text in fields.items()
+        if mode == "force" or not already_translated(text, target_regex)
+    }
+    return BQSelection(
+        properties_key=properties_key,
+        betterquesting_key=betterquesting_key,
+        total_translatable=len(fields),
+        pending=pending,
+    )
+
+
+@dataclass
+class SnbtSelection:
+    total_translatable: int
+    pending: list[str]
+
+
+def collect_snbt_selection(
+    original_content: str,
+    current_content: str,
+    mode: str,
+    target_regex: str,
+) -> SnbtSelection:
+    from mineai.processors.snbt_extract import extract_snbt_strings
+
+    original_strings = extract_snbt_strings(original_content)
+    pending = (
+        original_strings
+        if mode == "force"
+        else extract_snbt_strings(
+            current_content,
+            skip_translated_regex=target_regex,
+        )
+    )
+    return SnbtSelection(
+        total_translatable=len(original_strings),
+        pending=pending,
+    )

--- a/mineai/processors/snbt.py
+++ b/mineai/processors/snbt.py
@@ -1,99 +1,141 @@
 import os
-import shutil
 import re
+import shutil
 
 from mineai.engines.base import EngineCallbacks
 from mineai.engines.service import TranslationService
 from mineai.io_utils import atomic_write_text
-from mineai.processors.snbt_extract import apply_snbt_translations, extract_snbt_strings
+from mineai.processors.selection import (
+    collect_snbt_selection,
+    skip_threshold_reached,
+)
+from mineai.processors.snbt_extract import apply_snbt_translations
 from mineai.runtime.state import JobState
-from mineai.text_processing import already_translated
+
+
+def should_ignore_snbt_source(file_path: str) -> bool:
+    filename = os.path.basename(file_path)
+    if re.match(r"^[a-z]{2}_[a-z]{2}\.snbt$", filename):
+        if filename != "en_us.snbt":
+            return True
+        en_us_folder = os.path.join(os.path.dirname(file_path), "en_us")
+        if os.path.isdir(en_us_folder):
+            return True
+    return False
+
+
+def get_snbt_target_path(file_path: str, target_code: str) -> str:
+    if os.path.basename(file_path) == "en_us.snbt":
+        return os.path.join(
+            os.path.dirname(file_path),
+            f"{target_code}.snbt",
+        )
+    return file_path.replace(
+        "\\en_us\\",
+        f"\\{target_code}\\",
+    ).replace(
+        "/en_us/",
+        f"/{target_code}/",
+    )
 
 
 class SnbtProcessor:
-    def __init__(self, service: TranslationService, state: JobState, callbacks: EngineCallbacks) -> None:
+    def __init__(
+        self,
+        service: TranslationService,
+        state: JobState,
+        callbacks: EngineCallbacks,
+    ) -> None:
         self.service = service
         self.state = state
         self.callbacks = callbacks
 
     def process(self, file_path: str, *, target_lang: dict, mode: str) -> None:
         filename = os.path.basename(file_path)
-        
-        # Если файл называется как локализация (например, es_es.snbt), но это не английский - полностью игнорируем его
-        if re.match(r"^[a-z]{2}_[a-z]{2}\.snbt$", filename) and filename != "en_us.snbt":
+        if should_ignore_snbt_source(file_path):
+            if filename == "en_us.snbt":
+                self.callbacks.on_log(
+                    f"⏩ Пропуск {filename} (найдена папка с квестами)",
+                    "dim",
+                )
             return
-            
-        # --- НОВАЯ ЛОГИКА: ИГНОРИРОВАНИЕ ОГРОМНОГО ФАЙЛА ПРИ НАЛИЧИИ ПАПКИ ---
-        if filename == "en_us.snbt":
-            dir_name = os.path.dirname(file_path)
-            en_us_folder = os.path.join(dir_name, "en_us")
-            # Если рядом есть папка en_us (с разбитыми квестами), игнорируем этот гигантский резервный файл
-            if os.path.isdir(en_us_folder):
-                self.callbacks.on_log(f"⏩ Пропуск {filename} (найдена папка с квестами)", "dim")
-                return
-        # ----------------------------------------------------------------------
-        
-        is_lang_file = filename == "en_us.snbt"
-        mc_code = target_lang["file"]
-        
-        # Шаг 1. Определяем, куда сохранять и откуда читать
-        if is_lang_file:
-            target_file_path = os.path.join(os.path.dirname(file_path), f"{mc_code}.snbt")
-            
-            # Для en_us мы всегда берем оригинал как шаблон, он не должен меняться
-            source_path = file_path
+
+        target_file_path = get_snbt_target_path(
+            file_path,
+            target_lang["file"],
+        )
+        separate_target = target_file_path != file_path
+
+        if (
+            separate_target
+            and mode in ("append", "skip")
+            and os.path.exists(target_file_path)
+        ):
+            self.callbacks.on_log(
+                f"⏩ Пропуск {os.path.basename(target_file_path)}: "
+                "существующий SNBT сохранён без перезаписи",
+                "dim",
+            )
+            return
+
+        if separate_target:
+            os.makedirs(os.path.dirname(target_file_path), exist_ok=True)
+            original_path = file_path
+            current_path = file_path
         else:
-            # Для разбитых квестов (например, внутри папки en_us/chapters/)
-            # Заменяем en_us в пути на целевой язык (например, ru_ru), чтобы не сломать английские исходники
-            target_file_path = file_path.replace("\\en_us\\", f"\\{mc_code}\\").replace("/en_us/", f"/{mc_code}/")
-            
-            if target_file_path != file_path:
-                # Если путь успешно изменен на ru_ru, бэкап не нужен, берем оригинал
-                os.makedirs(os.path.dirname(target_file_path), exist_ok=True)
-                source_path = file_path
-            else:
-                # Старое поведение для файлов, лежащих в корне (перевод на месте с бэкапом)
-                backup = file_path + ".bak"
-                if not os.path.exists(backup):
-                    shutil.copy2(file_path, backup)
-                source_path = file_path if mode == "append" else backup
+            backup_path = file_path + ".bak"
+            if not os.path.exists(backup_path):
+                shutil.copy2(file_path, backup_path)
+            original_path = backup_path
+            current_path = backup_path if mode == "force" else file_path
 
-        target_regex = target_lang["regex"]
+        with open(original_path, encoding="utf-8") as source_file:
+            original_content = source_file.read()
+        with open(current_path, encoding="utf-8") as current_file:
+            current_content = current_file.read()
 
-        with open(source_path, encoding="utf-8") as f:
-            content = f.read()
-            
-        
-
-        # Шаг 2. Достаем строки и переводим
-        skip_regex = target_regex if mode == "append" else None
-        strings = extract_snbt_strings(content, skip_translated_regex=skip_regex)
-        if not strings:
+        selection = collect_snbt_selection(
+            original_content,
+            current_content,
+            mode,
+            target_lang["regex"],
+        )
+        if not selection.pending:
             return
-
-        if mode == "skip" and os.path.exists(target_file_path):
-            try:
-                with open(target_file_path, encoding="utf-8") as f:
-                    if already_translated(f.read(), target_regex):
-                        return
-            except OSError:
-                pass
+        if mode == "skip" and skip_threshold_reached(
+            selection.total_translatable,
+            len(selection.pending),
+        ):
+            self.callbacks.on_log(
+                f"⏩ Пропуск {os.path.basename(target_file_path)}: "
+                "готово не менее 90% строк",
+                "dim",
+            )
+            return
 
         name = os.path.basename(target_file_path)
-        self.callbacks.on_log(f"⚡ Перевод {name} [Квесты] — {len(strings)} строк", "yellow")
-        
-        chunk = {str(i): s for i, s in enumerate(strings)}
-        # ДОБАВЛЕНО: prompt_type="quests"
-        translated = self.service.translate_dict(chunk, target_lang, self.callbacks, context=name, prompt_type="quests")
-        
-        # --- НОВАЯ ПРОВЕРКА ОТМЕНЫ ---
+        self.callbacks.on_log(
+            f"⚡ Перевод {name} [Квесты] — {len(selection.pending)} строк",
+            "yellow",
+        )
+        chunk = {
+            str(index): text
+            for index, text in enumerate(selection.pending)
+        }
+        translated = self.service.translate_dict(
+            chunk,
+            target_lang,
+            self.callbacks,
+            context=name,
+            prompt_type="quests",
+        )
+
         if not self.state.should_run():
             return
-        # -----------------------------
-        
-        mapping = {strings[i]: translated.get(str(i), strings[i]) for i in range(len(strings))}
-        
-        new_content = apply_snbt_translations(content, mapping)
-        
-        # Шаг 3. Сохраняем в целевой файл (заменяя авторский ru_ru.snbt)
+
+        mapping = {
+            text: translated.get(str(index), text)
+            for index, text in enumerate(selection.pending)
+        }
+        new_content = apply_snbt_translations(current_content, mapping)
         atomic_write_text(target_file_path, new_content)

--- a/tests/test_estimator_processor_parity.py
+++ b/tests/test_estimator_processor_parity.py
@@ -1,0 +1,558 @@
+import json
+import os
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from mineai.engines.base import EngineCallbacks
+from mineai.processors.bq_json import BQProcessor
+from mineai.processors.estimator import StringEstimator
+from mineai.processors.jar import JarProcessor
+from mineai.processors.locale_keys import (
+    collect_lang_keys_to_translate,
+    count_translatable_lang_entries,
+)
+from mineai.processors.loose_json import LooseJsonProcessor
+from mineai.processors.snbt import SnbtProcessor
+from mineai.runtime.state import JobState
+
+
+TARGET_LANG = {
+    "file": "ru_ru",
+    "api": "ru",
+    "name": "Russian",
+    "regex": r"[А-Яа-яЁё]",
+}
+
+
+class _Config:
+    def __init__(self, smart_glue: bool = False) -> None:
+        self.smart_glue = smart_glue
+
+    def getboolean(self, _section: str, key: str) -> bool:
+        return self.smart_glue if key == "smart_glue" else False
+
+
+class _Service:
+    def __init__(self, smart_glue: bool = False) -> None:
+        self.config = _Config(smart_glue)
+        self.calls: list[dict[str, str]] = []
+
+    def translate_dict(
+        self,
+        strings,
+        _target_lang,
+        _callbacks,
+        **_kwargs,
+    ):
+        self.calls.append(dict(strings))
+        return {key: f"Перевод: {value}" for key, value in strings.items()}
+
+
+class _Writer:
+    def __init__(self) -> None:
+        self.files: dict[str, bytes] = {}
+
+    def write(self, path: str, payload: bytes) -> None:
+        self.files[path] = payload
+
+
+def _callbacks(logs: list[str] | None = None) -> EngineCallbacks:
+    logs = logs if logs is not None else []
+    return EngineCallbacks(
+        should_run=lambda: True,
+        wait_if_paused=lambda: None,
+        on_log=lambda message, _tag: logs.append(message),
+        on_status=lambda _message: None,
+        on_progress=lambda _count: None,
+    )
+
+
+def _state() -> JobState:
+    state = JobState()
+    state.start()
+    return state
+
+
+class LocaleContractTests(unittest.TestCase):
+    def test_collect_lang_keys_obeys_force_append_and_skip(self) -> None:
+        source = {
+            "new": "New entry",
+            "same": "Same entry",
+            "done": "Completed entry",
+            "empty": "",
+            "technical": "create_machine",
+            "target": "Готово",
+        }
+        target = {
+            "same": "Same entry",
+            "done": "Готовая запись",
+        }
+
+        force = collect_lang_keys_to_translate(
+            source,
+            target,
+            "force",
+            TARGET_LANG["regex"],
+        )
+        append = collect_lang_keys_to_translate(
+            source,
+            target,
+            "append",
+            TARGET_LANG["regex"],
+        )
+        skip = collect_lang_keys_to_translate(
+            source,
+            target,
+            "skip",
+            TARGET_LANG["regex"],
+        )
+
+        self.assertEqual(set(force), {"new", "same", "done"})
+        self.assertEqual(set(append), {"new", "same"})
+        self.assertEqual(skip, append)
+        self.assertEqual(count_translatable_lang_entries(source), 3)
+
+    def test_loose_json_estimator_matches_processor_for_all_modes(self) -> None:
+        cases = {
+            "force": 3,
+            "append": 2,
+            "skip": 2,
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_path = root / "en_us.json"
+            target_path = root / "ru_ru.json"
+            source_path.write_text(
+                json.dumps(
+                    {
+                        "new": "New entry",
+                        "same": "Same entry",
+                        "done": "Completed entry",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            target_path.write_text(
+                json.dumps(
+                    {
+                        "same": "Same entry",
+                        "done": "Готовая запись",
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+
+            for mode, expected in cases.items():
+                with self.subTest(mode=mode):
+                    state = _state()
+                    estimator = StringEstimator(state)
+                    estimated = estimator._estimate_loose(
+                        str(source_path),
+                        "ru_ru.json",
+                        mode,
+                        TARGET_LANG["regex"],
+                    )
+
+                    service = _Service()
+                    processor = LooseJsonProcessor(
+                        service,
+                        state,
+                        _callbacks(),
+                    )
+                    processor.process(
+                        str(source_path),
+                        str(root),
+                        target_lang=TARGET_LANG,
+                        mode=mode,
+                        output_mode="inplace",
+                        pack_writer=None,
+                    )
+                    actual = len(service.calls[0]) if service.calls else 0
+
+                    self.assertEqual(estimated, expected)
+                    self.assertEqual(actual, expected)
+                    # Restore the fixture changed by the previous subtest.
+                    target_path.write_text(
+                        json.dumps(
+                            {
+                                "same": "Same entry",
+                                "done": "Готовая запись",
+                            },
+                            ensure_ascii=False,
+                        ),
+                        encoding="utf-8",
+                    )
+
+    def test_loose_json_skip_uses_ninety_percent_formula(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = {f"key{i}": f"Source line {i}" for i in range(10)}
+            target = {
+                f"key{i}": f"Перевод {i}"
+                for i in range(9)
+            }
+            (root / "en_us.json").write_text(
+                json.dumps(source),
+                encoding="utf-8",
+            )
+            target_path = root / "ru_ru.json"
+            original_target = json.dumps(target, ensure_ascii=False)
+            target_path.write_text(original_target, encoding="utf-8")
+
+            state = _state()
+            estimator = StringEstimator(state)
+            self.assertEqual(
+                estimator._estimate_loose(
+                    str(root / "en_us.json"),
+                    "ru_ru.json",
+                    "skip",
+                    TARGET_LANG["regex"],
+                ),
+                0,
+            )
+
+            service = _Service()
+            LooseJsonProcessor(service, state, _callbacks()).process(
+                str(root / "en_us.json"),
+                str(root),
+                target_lang=TARGET_LANG,
+                mode="skip",
+                output_mode="inplace",
+                pack_writer=None,
+            )
+            self.assertEqual(service.calls, [])
+            self.assertEqual(
+                target_path.read_text(encoding="utf-8"),
+                original_target,
+            )
+
+
+class BookParityTests(unittest.TestCase):
+    @staticmethod
+    def _write_jar(path: Path, files: dict[str, str]) -> None:
+        with zipfile.ZipFile(path, "w") as archive:
+            for internal, content in files.items():
+                archive.writestr(internal, content.encode("utf-8"))
+
+    def test_book_json_append_preserves_existing_and_counts_new(self) -> None:
+        source_path = "assets/demo/patchouli_books/guide/en_us/entries/a.json"
+        target_path = "assets/demo/patchouli_books/guide/ru_ru/entries/a.json"
+        source = {
+            "name": "Original title",
+            "text": "New paragraph",
+        }
+        target = {
+            "name": "Сохранённый заголовок",
+            "text": "New paragraph",
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            jar_path = Path(temp_dir) / "book.jar"
+            self._write_jar(
+                jar_path,
+                {
+                    source_path: json.dumps(source),
+                    target_path: json.dumps(target, ensure_ascii=False),
+                },
+            )
+
+            state = _state()
+            estimator = StringEstimator(state)
+            estimated = estimator.estimate(
+                [str(jar_path)],
+                [],
+                [],
+                [],
+                target_lang=TARGET_LANG,
+                mode="append",
+                translate_mods=False,
+                translate_books=True,
+                translate_quests=False,
+                smart_glue=False,
+            )
+
+            service = _Service()
+            writer = _Writer()
+            JarProcessor(service, state, _callbacks()).process(
+                str(jar_path),
+                target_lang=TARGET_LANG,
+                mode="append",
+                output_mode="resourcepack",
+                translate_mods=False,
+                translate_books=True,
+                pack_writer=writer,
+            )
+
+            self.assertEqual(estimated, 1)
+            self.assertEqual(len(service.calls), 1)
+            self.assertEqual(set(service.calls[0]), {"text"})
+            output = json.loads(writer.files[target_path])
+            self.assertEqual(output["name"], "Сохранённый заголовок")
+            self.assertEqual(output["text"], "Перевод: New paragraph")
+
+    def test_book_markdown_append_uses_same_yaml_and_line_rules(self) -> None:
+        source_path = "assets/demo/guide/en_us/page.md"
+        target_path = "assets/demo/guide/ru_ru/page.md"
+        source = "\n".join(
+            [
+                "---",
+                "title: Original Title",
+                "---",
+                "<page>",
+                "![image](image.png)",
+                "Existing paragraph",
+                "New paragraph",
+            ]
+        )
+        target = "\n".join(
+            [
+                "---",
+                "title: Сохранённый заголовок",
+                "---",
+                "<page>",
+                "![image](image.png)",
+                "Сохранённый абзац",
+                "New paragraph",
+            ]
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            jar_path = Path(temp_dir) / "manual.jar"
+            self._write_jar(
+                jar_path,
+                {
+                    source_path: source,
+                    target_path: target,
+                },
+            )
+
+            state = _state()
+            estimator = StringEstimator(state)
+            estimated = estimator.estimate(
+                [str(jar_path)],
+                [],
+                [],
+                [],
+                target_lang=TARGET_LANG,
+                mode="append",
+                translate_mods=False,
+                translate_books=True,
+                translate_quests=False,
+                smart_glue=False,
+            )
+
+            service = _Service()
+            writer = _Writer()
+            JarProcessor(service, state, _callbacks()).process(
+                str(jar_path),
+                target_lang=TARGET_LANG,
+                mode="append",
+                output_mode="resourcepack",
+                translate_mods=False,
+                translate_books=True,
+                pack_writer=writer,
+            )
+
+            self.assertEqual(estimated, 1)
+            self.assertEqual(service.calls, [{"6": "New paragraph"}])
+            output = writer.files[target_path].decode("utf-8")
+            self.assertIn("title: Сохранённый заголовок", output)
+            self.assertIn("Сохранённый абзац", output)
+            self.assertIn("Перевод: New paragraph", output)
+            self.assertIn("![image](image.png)", output)
+
+
+class SnbtParityTests(unittest.TestCase):
+    def test_existing_separate_target_is_preserved_in_append(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_path = root / "en_us.snbt"
+            target_path = root / "ru_ru.snbt"
+            source_path.write_text('{title:"Original title"}', encoding="utf-8")
+            target_content = '{title:"Существующий перевод"}'
+            target_path.write_text(target_content, encoding="utf-8")
+
+            state = _state()
+            estimator = StringEstimator(state)
+            self.assertEqual(
+                estimator._estimate_snbt(
+                    str(source_path),
+                    "append",
+                    TARGET_LANG["regex"],
+                    TARGET_LANG["file"],
+                ),
+                0,
+            )
+
+            logs: list[str] = []
+            service = _Service()
+            SnbtProcessor(service, state, _callbacks(logs)).process(
+                str(source_path),
+                target_lang=TARGET_LANG,
+                mode="append",
+            )
+            self.assertEqual(service.calls, [])
+            self.assertEqual(
+                target_path.read_text(encoding="utf-8"),
+                target_content,
+            )
+            self.assertTrue(any("без перезаписи" in log for log in logs))
+
+    def test_root_snbt_skip_uses_ninety_percent_formula(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            path = root / "chapter.snbt"
+            backup = root / "chapter.snbt.bak"
+            original_values = [f'"Source {index}"' for index in range(10)]
+            current_values = [
+                f'"Перевод {index}"' if index < 9 else '"Source 9"'
+                for index in range(10)
+            ]
+            backup.write_text(
+                "{description:[" + ",".join(original_values) + "]}",
+                encoding="utf-8",
+            )
+            current_content = (
+                "{description:[" + ",".join(current_values) + "]}"
+            )
+            path.write_text(current_content, encoding="utf-8")
+
+            state = _state()
+            estimator = StringEstimator(state)
+            self.assertEqual(
+                estimator._estimate_snbt(
+                    str(path),
+                    "skip",
+                    TARGET_LANG["regex"],
+                    TARGET_LANG["file"],
+                ),
+                0,
+            )
+
+            service = _Service()
+            SnbtProcessor(service, state, _callbacks()).process(
+                str(path),
+                target_lang=TARGET_LANG,
+                mode="skip",
+            )
+            self.assertEqual(service.calls, [])
+            self.assertEqual(path.read_text(encoding="utf-8"), current_content)
+
+    def test_force_overwrites_separate_snbt_from_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_path = root / "en_us.snbt"
+            target_path = root / "ru_ru.snbt"
+            source_path.write_text('{title:"Original title"}', encoding="utf-8")
+            target_path.write_text('{title:"Старый перевод"}', encoding="utf-8")
+
+            state = _state()
+            estimator = StringEstimator(state)
+            self.assertEqual(
+                estimator._estimate_snbt(
+                    str(source_path),
+                    "force",
+                    TARGET_LANG["regex"],
+                    TARGET_LANG["file"],
+                ),
+                1,
+            )
+
+            service = _Service()
+            SnbtProcessor(service, state, _callbacks()).process(
+                str(source_path),
+                target_lang=TARGET_LANG,
+                mode="force",
+            )
+            self.assertEqual(len(service.calls[0]), 1)
+            self.assertIn(
+                "Перевод: Original title",
+                target_path.read_text(encoding="utf-8"),
+            )
+
+
+class BetterQuestingParityTests(unittest.TestCase):
+    @staticmethod
+    def _data(name: str, desc: str) -> dict:
+        return {
+            "properties:10": {
+                "betterquesting:10": {
+                    "name:8": name,
+                    "desc:8": desc,
+                }
+            }
+        }
+
+    def test_bq_append_estimator_matches_processor_and_preserves_existing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "quest.json"
+            path.write_text(
+                json.dumps(
+                    self._data("Существующее имя", "New description"),
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+
+            state = _state()
+            estimator = StringEstimator(state)
+            self.assertEqual(
+                estimator._estimate_bq(
+                    str(path),
+                    "append",
+                    TARGET_LANG["regex"],
+                ),
+                1,
+            )
+
+            service = _Service()
+            BQProcessor(service, state, _callbacks()).process(
+                str(path),
+                target_lang=TARGET_LANG,
+                mode="append",
+            )
+            self.assertEqual(len(service.calls), 1)
+            self.assertEqual(set(service.calls[0]), {"desc:8"})
+            output = json.loads(path.read_text(encoding="utf-8"))
+            bq = output["properties:10"]["betterquesting:10"]
+            self.assertEqual(bq["name:8"], "Существующее имя")
+            self.assertEqual(
+                bq["desc:8"],
+                "Перевод: New description",
+            )
+
+    def test_bq_skip_does_not_touch_fully_translated_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "quest.json"
+            original = json.dumps(
+                self._data("Готовое имя", "Готовое описание"),
+                ensure_ascii=False,
+            )
+            path.write_text(original, encoding="utf-8")
+
+            state = _state()
+            estimator = StringEstimator(state)
+            self.assertEqual(
+                estimator._estimate_bq(
+                    str(path),
+                    "skip",
+                    TARGET_LANG["regex"],
+                ),
+                0,
+            )
+
+            service = _Service()
+            BQProcessor(service, state, _callbacks()).process(
+                str(path),
+                target_lang=TARGET_LANG,
+                mode="skip",
+            )
+            self.assertEqual(service.calls, [])
+            self.assertEqual(path.read_text(encoding="utf-8"), original)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Описание

Зависит от PR #29. Этот PR построен поверх исправлений прогресса и ETA и не откатывает их.

PR синхронизирует StringEstimator с фактическими процессорами, чтобы предварительный подсчёт и реальная обработка выбирали одинаковые строки в режимах append, skip и force.

Единый контракт режимов

* force — переводятся все подходящие исходные строки;
* append — переводятся только отсутствующие, пустые или совпадающие с оригиналом строки;
* skip — при готовности не менее 90% файл пропускается целиком, иначе работает как append.

Для всех форматов используется единая формула:

translated_count / total_translatable >= 0.9

Locale JSON

* collect_lang_keys_to_translate() приведён к единому контракту;
* исключаются пустые, технические и нецелевые строки;
* JAR locale, loose JSON и estimator используют один и тот же отбор;
* estimator считает ровно те строки, которые процессор передаёт в сервис перевода.

JSON- и Markdown-книги

* удалён ложный полный пропуск книги в режиме append;
* существующие пользовательские переводы сохраняются;
* новые и совпадающие с оригиналом строки допереводятся;
* estimator читает существующий целевой файл из JAR;
* JSON-пути выбираются одинаково в estimator и processor;
* Markdown и YAML используют общий алгоритм;
* одинаково обрабатываются:
    * блоки ---;
    * поле title:;
    * smart_glue;
    * строки с <...>;
    * изображения ![...];
    * технические строки;
* добавлен единый skip-порог.

SNBT

* estimator повторяет правила определения исходного и целевого пути процессора;
* en_us.snbt пропускается при наличии соседней папки en_us;
* для корневых SNBT estimator и processor используют одинаковый подсчёт;
* в режиме skip применяется общий порог 90%;
* существующий отдельный целевой SNBT в append/skip безопасно сохраняется без молчаливой перезаписи;
* force сохраняет поведение полной перегенерации перевода.

BetterQuesting

* estimator и processor используют один отбор name и desc;
* добавлен единый skip-порог;
* существующие переводы сохраняются в append;
* для перевода используется тип промпта quests.

Проверка

После групп изменений и перед публикацией выполнены:

python -m compileall mineai tests translator.py
python -m unittest discover -s tests -v

Результат:

Ran 55 tests
OK

Добавлена интеграционная матрица, сравнивающая количество строк estimator с фактическими строками, переданными процессорами в сервис перевода.