### PR TITLE
fix(release): финальный hardening перед переходом beta в main

### DIFF
--- a/mineai/engines/deepl.py
+++ b/mineai/engines/deepl.py
@@ -2,7 +2,7 @@ import time
 import requests
 
 from mineai.engines.base import EngineCallbacks, EngineItem, TranslationEngine
-from mineai.engines.http_retry import request_with_retry
+from mineai.engines.http_retry import RequestCancelled, request_with_retry
 from mineai.text_processing import polish_translation, unmask_translation
 
 
@@ -41,15 +41,17 @@ class DeepLEngine(TranslationEngine):
                     ),
                     operation="DeepL",
                     on_log=callbacks.on_log,
+                    should_continue=callbacks.should_run,
                 )
                 translations = response.json()["translations"]
                 for idx, key in enumerate(chunk_keys):
                     raw = translations[idx]["text"]
                     raw = unmask_translation(raw, items[key].mapping)
                     result[key] = polish_translation(raw)
+            except RequestCancelled:
+                break
             except (requests.RequestException, KeyError, IndexError, TypeError, ValueError) as exc:
                 callbacks.on_log(f"❌ Ошибка DeepL: {exc}", "red")
-                    # Ключи при сбое НЕ возвращаем: сервис сам подставит
-                    # оригинал для отсутствующих ключей — без записи в кэш
-            time.sleep(0.5)
+            if callbacks.should_run():
+                time.sleep(0.5)
         return result

--- a/mineai/engines/google.py
+++ b/mineai/engines/google.py
@@ -4,7 +4,7 @@ import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from mineai.engines.base import EngineCallbacks, EngineItem, TranslationEngine
-from mineai.engines.http_retry import request_with_retry
+from mineai.engines.http_retry import RequestCancelled, request_with_retry
 from mineai.text_processing import polish_translation, unmask_translation
 
 
@@ -29,6 +29,8 @@ class GoogleEngine(TranslationEngine):
                 should_continue=should_continue,
             )
             return "".join(part[0] for part in response.json()[0] if part[0])
+        except RequestCancelled:
+            raise
         except (requests.RequestException, KeyError, IndexError, ValueError, TypeError):
             return None
 
@@ -70,7 +72,10 @@ class GoogleEngine(TranslationEngine):
                 callbacks.wait_if_paused()
                 if not callbacks.should_run():
                     break
-                key, raw = fut.result()
+                try:
+                    key, raw = fut.result()
+                except RequestCancelled:
+                    break
                 if raw:
                     result[key] = self._finalize(raw, items[key])
         return result
@@ -117,7 +122,10 @@ class GoogleEngine(TranslationEngine):
                 callbacks.wait_if_paused()
                 if not callbacks.should_run():
                     break
-                chunk_keys, parts = fut.result()
+                try:
+                    chunk_keys, parts = fut.result()
+                except RequestCancelled:
+                    break
                 if parts:
                     for idx, key in enumerate(chunk_keys):
                         result[key] = self._finalize(parts[idx].strip(), items[key])
@@ -125,14 +133,18 @@ class GoogleEngine(TranslationEngine):
                     for key in chunk_keys:
                         if not callbacks.should_run():
                             break
-                        single = self._request(
-                            items[key].masked,
-                            api_code,
-                            timeout=5,
-                            on_log=callbacks.on_log,
-                            should_continue=callbacks.should_run,
-                        )
+                        try:
+                            single = self._request(
+                                items[key].masked,
+                                api_code,
+                                timeout=5,
+                                on_log=callbacks.on_log,
+                                should_continue=callbacks.should_run,
+                            )
+                        except RequestCancelled:
+                            break
                         if single:
                             result[key] = self._finalize(single, items[key])
-                        time.sleep(0.3)
+                        if callbacks.should_run():
+                            time.sleep(0.3)
         return result

--- a/mineai/engines/google.py
+++ b/mineai/engines/google.py
@@ -16,7 +16,7 @@ class GoogleEngine(TranslationEngine):
         self.workers = max(1, min(workers, 10))
         self.mode = mode
 
-    def _request(self, text: str, api_code: str, timeout: int = 10, on_log=None) -> str | None:
+    def _request(self, text: str, api_code: str, timeout: int = 10, on_log=None, should_continue=None) -> str | None:
         try:
             response = request_with_retry(
                 lambda: requests.get(
@@ -26,6 +26,7 @@ class GoogleEngine(TranslationEngine):
                 ),
                 operation="Google Translate",
                 on_log=on_log,
+                should_continue=should_continue,
             )
             return "".join(part[0] for part in response.json()[0] if part[0])
         except (requests.RequestException, KeyError, IndexError, ValueError, TypeError):
@@ -56,7 +57,12 @@ class GoogleEngine(TranslationEngine):
         def work(key: str, masked: str) -> tuple[str, str | None]:
             if not callbacks.should_run():
                 return key, None
-            return key, self._request(masked, api_code, on_log=callbacks.on_log)
+            return key, self._request(
+                masked,
+                api_code,
+                on_log=callbacks.on_log,
+                should_continue=callbacks.should_run,
+            )
 
         with ThreadPoolExecutor(max_workers=self.workers) as pool:
             futures = {pool.submit(work, k, v.masked): k for k, v in items.items()}
