### PR TITLE
Стабильность переводов: дедупликация, проверка кэша и прозрачный fallback

### DIFF
--- a/mineai/cache.py
+++ b/mineai/cache.py
@@ -2,11 +2,21 @@ import json
 import os
 import shutil
 import threading
+import unicodedata
 from typing import Callable
 
 from mineai.constants import CACHE_FILE_AI, CACHE_FILE_STD
 from mineai.io_utils import atomic_write_text
 from mineai.text_processing import polish_translation
+
+
+_IDENTITY_PREFIX = "__mineai_identity__:"
+
+
+def _normalize_cache_source(text: str) -> str:
+    """Normalize representation without changing case or inner whitespace."""
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    return unicodedata.normalize("NFC", text)
 
 
 class TranslationCache:
@@ -15,11 +25,11 @@ class TranslationCache:
     def __init__(self, filepath: str) -> None:
         self.filepath = filepath
         self._data: dict[str, str] = {}
-        self._imported_data: dict[str, str] = {}  # Изолированный кэш для импорта
+        self._imported_data: dict[str, str] = {}
         self._lock = threading.RLock()
         self._dirty = False
         self._last_saved_count = 0
-        
+
         self.load_imported_caches()
         self.polish_changes = self.load_and_polish()
 
@@ -29,10 +39,10 @@ class TranslationCache:
             cache_name = os.path.basename(self.filepath)
             subfolder = "ai" if "ai" in cache_name else "std"
             import_dir = os.path.join(os.getcwd(), "imported_caches", subfolder)
-            
+
             if not os.path.exists(import_dir):
                 return
-                
+
             for filename in os.listdir(import_dir):
                 if filename.endswith(".json"):
                     path = os.path.join(import_dir, filename)
@@ -68,7 +78,15 @@ class TranslationCache:
                 return 0
 
             for key, value in list(self._data.items()):
-                api_code, _, source = key.partition("_")
+                if key.startswith(_IDENTITY_PREFIX):
+                    continue
+
+                api_code, separator, source = key.partition("_")
+                if not separator:
+                    del self._data[key]
+                    changes += 1
+                    continue
+
                 if api_code != "en" and value == source:
                     del self._data[key]
                     changes += 1
@@ -84,22 +102,84 @@ class TranslationCache:
         return changes
 
     def make_key(self, api_code: str, source_text: str) -> str:
-        return f"{api_code}_{source_text}"
+        normalized = _normalize_cache_source(source_text)
+        return f"{api_code}_{normalized}"
 
-    def get(self, api_code: str, source_text: str) -> tuple[str | None, bool]:
-        key = self.make_key(api_code, source_text)
+    def make_identity_key(self, api_code: str, source_text: str) -> str:
+        return _IDENTITY_PREFIX + self.make_key(api_code, source_text)
+
+    def get(
+        self,
+        api_code: str,
+        source_text: str,
+    ) -> tuple[str | None, bool]:
+        canonical_key = self.make_key(api_code, source_text)
+        legacy_key = f"{api_code}_{source_text}"
+        keys = tuple(dict.fromkeys((canonical_key, legacy_key)))
+        identity_key = self.make_identity_key(api_code, source_text)
+
         with self._lock:
-            if key in self._data:
-                return self._data[key], False  # False = из обычного кэша
-            if key in self._imported_data:
-                return self._imported_data[key], True  # True = из импортированного архива
+            for key in keys:
+                if key in self._data:
+                    return self._data[key], False
+
+            for key in keys:
+                if key in self._imported_data:
+                    return self._imported_data[key], True
+
+            if identity_key in self._data:
+                return source_text, False
+
             return None, False
 
     def set(self, api_code: str, source_text: str, translated: str) -> None:
-        key = self.make_key(api_code, source_text)
+        canonical_key = self.make_key(api_code, source_text)
+        legacy_key = f"{api_code}_{source_text}"
+        identity_key = self.make_identity_key(api_code, source_text)
+
         with self._lock:
