### PR TITLE
Тесты Windows: исправить cleanup временной папки и проверку прав JAR

### DIFF
--- a/tests/test_gui_active_job.py
+++ b/tests/test_gui_active_job.py
@@ -30,10 +30,12 @@ sys.modules["tkinter"] = _tkinter
 sys.modules["mineai.gui.settings"] = _gui_settings
 try:
     with tempfile.TemporaryDirectory() as _import_dir:
-        os.chdir(_import_dir)
-        from mineai.gui import app as gui_app
+        try:
+            os.chdir(_import_dir)
+            from mineai.gui import app as gui_app
+        finally:
+            os.chdir(_original_cwd)
 finally:
-    os.chdir(_original_cwd)
     for name, previous in _previous_modules.items():
         if previous is None:
             sys.modules.pop(name, None)

--- a/tests/test_jar_inplace_safety.py
+++ b/tests/test_jar_inplace_safety.py
@@ -50,6 +50,7 @@ class JarInplaceSafetyTests(unittest.TestCase):
             path = os.path.join(directory, "example.jar")
             _write_jar(path)
             os.chmod(path, 0o640)
+            expected_mode = stat.S_IMODE(os.stat(path).st_mode)
 
             JarProcessor(_Service(), state, _callbacks(logs)).process(
                 path,
@@ -68,7 +69,10 @@ class JarInplaceSafetyTests(unittest.TestCase):
                     archive.read("assets/example/lang/ru_ru.json").decode("utf-8")
                 )
                 self.assertEqual(translated["example.hello"], "Привет")
-            self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), 0o640)
+            self.assertEqual(
+                stat.S_IMODE(os.stat(path).st_mode),
+                expected_mode,
+            )
             self.assertFalse(os.path.exists(path + ".temp"))
 
     def test_validation_failure_preserves_original_jar(self):


### PR DESCRIPTION
Что исправлено

Этот PR устраняет два Windows-специфичных падения тестов, обнаруженных при прогоне beta на Windows 11 и Python 3.14.

test_gui_active_job.py

Рабочая директория теперь возвращается до выхода из TemporaryDirectory.

На Windows текущую рабочую папку нельзя удалить, поэтому прежний порядок приводил к WinError 32 во время импорта тестового модуля.

test_jar_inplace_safety.py

Тест больше не требует буквального Unix-режима 0o640 на Windows.

После os.chmod() запоминается режим, реально поддержанный текущей операционной системой, а после атомарной замены JAR проверяется сохранение именно этого режима.

На Linux проверка продолжит контролировать 0o640, а на Windows — поддерживаемое Windows представление прав файла.

Область изменений

* изменены только два тестовых файла;
* production-код не затронут;
* существующие тесты не удалены и не ослаблены;
* проверки валидности JAR, атомарной замены и удаления .temp сохранены.

Причина

Предыдущий Windows-прогон завершился так:

Ran 71 tests
FAILED (failures=1, errors=1)

Оба падения были вызваны POSIX-допущениями тестовой инфраструктуры, а не ошибками обработки JAR или GUI в production-коде.

Проверка

Изменённые файлы проходят синтаксическую проверку.

После публикации PR необходимо выполнить штатный GitHub Actions и повторить на Windows:

python.exe -m unittest discover -s tests -v

Ожидаемый результат:

Ran 71 tests
OK