@@ -65,9 +71,6 @@ class GoogleEngine(TranslationEngine):
                 if not callbacks.should_run():
                     break
                 key, raw = fut.result()
-                # При сбое/остановке НЕ кладём оригинал в result:
-                # иначе сервис закэширует "английский = английский" навсегда.
-                # Сервис сам подставит оригинал для отсутствующих ключей (без кэша).
                 if raw:
                     result[key] = self._finalize(raw, items[key])
         return result
@@ -95,7 +98,12 @@ class GoogleEngine(TranslationEngine):
         def translate_chunk(chunk_keys: list[str], text: str) -> tuple[list[str], list[str] | None]:
             if not callbacks.should_run():
                 return chunk_keys, None
-            raw = self._request(text, api_code, on_log=callbacks.on_log)
+            raw = self._request(
+                text,
+                api_code,
+                on_log=callbacks.on_log,
+                should_continue=callbacks.should_run,
+            )
             if not raw:
                 return chunk_keys, None
             parts = re.split(r"\s*\|\s*~\s*\|\s*", raw)
@@ -115,7 +123,15 @@ class GoogleEngine(TranslationEngine):
                         result[key] = self._finalize(parts[idx].strip(), items[key])
                 else:
                     for key in chunk_keys:
-                        single = self._request(items[key].masked, api_code, timeout=5, on_log=callbacks.on_log)
+                        if not callbacks.should_run():
+                            break
+                        single = self._request(
+                            items[key].masked,
+                            api_code,
+                            timeout=5,
+                            on_log=callbacks.on_log,
+                            should_continue=callbacks.should_run,
+                        )
                         if single:
                             result[key] = self._finalize(single, items[key])
                         time.sleep(0.3)

--- a/mineai/engines/http_retry.py
+++ b/mineai/engines/http_retry.py
@@ -13,7 +13,7 @@ DEFAULT_ATTEMPTS = 4
 DEFAULT_BASE_DELAY = 1.0
 
 
-class RequestCancelled(requests.RequestException):
+class RequestCancelled(Exception):
     """Raised when the active translation job is cancelled between HTTP attempts."""
 
 

--- a/mineai/engines/http_retry.py
+++ b/mineai/engines/http_retry.py
@@ -13,6 +13,10 @@ DEFAULT_ATTEMPTS = 4
 DEFAULT_BASE_DELAY = 1.0
 
 
+class RequestCancelled(requests.RequestException):
+    """Raised when the active translation job is cancelled between HTTP attempts."""
+
+
 def _is_retryable(exc: requests.RequestException) -> bool:
     if isinstance(exc, (requests.Timeout, requests.ConnectionError)):
         return True
@@ -20,6 +24,31 @@ def _is_retryable(exc: requests.RequestException) -> bool:
         status_code = exc.response.status_code
         return status_code == 429 or 500 <= status_code <= 599
     return False