-            self._data[key] = translated
+            self._data.pop(identity_key, None)
+            if legacy_key != canonical_key:
+                self._data.pop(legacy_key, None)
+            self._data[canonical_key] = translated
             self._dirty = True
+
+    def set_identity(self, api_code: str, source_text: str) -> None:
+        """Remember an intentionally unchanged technical token."""
+        canonical_key = self.make_key(api_code, source_text)
+        legacy_key = f"{api_code}_{source_text}"
+        identity_key = self.make_identity_key(api_code, source_text)
+
+        with self._lock:
+            self._data.pop(canonical_key, None)
+            self._data.pop(legacy_key, None)
+            self._data[identity_key] = "1"
+            self._dirty = True
+
+    def discard(
+        self,
+        api_code: str,
+        source_text: str,
+        *,
+        include_imported: bool = False,
+    ) -> None:
+        canonical_key = self.make_key(api_code, source_text)
+        legacy_key = f"{api_code}_{source_text}"
+        identity_key = self.make_identity_key(api_code, source_text)
+
+        with self._lock:
+            local_removed = False
+            for key in dict.fromkeys((canonical_key, legacy_key, identity_key)):
+                if key in self._data:
+                    del self._data[key]
+                    local_removed = True
+
+            if include_imported:
+                self._imported_data.pop(canonical_key, None)
+                self._imported_data.pop(legacy_key, None)
+
+            if local_removed:
+                self._dirty = True
 
     def __len__(self) -> int:
         with self._lock:

--- a/mineai/engines/service.py
+++ b/mineai/engines/service.py
@@ -1,13 +1,108 @@
+from collections import Counter
 import re
+
 from mineai.cache import TranslationCache
 from mineai.config import ConfigManager
+from mineai.constants import DEFAULT_OPENROUTER_MODEL
 from mineai.engines.base import EngineCallbacks, EngineItem, TranslationEngine
 from mineai.engines.deepl import DeepLEngine
 from mineai.engines.google import GoogleEngine
-from mineai.constants import DEFAULT_OPENROUTER_MODEL
 from mineai.engines.kobold import KoboldEngine
 from mineai.engines.openrouter import OpenRouterEngine
-from mineai.text_processing import apply_smart_glue, mask_protected_fragments
+from mineai.text_processing import (
+    PLACEHOLDER_PATTERN,
+    apply_smart_glue,
+    is_technical_term,
+    mask_protected_fragments,
+)
+
+
+_CJK_PATTERN = re.compile(
+    r"[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff"
+    r"\uac00-\ud7af]"
+)
+
+_PROMPT_LEAK_MARKERS = (
+    "no markers",
+    "marker whitelist",
+    "strict rules",
+    "do not translate",
+)
+
+
+def _source_fingerprint(text: str) -> str:
+    """Normalize representation only, without changing text semantics."""
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _can_cache_identity(original: str) -> bool:
+    """Return whether an unchanged result is an intentional technical token."""
+    stripped = original.strip()
+    if not stripped:
+        return False
+    if is_technical_term(stripped):
+        return True
+    return bool(
+        re.fullmatch(
+            r"[A-Z0-9][A-Z0-9+./_:#-]{0,15}",
+            stripped,
+        )
+    )
+
+
+def _validate_candidate(
+    item: EngineItem,
+    candidate: object,
+    target_lang: dict,
+) -> tuple[bool, str | None, bool]:
+    """Return accepted, rejection reason, and intentional-identity flag."""
+    if not isinstance(candidate, str):
+        return False, "ответ не является строкой", False
+
+    if not candidate.strip():
+        return False, "получена пустая строка", False
+
+    lowered = candidate.casefold()
+    for marker in _PROMPT_LEAK_MARKERS:
+        if marker in lowered:
+            return (
+                False,
+                f"в ответ попала служебная инструкция: {marker}",
+                False,
+            )
+
+    expected_fragments = Counter(item.mapping.values())
+    for fragment, expected_count in expected_fragments.items():
+        actual_count = candidate.count(fragment)
+        if actual_count != expected_count:
+            return (
+                False,
+                "изменён защищённый фрагмент "
+                f"{fragment!r}: ожидалось {expected_count}, "
+                f"получено {actual_count}",
+                False,
+            )
+
+    expected_literals = Counter(PLACEHOLDER_PATTERN.findall(item.original))
+    actual_literals = Counter(PLACEHOLDER_PATTERN.findall(candidate))
+    if actual_literals != expected_literals:
+        return False, "изменены буквальные маркеры [#N#]", False
+
+    same_as_source = candidate.strip() == item.original.strip()
+    if same_as_source:
+        if target_lang["api"] == "en":
+            return True, None, False
+        if _can_cache_identity(item.original):
+            return True, None, True
+        return False, "ответ совпадает с исходным текстом", False
+
+    if not re.search(target_lang["regex"], candidate):
+        return False, "в ответе нет символов целевого языка", False
+
+    if target_lang["api"] == "ru" and _CJK_PATTERN.search(candidate):
+        return False, "в русском переводе обнаружены CJK-символы", False
+
+    return True, None, False
 
 
 class TranslationService:
@@ -32,12 +127,16 @@ class TranslationService:
         self.ai_batch = ai_batch
         self.ai_provider = ai_provider
 
-    def _build_engine(self, context: str = "", prompt_type: str = "mods") -> TranslationEngine:
+    def _build_engine(
+        self,
+        context: str = "",
+        prompt_type: str = "mods",
+    ) -> TranslationEngine:
         try:
             retries = self.config.getint("AI", "ai_retries")
         except Exception:
             retries = 3
-        
+
         if self.engine_name == "google":
             return GoogleEngine(
                 workers=self.config.getint("GENERAL", "google_workers", 5),
@@ -49,7 +148,8 @@ class TranslationService:
             return OpenRouterEngine(
                 api_url=self.config.get("OPENROUTER", "api_url"),
                 api_key=self.config.get("OPENROUTER", "api_key"),
-                model=self.config.get("OPENROUTER", "model") or DEFAULT_OPENROUTER_MODEL,
+                model=self.config.get("OPENROUTER", "model")
+                or DEFAULT_OPENROUTER_MODEL,
                 mode=self.ai_mode,
                 context=context,
                 prompt_type=prompt_type,
@@ -79,70 +179,142 @@ class TranslationService:
         smart_glue = self.config.getboolean("GENERAL", "smart_glue")
         result: dict[str, str] = {}
         pending: dict[str, EngineItem] = {}
+        source_owner: dict[str, str] = {}
+        aliases: dict[str, list[str]] = {}
+        accepted: set[str] = set()
+        failure_reasons: dict[str, str] = {}
         cached_count = 0
         imported_count = 0
-        translated: dict[str, str] = {}
+        deduplicated_count = 0
 
         def bump(n: int = 1) -> None:
             if callbacks.on_progress:
                 callbacks.on_progress(n)
 
-        def is_acceptable(text: str, original: str) -> bool:
-            if not isinstance(text, str) or not text.strip():
-                return False
-            low = text.lower()
-            if any(
-                marker in low
-                for marker in (
-                    "no markers",
-                    "marker whitelist",
-                    "strict rules",
-                    "do not translate",
-                )
-            ):
-                return False
-            if text.strip() == original.strip():
-                return target_lang["api"] == "en"
-            return bool(re.search(target_lang["regex"], text))
+        def commit(owner_key: str, text: object, source_label: str) -> bool:
+            item = pending[owner_key]
+            accepted_value, reason, identity = _validate_candidate(
+                item,
+                text,
+                target_lang,
+            )
 
-        def commit(key: str, text: str) -> bool:
-            original = pending[key].original
-            if not is_acceptable(text, original):
+            if not accepted_value:
+                failure_reasons[owner_key] = f"{source_label}: {reason}"
+                candidate_preview = repr(text)[:120] if text is not None else "None"
+                callbacks.on_log(
+                    "❌ Отклонён перевод "
+                    f"{item.original[:70]!r}: {reason}; "
+                    f"ответ={candidate_preview}",
+                    "red",
+                )
                 return False
-            result[key] = text
-            translated[key] = text
-            self.cache.set(target_lang["api"], original, text)
-            callbacks.on_log(f" > {original[:40]} -> {text[:40]}", "dim")
-            bump()
+
+            assert isinstance(text, str)
+            output_keys = aliases[owner_key]
+            for output_key in output_keys:
+                result[output_key] = text
+            accepted.add(owner_key)
+
+            if identity:
+                self.cache.set_identity(target_lang["api"], item.original)
+                callbacks.on_log(
+                    "   ↪ Оставлено без изменений и запомнено: "
+                    f"{item.original[:70]}",
+                    "dim",
+                )
+            else:
+                self.cache.set(target_lang["api"], item.original, text)
+                duplicate_suffix = (
+                    f" ×{len(output_keys)}" if len(output_keys) > 1 else ""
+                )
+                callbacks.on_log(
+                    f" > {item.original[:40]} -> "
+                    f"{text[:40]}{duplicate_suffix}",
+                    "dim",
+                )
+
+            bump(len(output_keys))
             return True
+
+        def apply_engine_result(
+            requested: dict[str, EngineItem],
+            engine_result: dict[str, str],
+            source_label: str,
+        ) -> None:
+            for key, text in engine_result.items():
+                if key not in requested or key not in pending:
+                    callbacks.on_log(
+                        f"⚠️ {source_label} вернул неизвестный ключ: {key}",
+                        "yellow",
+                    )
+                    continue
+                commit(key, text, source_label)
+
+            for key in requested:
+                if key not in engine_result and key not in accepted:
+                    failure_reasons[key] = (
+                        f"{source_label}: движок не вернул результата"
+                    )
 
         for key, text in strings.items():
             if not callbacks.should_run():
                 break
             callbacks.wait_if_paused()
+
             if smart_glue:
                 text = apply_smart_glue(text)
 
-            hit, is_imported = self.cache.get(target_lang["api"], text)
-            if hit is not None:
-                result[key] = hit
-                if is_imported:
-                    imported_count += 1
-                else:
-                    cached_count += 1
-                bump()
-                continue
             masked, mapping = mask_protected_fragments(text)
-            if not masked:
-                result[key] = text
-                bump()
-                continue
-            pending[key] = EngineItem(
+            item = EngineItem(
                 key=key,
                 original=text,
                 masked=masked,
                 mapping=mapping,
             )
+
+            hit, is_imported = self.cache.get(target_lang["api"], text)
+            if hit is not None:
+                valid, reason, _identity = _validate_candidate(
+                    item,
+                    hit,
+                    target_lang,
+                )
+                if valid:
+                    result[key] = hit
+                    if is_imported:
+                        imported_count += 1
+                    else:
+                        cached_count += 1
+                    bump()
+                    continue
+
+                callbacks.on_log(
+                    "⚠️ Невалидная запись кэша отброшена "
+                    f"для {text[:70]!r}: {reason}",
+                    "yellow",
+                )
+                self.cache.discard(
+                    target_lang["api"],
+                    text,
+                    include_imported=is_imported,
+                )
+
+            if not masked:
+                result[key] = text
+                bump()
+                continue
+
+            fingerprint = _source_fingerprint(text)
+            existing_owner = source_owner.get(fingerprint)
+            if existing_owner is not None:
+                aliases[existing_owner].append(key)
+                deduplicated_count += 1
+                continue
+
+            source_owner[fingerprint] = key
+            aliases[key] = [key]
+            pending[key] = item
 
         if cached_count:
             callbacks.on_log(f"   🗃️ Из кэша: {cached_count} строк", "dim")
@@ -150,6 +322,12 @@ class TranslationService:
             callbacks.on_log(
                 f"   📦 Из ресурс-паков: {imported_count} строк",
                 "cyan",
+            )
+        if deduplicated_count:
+            callbacks.on_log(
+                "   ♻️ Повторяющиеся строки объединены: "
+                f"{deduplicated_count}",
+                "dim",
             )
 
         if not pending or not callbacks.should_run():
@@ -160,10 +338,8 @@ class TranslationService:
         max_chars = self.ai_batch * 100 if is_ai else 999999
         max_placeholders_per_batch = 30
 
-        from mineai.text_processing import PLACEHOLDER_PATTERN
-
-        batches = []
-        current_batch = {}
+        batches: list[dict[str, EngineItem]] = []
+        current_batch: dict[str, EngineItem] = {}
         current_chars = 0
         current_placeholders = 0
 
@@ -216,11 +392,10 @@ class TranslationService:
                     "dim",
                 )
             batch_result = engine.translate_batch(batch, target_lang, callbacks)
-            for key, text in batch_result.items():
-                commit(key, text)
+            apply_engine_result(batch, batch_result, "основной движок")
 
         failed_pending = {
-            key: value for key, value in pending.items() if key not in translated
+            key: item for key, item in pending.items() if key not in accepted
         }
 
         try:
@@ -228,12 +403,7 @@ class TranslationService:
         except Exception:
             use_fallback = False
 
-        if (
-            failed_pending
-            and is_ai
-            and use_fallback
-            and callbacks.should_run()
-        ):
+        if failed_pending and is_ai and use_fallback and callbacks.should_run():
             callbacks.on_log(
                 f"🔄 ИИ не справился. Переводим {len(failed_pending)} "
                 "строк через Google...",
@@ -248,15 +418,33 @@ class TranslationService:
                 target_lang,
                 callbacks,
             )
-            for key, text in google_translated.items():
-                commit(key, text)
+            apply_engine_result(
+                failed_pending,
+                google_translated,
+                "Google fallback",
+            )
+            accepted_by_google = sum(
+                1 for key in failed_pending if key in accepted
+            )
+            if accepted_by_google:
+                callbacks.on_log(
+                    f"   ✅ Google fallback: принято "
+                    f"{accepted_by_google}/{len(failed_pending)} строк",
+                    "green",
+                )
+            if accepted_by_google < len(failed_pending):
+                callbacks.on_log(
+                    f"   ⚠️ Google fallback: не принято "
+                    f"{len(failed_pending) - accepted_by_google} строк",
+                    "yellow",
+                )
 
         if is_ai and use_fallback and callbacks.should_run():
             still_failed_complex = {
-                key: value
-                for key, value in pending.items()
-                if key not in translated
-                and len(PLACEHOLDER_PATTERN.findall(value.masked)) > 10
+                key: item
+                for key, item in pending.items()
+                if key not in accepted
+                and len(PLACEHOLDER_PATTERN.findall(item.masked)) > 10
             }
             if still_failed_complex:
                 callbacks.on_log(
@@ -273,12 +461,31 @@ class TranslationService:
                     target_lang,
                     callbacks,
                 )
-                for key, text in google_result.items():
-                    commit(key, text)
+                apply_engine_result(
+                    still_failed_complex,
+                    google_result,
+                    "Google complex fallback",
+                )
 
-        for key, item in pending.items():
-            if key not in translated:
-                result[key] = item.original
-                bump()
+        for owner_key, item in pending.items():
+            if owner_key in accepted:
+                continue
+
+            output_keys = aliases[owner_key]
+            reason = failure_reasons.get(
+                owner_key,
+                "движок не вернул валидного результата",
+            )
+            callbacks.on_log(
+                "⚠️ Строка не переведена: "
+                f"{item.original[:90]!r}; "
+                f"причина: {reason}; "
+                "сохранён исходный текст",
+                "yellow",
+            )
+            for output_key in output_keys:
+                result[output_key] = item.original
+            bump(len(output_keys))
+
         self.cache.save_if_threshold()
         return result

--- a/mineai/text_processing.py
+++ b/mineai/text_processing.py
@@ -6,6 +6,11 @@ from mineai.constants import DICT_FILE, IGNORE_TERMS
 from mineai.io_utils import atomic_write_text
 
 
+_IGNORE_TERMS_CASEFOLD = frozenset(
+    term.casefold() for term in IGNORE_TERMS
+)
+
+
 PLACEHOLDER_PATTERN = re.compile(r"\[\s*#\s*(\d+)\s*#\s*\]")
 
 FORMAT_PATTERN = re.compile(
@@ -129,16 +134,40 @@ def unmask_translation(text: str, mapping: dict[str, str]) -> str:
 def is_technical_term(text: str) -> bool:
     if not text:
         return True
-    lower = text.lower()
+
+    stripped = text.strip()
+    if not stripped:
+        return True
+
+    if stripped.casefold() in _IGNORE_TERMS_CASEFOLD:
+        return True
+
+    lower = stripped.lower()
+
     if not re.search(r"[a-z]", lower):
         return True
-    if re.match(r"^[a-z0-9_.-]+$", lower) and any(c in lower for c in "._"):
+
+    if (
+        re.fullmatch(r"[a-z0-9_.-]+", lower)
+        and any(char in lower for char in "._")
+    ):
         return True
+
     prefixes = (
-        "glyph_", "ritual_", "familiar_", "source_", "mana_", "spell_",
-        "effect_", "rune_", "altar_", "botania_", "create_", "kubejs_",
+        "glyph_",
+        "ritual_",
+        "familiar_",
+        "source_",
+        "mana_",
+        "spell_",
+        "effect_",
+        "rune_",
+        "altar_",
+        "botania_",
+        "create_",
+        "kubejs_",
     )
-    return any(lower.startswith(p) for p in prefixes)
+    return any(lower.startswith(prefix) for prefix in prefixes)
 
 
 def is_translation_key(text: str) -> bool:

--- a/tests/test_translation_service.py
+++ b/tests/test_translation_service.py
@@ -1,0 +1,204 @@
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+_original_cwd = os.getcwd()
+with tempfile.TemporaryDirectory() as _import_cwd:
+    os.chdir(_import_cwd)
+    try:
+        from mineai.cache import TranslationCache
+        from mineai.engines.base import EngineCallbacks, TranslationEngine
+        from mineai.engines.service import TranslationService
+        from mineai.text_processing import is_technical_term
+    finally:
+        os.chdir(_original_cwd)
+
+
+TARGET_LANG = {
+    "api": "ru",
+    "name": "Russian",
+    "regex": r"[А-Яа-яЁё]",
+}
+
+
+class _Config:
+    def __init__(self, fallback_google=False):
+        self.fallback_google = fallback_google
+
+    def getboolean(self, section, key):
+        if (section, key) == ("GENERAL", "smart_glue"):
+            return False
+        if (section, key) == ("AI", "fallback_google"):
+            return self.fallback_google
+        raise AssertionError((section, key))
+
+    def getint(self, _section, _key, fallback=0):
+        return fallback
+
+
+class _MemoryCache:
+    def __init__(self):
+        self.values = {}
+        self.identities = set()
+        self.discarded = []
+
+    def get(self, api_code, source):
+        key = (api_code, source)
+        if key in self.values:
+            return self.values[key], False
+        if key in self.identities:
+            return source, False
+        return None, False
+
+    def set(self, api_code, source, translated):
+        key = (api_code, source)
+        self.identities.discard(key)
+        self.values[key] = translated
+
+    def set_identity(self, api_code, source):
+        key = (api_code, source)
+        self.values.pop(key, None)
+        self.identities.add(key)
+
+    def discard(self, api_code, source, *, include_imported=False):
+        key = (api_code, source)
+        self.values.pop(key, None)
+        self.identities.discard(key)
+        self.discarded.append((api_code, source, include_imported))
+
+    def save_if_threshold(self):
+        pass
+
+
+class _Engine(TranslationEngine):
+    def __init__(self, response_factory):
+        self.response_factory = response_factory
+        self.calls = []
+
+    def translate_batch(self, items, target_lang, callbacks):
+        self.calls.append(dict(items))
+        return self.response_factory(items)
+
+
+class _Service(TranslationService):
+    def __init__(self, engine, cache, config):
+        super().__init__("ai", cache, config, ai_batch=20)
+        self.engine = engine
+
+    def _build_engine(self, context="", prompt_type="mods"):
+        return self.engine
+
+
+def _callbacks(logs, progress=None):
+    progress = progress if progress is not None else []
+    return EngineCallbacks(
+        should_run=lambda: True,
+        wait_if_paused=lambda: None,
+        on_log=lambda message, tag: logs.append((message, tag)),
+        on_status=lambda _message: None,
+        on_progress=lambda count: progress.append(count),
+    )
+
+
+class TranslationServiceRegressionTests(unittest.TestCase):
+    def test_identical_sources_are_sent_to_engine_once(self):
+        engine = _Engine(lambda items: {next(iter(items)): "Список"})
+        logs, progress = [], []
+        result = _Service(engine, _MemoryCache(), _Config()).translate_dict(
+            {"a": "Unordered List", "b": "Unordered List"},
+            TARGET_LANG,
+            _callbacks(logs, progress),
+        )
+        self.assertEqual(list(engine.calls[0]), ["a"])
+        self.assertEqual(result, {"a": "Список", "b": "Список"})
+        self.assertEqual(sum(progress), 2)
+        self.assertTrue(any("объединены: 1" in msg for msg, _ in logs))
+
+    def test_short_technical_identity_is_not_retranslated(self):
+        cache = _MemoryCache()
+        first = _Engine(lambda items: {next(iter(items)): "RF"})
+        _Service(first, cache, _Config()).translate_dict(
+            {"key": "RF"}, TARGET_LANG, _callbacks([])
+        )
+        self.assertIn(("ru", "RF"), cache.identities)
+
+        second = _Engine(lambda _items: self.fail("engine must be skipped"))
+        logs = []
+        result = _Service(second, cache, _Config()).translate_dict(
+            {"key": "RF"}, TARGET_LANG, _callbacks(logs)
+        )
+        self.assertEqual(result, {"key": "RF"})
+        self.assertEqual(second.calls, [])
+        self.assertTrue(any("Из кэша: 1" in msg for msg, _ in logs))
+
+    def test_invalid_cached_placeholder_is_discarded(self):
+        cache = _MemoryCache()
+        cache.values[("ru", "Power: %s")] = "Мощность:"
+        engine = _Engine(lambda items: {next(iter(items)): "Мощность: %s"})
+        logs = []
+        result = _Service(engine, cache, _Config()).translate_dict(
+            {"key": "Power: %s"}, TARGET_LANG, _callbacks(logs)
+        )
+        self.assertEqual(result, {"key": "Мощность: %s"})
+        self.assertEqual(cache.discarded, [("ru", "Power: %s", False)])
+        self.assertTrue(any("кэша отброшена" in msg for msg, _ in logs))
+
+    def test_google_fallback_rejection_is_logged(self):
+        source = "Original value"
+        google = mock.Mock()
+        google.translate_batch.return_value = {"key": source}
+        logs = []
+        with mock.patch(
+            "mineai.engines.service.GoogleEngine", return_value=google
+        ):
+            result = _Service(
+                _Engine(lambda _items: {}),
+                _MemoryCache(),
+                _Config(fallback_google=True),
+            ).translate_dict({"key": source}, TARGET_LANG, _callbacks(logs))
+        self.assertEqual(result, {"key": source})
+        self.assertTrue(any(
+            "Google fallback: ответ совпадает" in msg for msg, _ in logs
+        ))
+        self.assertTrue(any("не принято 1 строк" in msg for msg, _ in logs))
+        self.assertTrue(any("Строка не переведена" in msg for msg, _ in logs))
+
+    def test_russian_candidate_with_cjk_is_rejected(self):
+        source = "Villager Egg Drop Chance"
+        engine = _Engine(
+            lambda items: {next(iter(items)): "Вероятность яйца村民"}
+        )
+        logs = []
+        result = _Service(engine, _MemoryCache(), _Config()).translate_dict(
+            {"key": source}, TARGET_LANG, _callbacks(logs)
+        )
+        self.assertEqual(result, {"key": source})
+        self.assertTrue(any("CJK-символы" in msg for msg, _ in logs))
+
+    def test_ignore_terms_are_case_insensitive(self):
+        self.assertTrue(is_technical_term(" RF "))
+        self.assertTrue(is_technical_term("gui"))
+        self.assertFalse(is_technical_term("Iron"))
+
+
+class TranslationCacheIdentityTests(unittest.TestCase):
+    def test_identity_survives_reload_and_normalizes_newlines(self):
+        with tempfile.TemporaryDirectory() as directory:
+            previous_cwd = os.getcwd()
+            os.chdir(directory)
+            try:
+                path = os.path.join(directory, "ai_cache.json")
+                cache = TranslationCache(path)
+                cache.set_identity("ru", "RF\r\n/t")
+                cache.save()
+                self.assertEqual(
+                    TranslationCache(path).get("ru", "RF\n/t"),
+                    ("RF\n/t", False),
+                )
+            finally:
+                os.chdir(previous_cwd)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Описание

PR исправляет подтверждённые тестированием проблемы повторной отправки одинаковых строк, повторного перевода технических токенов, непрозрачного Google fallback и использования невалидных значений из кэша.

PR построен поверх актуальной ветки beta после #32. Процессоры, режимы force/append/skip, прогресс, ETA, UI и запись архивов не изменялись.

Изменения

Дедупликация

Одинаковый исходный текст объединяется до обращения к движку. LLM получает одну representative-запись, а готовый перевод применяется ко всем соответствующим JSON-ключам. Прогресс учитывает фактическое число выходных строк.

Технические токены

Точные значения из IGNORE_TERMS распознаются без учёта регистра и внешних пробелов.

Намеренно неизменённые технические токены сохраняются отдельными identity-ключами и не удаляются очистителем кэша. Обычные короткие слова не помечаются identity автоматически.

Проверка кэша и ответов

Общий валидатор применяется к:

* результатам основного движка;
* Google fallback;
* обычному кэшу;
* импортированному кэшу.

Проверяются пустые ответы, служебный текст промпта, защищённые фрагменты, буквальные маркеры [#N#], целевой алфавит и посторонние CJK-символы в русском переводе.

Невалидная кэш-запись отбрасывается, после чего строка переводится заново.

Google fallback

Теперь лог содержит:

* отсутствие ответа;
* конкретную причину отклонения;
* количество принятых и непринятых строк;
* причину сохранения исходного текста.

Область изменений

Изменены только:

* mineai/cache.py;
* mineai/engines/service.py;
* mineai/text_processing.py;
* tests/test_translation_service.py.

Проверка

python3 -m compileall -q mineai tests translator.py
python3 -m unittest -v \
  tests.test_translation_service \
  tests.test_service_fallback \
  tests.test_safe_writes

Результат:

Ran 13 tests
OK

Добавлены регрессионные тесты дедупликации, identity-кэша, повреждённых placeholder-маркеров, Google fallback, CJK-валидации, технических терминов и перезагрузки identity-кэша.