+
+
+def _ensure_running(should_continue: Callable[[], bool] | None) -> None:
+    if should_continue is not None and not should_continue():
+        raise RequestCancelled("request cancelled")
+
+
+def _interruptible_sleep(
+    delay: float,
+    should_continue: Callable[[], bool] | None,
+) -> None:
+    if delay <= 0:
+        _ensure_running(should_continue)
+        return
+    if should_continue is None:
+        time.sleep(delay)
+        return
+
+    deadline = time.monotonic() + delay
+    while True:
+        _ensure_running(should_continue)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return
+        time.sleep(min(0.1, remaining))
 
 
 def request_with_retry(
@@ -30,11 +59,13 @@ def request_with_retry(
     base_delay: float = DEFAULT_BASE_DELAY,
     on_log: Callable[[str, str], None] | None = None,
     delay_func: Callable[[int, Exception], float] | None = None,
+    should_continue: Callable[[], bool] | None = None,
 ) -> requests.Response:
-    """Execute an HTTP request with bounded exponential backoff.
+    """Execute an HTTP request with bounded, cancellation-aware backoff.
 
     Timeouts, connection failures, HTTP 429 and HTTP 5xx responses are retried.
-    Other HTTP and request errors are raised immediately.
+    Other HTTP and request errors are raised immediately. Cancellation is checked
+    before every attempt and while waiting between retries.
     """
     if attempts < 1:
         raise ValueError("attempts must be at least 1")
@@ -42,28 +73,28 @@ def request_with_retry(
         raise ValueError("base_delay must be non-negative")
 
     for attempt in range(1, attempts + 1):
+        _ensure_running(should_continue)
         try:
             response = request()
             response.raise_for_status()
             return response
+        except RequestCancelled:
+            raise
         except requests.RequestException as exc:
             if not _is_retryable(exc) or attempt >= attempts:
                 raise
 
-            # Считаем задержку: либо кастомная (например, для OpenRouter), либо стандартная экспоненциальная
             if delay_func:
                 delay = delay_func(attempt, exc)
             else:
                 delay = base_delay * (2 ** (attempt - 1))
-            
+
             msg = f"{operation} (попытка {attempt}/{attempts}): {exc}. Повтор через {delay:.1f}с"
-            
-            # Отправляем в GUI, если передан callback, иначе пишем в стандартный скрытый логгер
             if on_log:
                 on_log(f"⚠️ {msg}", "yellow")
             else:
                 logger.warning(msg)
-            
-            time.sleep(delay)
+
+            _interruptible_sleep(delay, should_continue)
 
     raise RuntimeError("unreachable retry state")

--- a/mineai/engines/kobold.py
+++ b/mineai/engines/kobold.py
@@ -1,12 +1,13 @@
 import requests
 
 from mineai.constants import KOBOLD_API
-from mineai.engines.http_retry import request_with_retry
+from mineai.engines.http_retry import RequestCancelled, request_with_retry
 from mineai.engines.llm_common import BatchLlmEngine
 
 
 class KoboldEngine(BatchLlmEngine):
     def __init__(self, mode: str = "safe", context: str = "", prompt_type: str = "mods", retries: int = 3) -> None:
+        self._should_continue = None
         super().__init__(
             mode=mode,
             context=context,
@@ -15,6 +16,13 @@ class KoboldEngine(BatchLlmEngine):
             label="KoboldCPP",
             retries=retries,
         )
+
+    def translate_batch(self, items, target_lang, callbacks):
+        self._should_continue = callbacks.should_run
+        try:
+            return super().translate_batch(items, target_lang, callbacks)
+        finally:
+            self._should_continue = None
 
     def _request(self, prompt: str, max_tokens: int, on_log=None) -> str | None:
         try:
@@ -31,10 +39,13 @@ class KoboldEngine(BatchLlmEngine):
                 ),
                 operation="KoboldCPP",
                 on_log=on_log,
+                should_continue=self._should_continue,
             )
             content = response.json()["choices"][0]["message"]["content"]
             if not isinstance(content, str) or not content.strip():
                 return None
             return content.strip()
+        except RequestCancelled:
+            return None
         except (requests.RequestException, KeyError, IndexError, TypeError, ValueError):
             return None

--- a/mineai/engines/kobold.py
+++ b/mineai/engines/kobold.py
@@ -23,6 +23,8 @@ class KoboldEngine(BatchLlmEngine):
         self._on_log = callbacks.on_log
         try:
             return super().translate_batch(items, target_lang, callbacks)
+        except RequestCancelled:
+            return {}
         finally:
             self._should_continue = None
             self._on_log = None
@@ -51,7 +53,7 @@ class KoboldEngine(BatchLlmEngine):
                 return None
             return content.strip()
         except RequestCancelled:
-            return None
+            raise
         except (requests.RequestException, KeyError, IndexError, TypeError, ValueError) as exc:
             if active_log: active_log(f"❌ KoboldCPP: {exc}", "red")
             return None

--- a/mineai/engines/kobold.py
+++ b/mineai/engines/kobold.py
@@ -8,6 +8,7 @@ from mineai.engines.llm_common import BatchLlmEngine
 class KoboldEngine(BatchLlmEngine):
     def __init__(self, mode: str = "safe", context: str = "", prompt_type: str = "mods", retries: int = 3) -> None:
         self._should_continue = None
+        self._on_log = None
         super().__init__(
             mode=mode,
             context=context,
@@ -19,12 +20,15 @@ class KoboldEngine(BatchLlmEngine):
 
     def translate_batch(self, items, target_lang, callbacks):
         self._should_continue = callbacks.should_run
+        self._on_log = callbacks.on_log
         try:
             return super().translate_batch(items, target_lang, callbacks)
         finally:
             self._should_continue = None
+            self._on_log = None
 
     def _request(self, prompt: str, max_tokens: int, on_log=None) -> str | None:
+        active_log = on_log or self._on_log
         try:
             response = request_with_retry(
                 lambda: requests.post(
@@ -38,14 +42,16 @@ class KoboldEngine(BatchLlmEngine):
                     timeout=300,
                 ),
                 operation="KoboldCPP",
-                on_log=on_log,
+                on_log=active_log,
                 should_continue=self._should_continue,
             )
             content = response.json()["choices"][0]["message"]["content"]
             if not isinstance(content, str) or not content.strip():
+                if active_log: active_log("⚠️ KoboldCPP вернул пустой ответ", "yellow")
                 return None
             return content.strip()
         except RequestCancelled:
             return None
-        except (requests.RequestException, KeyError, IndexError, TypeError, ValueError):
+        except (requests.RequestException, KeyError, IndexError, TypeError, ValueError) as exc:
+            if active_log: active_log(f"❌ KoboldCPP: {exc}", "red")
             return None

--- a/mineai/engines/openrouter.py
+++ b/mineai/engines/openrouter.py
@@ -18,6 +18,7 @@ class OpenRouterEngine(BatchLlmEngine):
         self.site_url = site_url.strip()
         self.app_name = app_name.strip() or "MineAI Translator"
         self._should_continue = None
+        self._on_log = None
         super().__init__(
             mode=mode, context=context, prompt_type=prompt_type,
             call_api=self._request, label="OpenRouter", retries=retries,
@@ -25,10 +26,12 @@ class OpenRouterEngine(BatchLlmEngine):
 
     def translate_batch(self, items, target_lang, callbacks):
         self._should_continue = callbacks.should_run
+        self._on_log = callbacks.on_log
         try:
             return super().translate_batch(items, target_lang, callbacks)
         finally:
             self._should_continue = None
+            self._on_log = None
 
     def _headers(self) -> dict[str, str]:
         headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
@@ -37,6 +40,8 @@ class OpenRouterEngine(BatchLlmEngine):
         return headers
 
     def _request(self, prompt: str, max_tokens: int, on_log=None) -> str | None:
+        active_log = on_log or self._on_log
+
         def openrouter_delay(attempt: int, exc: Exception) -> float:
             if isinstance(exc, requests.HTTPError) and exc.response is not None and exc.response.status_code == 429:
                 return 15.0 * attempt
@@ -52,24 +57,25 @@ class OpenRouterEngine(BatchLlmEngine):
                 ),
                 operation="OpenRouter",
                 attempts=4,
-                on_log=on_log,
+                on_log=active_log,
                 delay_func=openrouter_delay,
                 should_continue=self._should_continue,
             )
         except RequestCancelled:
             return None
         except requests.RequestException as exc:
-            if on_log: on_log(f"❌ OpenRouter сеть: {exc}", "red")
+            if active_log: active_log(f"❌ OpenRouter сеть: {exc}", "red")
             return None
 
         try:
             content = response.json()["choices"][0]["message"]["content"]
         except (KeyError, IndexError, TypeError, ValueError) as exc:
             logger.error("OpenRouter invalid JSON: %s", exc)
+            if active_log: active_log(f"❌ OpenRouter: неверный JSON ответа: {exc}", "red")
             return None
 
         if not isinstance(content, str) or not content.strip():
-            if on_log: on_log("⚠️ OpenRouter вернул пустой ответ (фильтр модели)", "yellow")
+            if active_log: active_log("⚠️ OpenRouter вернул пустой ответ (фильтр модели)", "yellow")
             return None
 
         return content.strip()

--- a/mineai/engines/openrouter.py
+++ b/mineai/engines/openrouter.py
@@ -1,7 +1,7 @@
 import logging
 import requests
 from mineai.constants import OPENROUTER_API
-from mineai.engines.http_retry import request_with_retry
+from mineai.engines.http_retry import RequestCancelled, request_with_retry
 from mineai.engines.llm_common import BatchLlmEngine
 
 logger = logging.getLogger(__name__)
@@ -17,10 +17,18 @@ class OpenRouterEngine(BatchLlmEngine):
         self.model = model.strip()
         self.site_url = site_url.strip()
         self.app_name = app_name.strip() or "MineAI Translator"
+        self._should_continue = None
         super().__init__(
             mode=mode, context=context, prompt_type=prompt_type,
             call_api=self._request, label="OpenRouter", retries=retries,
         )
+
+    def translate_batch(self, items, target_lang, callbacks):
+        self._should_continue = callbacks.should_run
+        try:
+            return super().translate_batch(items, target_lang, callbacks)
+        finally:
+            self._should_continue = None
 
     def _headers(self) -> dict[str, str]:
         headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
@@ -29,12 +37,11 @@ class OpenRouterEngine(BatchLlmEngine):
         return headers
 
     def _request(self, prompt: str, max_tokens: int, on_log=None) -> str | None:
-        # <--- ТА САМАЯ ЗАЩИТА ОТ БЛОКИРОВКИ БЕСПЛАТНЫХ МОДЕЛЕЙ ---
         def openrouter_delay(attempt: int, exc: Exception) -> float:
             if isinstance(exc, requests.HTTPError) and exc.response is not None and exc.response.status_code == 429:
-                return 15.0 * attempt  # 15, 30, 45 секунд для лимитов
-            return 4.0 * attempt       # Обычная задержка для других ошибок сети
-            
+                return 15.0 * attempt
+            return 4.0 * attempt
+
         try:
             response = request_with_retry(
                 lambda: requests.post(
@@ -46,8 +53,11 @@ class OpenRouterEngine(BatchLlmEngine):
                 operation="OpenRouter",
                 attempts=4,
                 on_log=on_log,
-                delay_func=openrouter_delay, # <--- Передаем нашу умную задержку
+                delay_func=openrouter_delay,
+                should_continue=self._should_continue,
             )
+        except RequestCancelled:
+            return None
         except requests.RequestException as exc:
             if on_log: on_log(f"❌ OpenRouter сеть: {exc}", "red")
             return None
@@ -57,9 +67,9 @@ class OpenRouterEngine(BatchLlmEngine):
         except (KeyError, IndexError, TypeError, ValueError) as exc:
             logger.error("OpenRouter invalid JSON: %s", exc)
             return None
-            
+
         if not isinstance(content, str) or not content.strip():
             if on_log: on_log("⚠️ OpenRouter вернул пустой ответ (фильтр модели)", "yellow")
             return None
-            
+
         return content.strip()

--- a/mineai/engines/openrouter.py
+++ b/mineai/engines/openrouter.py
@@ -29,6 +29,8 @@ class OpenRouterEngine(BatchLlmEngine):
         self._on_log = callbacks.on_log
         try:
             return super().translate_batch(items, target_lang, callbacks)
+        except RequestCancelled:
+            return {}
         finally:
             self._should_continue = None
             self._on_log = None
@@ -62,7 +64,7 @@ class OpenRouterEngine(BatchLlmEngine):
                 should_continue=self._should_continue,
             )
         except RequestCancelled:
-            return None
+            raise
         except requests.RequestException as exc:
             if active_log: active_log(f"❌ OpenRouter сеть: {exc}", "red")
             return None

--- a/mineai/json_utils.py
+++ b/mineai/json_utils.py
@@ -1,8 +1,96 @@
 import json
-import re
 from typing import Any, Iterator
 
 from mineai.constants import KEYS_TO_TRANSLATE
+
+
+def _strip_json_comments(text: str) -> str:
+    """Remove // and /* */ comments only when they are outside JSON strings."""
+    out: list[str] = []
+    i = 0
+    in_string = False
+    escaped = False
+
+    while i < len(text):
+        char = text[i]
+
+        if in_string:
+            out.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            i += 1
+            continue
+
+        if char == '"':
+            in_string = True
+            out.append(char)
+            i += 1
+            continue
+
+        if char == "/" and i + 1 < len(text):
+            next_char = text[i + 1]
+            if next_char == "/":
+                i += 2
+                while i < len(text) and text[i] not in "\r\n":
+                    i += 1
+                continue
+            if next_char == "*":
+                i += 2
+                while i + 1 < len(text) and text[i : i + 2] != "*/":
+                    i += 1
+                if i + 1 < len(text):
+                    i += 2
+                continue
+
+        out.append(char)
+        i += 1
+
+    return "".join(out)
+
+
+def _strip_trailing_commas(text: str) -> str:
+    """Remove trailing commas before ] or } only when outside JSON strings."""
+    out: list[str] = []
+    i = 0
+    in_string = False
+    escaped = False
+
+    while i < len(text):
+        char = text[i]
+
+        if in_string:
+            out.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            i += 1
+            continue
+
+        if char == '"':
+            in_string = True
+            out.append(char)
+            i += 1
+            continue
+
+        if char == ",":
+            lookahead = i + 1
+            while lookahead < len(text) and text[lookahead].isspace():
+                lookahead += 1
+            if lookahead < len(text) and text[lookahead] in "]}":
+                i += 1
+                continue
+
+        out.append(char)
+        i += 1
+
+    return "".join(out)
 
 
 def load_lenient_json(raw: bytes | str) -> Any:
@@ -10,9 +98,8 @@ def load_lenient_json(raw: bytes | str) -> Any:
         text = raw.decode("utf-8-sig", errors="ignore")
     else:
         text = raw
-    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
-    text = re.sub(r"(?m)^\s*//.*$", "", text)
-    text = re.sub(r",\s*([\]}])", r"\1", text)
+    text = _strip_json_comments(text)
+    text = _strip_trailing_commas(text)
     return json.loads(text)
 
 
@@ -28,7 +115,6 @@ def key_to_path(key: str) -> tuple:
         else:
             parts.append(part)
     return tuple(parts)
-
 
 
 def set_at_path(data: Any, path: tuple, value: Any) -> None:

--- a/mineai/output/pack_writer.py
+++ b/mineai/output/pack_writer.py
@@ -134,6 +134,10 @@ class PackWriter:
         self._close_handles()
         self._remove_output_archives()
 
+    def abort(self) -> None:
+        """Close and remove archives created by an incomplete translation job."""
+        self._cleanup_partial_archives()
+
     def close(self) -> tuple[str | None, str | None]:
         rp, dp = self.rp_zip_path, self.dp_zip_path
         errors = self._close_handles()

--- a/mineai/runtime/job.py
+++ b/mineai/runtime/job.py
@@ -97,18 +97,6 @@ class TranslationJob:
         elif name == "protected":
             self.state.mark_protected(count)
 
-    def _on_metric(self, name: str, count: int = 1) -> None:
-        if name == "ok":
-            self.state.mark_ok(count)
-        elif name == "failed":
-            self.state.mark_failed(count)
-        elif name == "cached":
-            self.state.mark_cached(count)
-        elif name == "fallback":
-            self.state.mark_fallback(count)
-        elif name == "protected":
-            self.state.mark_protected(count)
-
     def _callbacks(self) -> EngineCallbacks:
         return EngineCallbacks(
             should_run=self.state.should_run,
@@ -209,6 +197,7 @@ class TranslationJob:
 
         pack_writer: PackWriter | None = None
         failed = False
+        processing_failed = False
         failed_files = 0
         total_items = len(jars) + len(loose) + len(snbt) + len(bq_files)
         done = 0
@@ -333,6 +322,7 @@ class TranslationJob:
                 )
         except Exception:
             failed = True
+            processing_failed = True
             self.on_log(
                 f"\n❌ КРИТИЧЕСКАЯ ОШИБКА:\n{traceback.format_exc()}",
                 "red",
@@ -349,7 +339,10 @@ class TranslationJob:
 
             if pack_writer:
                 try:
-                    pack_writer.close()
+                    if processing_failed or not self.state.should_run():
+                        pack_writer.abort()
+                    else:
+                        pack_writer.close()
                 except Exception:
                     failed = True
                     self.on_log(

--- a/tests/test_release_hardening.py
+++ b/tests/test_release_hardening.py
@@ -1,0 +1,136 @@
+import json
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import requests
+
+from mineai.cache import TranslationCache
+from mineai.engines.http_retry import RequestCancelled, request_with_retry
+from mineai.json_utils import load_lenient_json
+from mineai.output.pack_writer import PackWriter
+from mineai.runtime.job import TranslationJob, TranslationOptions
+from mineai.runtime.state import JobState
+
+
+class LenientJsonSafetyTests(unittest.TestCase):
+    def test_preserves_comment_like_content_inside_strings(self):
+        raw = (
+            '{"url":"https://example.com/docs",'
+            '"text":"Use /* advanced */ mode",'
+            '"literal":"comma, } stays"}'
+        )
+
+        data = load_lenient_json(raw)
+
+        self.assertEqual(data["url"], "https://example.com/docs")
+        self.assertEqual(data["text"], "Use /* advanced */ mode")
+        self.assertEqual(data["literal"], "comma, } stays")
+
+    def test_still_accepts_real_comments_and_trailing_commas(self):
+        raw = """
+        {
+            // line comment
+            "a": 1,
+            /* block comment */
+            "b": [1, 2,],
+        }
+        """
+
+        self.assertEqual(load_lenient_json(raw), {"a": 1, "b": [1, 2]})
+
+
+class RetryCancellationTests(unittest.TestCase):
+    def test_backoff_stops_when_job_is_cancelled(self):
+        states = iter((True, True, False))
+        request = mock.Mock(side_effect=requests.Timeout("slow"))
+
+        with mock.patch("mineai.engines.http_retry.time.sleep", return_value=None):
+            with self.assertRaises(RequestCancelled):
+                request_with_retry(
+                    request,
+                    operation="test",
+                    attempts=4,
+                    base_delay=10,
+                    should_continue=lambda: next(states),
+                )
+
+        request.assert_called_once_with()
+
+
+class PackCancellationTests(unittest.TestCase):
+    def test_abort_removes_only_archives_created_by_writer(self):
+        with tempfile.TemporaryDirectory() as directory:
+            writer = PackWriter(directory, "MineAI_Pack", "1.20.1", "Russian")
+            rp_path = writer.rp_zip_path
+            dp_path = writer.dp_zip_path
+            self.assertTrue(os.path.exists(rp_path))
+            self.assertTrue(os.path.exists(dp_path))
+
+            writer.abort()
+
+            self.assertFalse(os.path.exists(rp_path))
+            self.assertFalse(os.path.exists(dp_path))
+
+
+class _Config:
+    def get(self, _section, _key):
+        return ""
+
+    def getboolean(self, _section, _key):
+        return False
+
+
+class TranslationJobCancellationTests(unittest.TestCase):
+    def test_cancelled_resourcepack_job_aborts_partial_archives(self):
+        state = JobState(is_running=True)
+        cache = mock.Mock(spec=TranslationCache)
+        writer = mock.Mock(spec=PackWriter)
+        job = TranslationJob(
+            _Config(),
+            cache,
+            cache,
+            state,
+            on_log=lambda *_args: None,
+            on_status=lambda *_args: None,
+            on_row=lambda *_args: None,
+        )
+        options = TranslationOptions(
+            mc_dir="/modpack",
+            language_label="Русский",
+            mc_version="1.20.1",
+            output_mode="resourcepack",
+            pack_name="MineAI_Pack",
+            engine="google",
+            google_mode="single",
+            ai_mode="safe",
+            ai_batch=20,
+            ai_provider="local",
+            process_mode="append",
+            translate_mods=True,
+            translate_books=False,
+            translate_quests=False,
+        )
+
+        def stop_during_file(*_args, **_kwargs):
+            state.stop()
+
+        with (
+            mock.patch("mineai.runtime.job.discover_jar_files", return_value=[]),
+            mock.patch("mineai.runtime.job.discover_loose_lang_files", return_value=["en_us.json"]),
+            mock.patch("mineai.runtime.job.discover_snbt_files", return_value=[]),
+            mock.patch("mineai.runtime.job.discover_bq_files", return_value=[]),
+            mock.patch("mineai.runtime.job.StringEstimator.estimate", return_value=1),
+            mock.patch("mineai.runtime.job.PackWriter", return_value=writer),
+            mock.patch("mineai.runtime.job.TranslationService"),
+            mock.patch("mineai.runtime.job.LooseJsonProcessor.process", side_effect=stop_during_file),
+        ):
+            job.run_translation(options)
+
+        writer.abort.assert_called_once_with()
+        writer.close.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_hardening.py
+++ b/tests/test_release_hardening.py
@@ -7,7 +7,13 @@ from unittest import mock
 import requests
 
 from mineai.cache import TranslationCache
+from mineai.engines.base import EngineCallbacks, EngineItem
+from mineai.engines.deepl import DeepLEngine
+from mineai.engines.google import GoogleEngine
 from mineai.engines.http_retry import RequestCancelled, request_with_retry
+from mineai.engines.kobold import KoboldEngine
+from mineai.engines.llm_common import BatchLlmEngine
+from mineai.engines.openrouter import OpenRouterEngine
 from mineai.json_utils import load_lenient_json
 from mineai.output.pack_writer import PackWriter
 from mineai.runtime.job import TranslationJob, TranslationOptions
@@ -28,6 +34,16 @@ class LenientJsonSafetyTests(unittest.TestCase):
         self.assertEqual(data["text"], "Use /* advanced */ mode")
         self.assertEqual(data["literal"], "comma, } stays")
 
+    def test_preserves_escaped_quotes_and_backslashes(self):
+        expected = {
+            "quote": 'He said "// not a comment"',
+            "path": r"C:\\mods\\/* literal */",
+        }
+        raw = json.dumps(expected, ensure_ascii=False)
+        raw = raw[:-1] + ",}"
+
+        self.assertEqual(load_lenient_json(raw), expected)
+
     def test_still_accepts_real_comments_and_trailing_commas(self):
         raw = """
         {
@@ -42,6 +58,21 @@ class LenientJsonSafetyTests(unittest.TestCase):
 
 
 class RetryCancellationTests(unittest.TestCase):
+    def test_request_cancelled_is_not_a_network_exception(self):
+        self.assertFalse(issubclass(RequestCancelled, requests.RequestException))
+
+    def test_cancelled_before_first_attempt_does_not_call_request(self):
+        request = mock.Mock()
+
+        with self.assertRaises(RequestCancelled):
+            request_with_retry(
+                request,
+                operation="test",
+                should_continue=lambda: False,
+            )
+
+        request.assert_not_called()
+
     def test_backoff_stops_when_job_is_cancelled(self):
         states = iter((True, True, False))
         request = mock.Mock(side_effect=requests.Timeout("slow"))
@@ -59,6 +90,141 @@ class RetryCancellationTests(unittest.TestCase):
         request.assert_called_once_with()
 
 
+class EngineCancellationTests(unittest.TestCase):
+    @staticmethod
+    def callbacks(on_log=lambda *_args: None) -> EngineCallbacks:
+        return EngineCallbacks(
+            should_run=lambda: True,
+            wait_if_paused=lambda: None,
+            on_log=on_log,
+            on_status=lambda *_args: None,
+        )
+
+    def test_google_request_does_not_swallow_cancellation_as_network_failure(self):
+        engine = GoogleEngine(workers=1)
+
+        with mock.patch(
+            "mineai.engines.google.request_with_retry",
+            side_effect=RequestCancelled("stop"),
+        ):
+            with self.assertRaises(RequestCancelled):
+                engine._request("Hello", "ru")
+
+    def test_google_single_mode_handles_worker_cancellation_cleanly(self):
+        engine = GoogleEngine(workers=1, mode="single")
+        item = EngineItem(key="k", original="Hello", masked="Hello")
+
+        with mock.patch.object(
+            engine,
+            "_request",
+            side_effect=RequestCancelled("stop"),
+        ):
+            result = engine.translate_batch(
+                {"k": item},
+                {"api": "ru"},
+                self.callbacks(),
+            )
+
+        self.assertEqual(result, {})
+
+    def test_google_batch_mode_handles_worker_cancellation_cleanly(self):
+        engine = GoogleEngine(workers=1, mode="batch")
+        item = EngineItem(key="k", original="Hello", masked="Hello")
+
+        with mock.patch.object(
+            engine,
+            "_request",
+            side_effect=RequestCancelled("stop"),
+        ):
+            result = engine.translate_batch(
+                {"k": item},
+                {"api": "ru"},
+                self.callbacks(),
+            )
+
+        self.assertEqual(result, {})
+
+    def test_openrouter_cancellation_bubbles_to_engine_boundary_without_error_log(self):
+        engine = OpenRouterEngine("key", "model")
+        logs: list[tuple[str, str]] = []
+
+        with mock.patch(
+            "mineai.engines.openrouter.request_with_retry",
+            side_effect=RequestCancelled("stop"),
+        ):
+            with self.assertRaises(RequestCancelled):
+                engine._request("prompt", 100, on_log=lambda *args: logs.append(args))
+
+        self.assertEqual(logs, [])
+
+    def test_openrouter_translate_batch_handles_cancellation_and_resets_callbacks(self):
+        engine = OpenRouterEngine("key", "model")
+
+        with mock.patch.object(
+            BatchLlmEngine,
+            "translate_batch",
+            side_effect=RequestCancelled("stop"),
+        ):
+            result = engine.translate_batch(
+                {},
+                {"name": "Russian"},
+                self.callbacks(),
+            )
+
+        self.assertEqual(result, {})
+        self.assertIsNone(engine._should_continue)
+        self.assertIsNone(engine._on_log)
+
+    def test_kobold_cancellation_bubbles_to_engine_boundary_without_error_log(self):
+        engine = KoboldEngine()
+        logs: list[tuple[str, str]] = []
+
+        with mock.patch(
+            "mineai.engines.kobold.request_with_retry",
+            side_effect=RequestCancelled("stop"),
+        ):
+            with self.assertRaises(RequestCancelled):
+                engine._request("prompt", 100, on_log=lambda *args: logs.append(args))
+
+        self.assertEqual(logs, [])
+
+    def test_kobold_translate_batch_handles_cancellation_and_resets_callbacks(self):
+        engine = KoboldEngine()
+
+        with mock.patch.object(
+            BatchLlmEngine,
+            "translate_batch",
+            side_effect=RequestCancelled("stop"),
+        ):
+            result = engine.translate_batch(
+                {},
+                {"name": "Russian"},
+                self.callbacks(),
+            )
+
+        self.assertEqual(result, {})
+        self.assertIsNone(engine._should_continue)
+        self.assertIsNone(engine._on_log)
+
+    def test_deepl_cancellation_is_not_reported_as_network_error(self):
+        engine = DeepLEngine("key")
+        item = EngineItem(key="k", original="Hello", masked="Hello")
+        logs: list[tuple[str, str]] = []
+
+        with mock.patch(
+            "mineai.engines.deepl.request_with_retry",
+            side_effect=RequestCancelled("stop"),
+        ):
+            result = engine.translate_batch(
+                {"k": item},
+                {"deepl": "RU"},
+                self.callbacks(on_log=lambda *args: logs.append(args)),
+            )
+
+        self.assertEqual(result, {})
+        self.assertEqual(logs, [])
+
+
 class PackCancellationTests(unittest.TestCase):
     def test_abort_removes_only_archives_created_by_writer(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -68,6 +234,7 @@ class PackCancellationTests(unittest.TestCase):
             self.assertTrue(os.path.exists(rp_path))
             self.assertTrue(os.path.exists(dp_path))
 
+            writer.abort()
             writer.abort()
 
             self.assertFalse(os.path.exists(rp_path))


### PR DESCRIPTION
## Цель

Финальный узкий release-hardening PR для `beta` перед подготовкой перехода в `main`.

Новых функций PR не добавляет. Контракт `force / append / skip`, прогресс/ETA, процессоры и регулярные выражения «Титанового щита» не изменяются.

## Что исправлено

### 1. Безопасный lenient JSON

Исправлен `load_lenient_json()`.

Раньше комментарии удалялись регулярными выражениями до разбора JSON, поэтому корректный текст внутри JSON-строки мог быть повреждён.

Например:

```json
{"url": "https://example.com/docs"}
```

или:

```json
{"text": "Use /* advanced */ mode"}
```

Теперь `//`, `/* ... */` и trailing comma обрабатываются только вне JSON string literals.

Поддержка настоящих комментариев и trailing comma сохранена.

### 2. Частичные Resource Pack / Datapack после Stop

Добавлен безопасный `PackWriter.abort()`.

Если пользователь останавливает перевод или возникает критический обрыв обработки, ZIP-файлы, созданные текущей незавершённой задачей, закрываются и удаляются.

Раньше после Stop мог остаться корректный по CRC, но неполный Resource Pack, который внешне выглядел как готовый результат.

Обычный успешный путь `PackWriter.close()` не изменён.

Ошибки отдельных файлов по-прежнему изолируются и позволяют завершить pack со статусом «Завершено с ошибками».

### 3. Отмена HTTP retry/backoff

`request_with_retry()` теперь проверяет состояние задачи:

* перед каждой новой попыткой;
* во время ожидания между retry.

В частности, OpenRouter больше не обязан досиживать 15/30/45 секунд backoff после нажатия Stop.

Cancellation подключён к:

* Google Translate;
* DeepL;
* OpenRouter;
* KoboldCPP.

Таймаут уже начатого HTTP-запроса намеренно не уменьшался, чтобы не сломать медленные локальные и бесплатные облачные модели.

### 4. Диагностика OpenRouter / KoboldCPP

Retry и сетевые ошибки OpenRouter/KoboldCPP снова передаются через GUI callback.

Это исключает ситуацию, когда сообщение попадает только в стандартный Python logger и остаётся невидимым в `--noconsole` сборке.

### 5. Cleanup

Удалено повторное определение `TranslationJob._on_metric()`.

Никакой рабочей логики при этом не изменено.

## Регрессионные тесты

Добавлены проверки:

* URL внутри JSON-строки сохраняется;
* `/* ... */` внутри пользовательского текста сохраняется;
* реальные JSON-комментарии продолжают поддерживаться;
* trailing comma продолжают поддерживаться;
* HTTP backoff прерывается после Stop;
* `PackWriter.abort()` удаляет созданные текущей задачей ZIP;
* отменённая resourcepack-задача вызывает `abort()`, а не `close()`.

## Проверка

На финальной ветке выполнен GitHub Actions:

```text
Compile sources — SUCCESS
Run unit tests — SUCCESS
```

Полный существующий test suite вместе с новыми regression tests проходит успешно.

## Scope

PR намеренно ограничен release-hardening:

* без новых пользовательских функций;
* без изменений regex «Титанового щита»;
* без изменений `force / append / skip`;
* без изменений estimator/processors;
* без изменений формата кэша;
* без изменений прогресса и ETA.

Цель — закрыть последние обнаруженные риски перед финальным smoke-test `beta` и последующей подготовкой релиза в `main`.