### PR TITLE
fix(release): закрыть блокеры перед beta → main

### DIFF
--- a/mineai/__main__.py
+++ b/mineai/__main__.py
@@ -1,4 +1,4 @@
-from mineai.gui.app import run
+from mineai.gui import run
 
 if __name__ == "__main__":
     run()

--- a/mineai/engines/service.py
+++ b/mineai/engines/service.py
@@ -8,6 +8,10 @@ from mineai.engines.deepl import DeepLEngine
 from mineai.engines.google import GoogleEngine
 from mineai.engines.kobold import KoboldEngine
 from mineai.engines.openrouter import OpenRouterEngine
+from mineai.language_validation import (
+    requires_target_script_marker,
+    uses_same_latin_script,
+)
 from mineai.text_processing import (
     PLACEHOLDER_PATTERN,
     apply_smart_glue,
@@ -89,8 +93,13 @@ def _validate_candidate(
         if _can_cache_identity(item.original):
             return True, None, True
         return False, "ответ совпадает с оригиналом", False
-    if not re.search(target_lang["regex"], candidate):
+    if (
+        requires_target_script_marker(target_lang)
+        and not re.search(target_lang["regex"], candidate)
+    ):
         return False, "нет символов целевого языка", False
+    if uses_same_latin_script(target_lang) and _CJK_PATTERN.search(candidate):
+        return False, "CJK-символы в латинском переводе", False
     if target_lang["api"] == "ru" and _CJK_PATTERN.search(candidate):
         return False, "CJK-символы в русском переводе", False
     return True, None, False

--- a/mineai/gui/__init__.py
+++ b/mineai/gui/__init__.py
@@ -1,3 +1,4 @@
-from mineai.gui.app import TranslatorApp, run
+from mineai.gui.app import TranslatorApp
+from mineai.gui.lifecycle import run
 
 __all__ = ["TranslatorApp", "run"]

--- a/mineai/gui/lifecycle.py
+++ b/mineai/gui/lifecycle.py
@@ -1,0 +1,57 @@
+"""Application lifecycle helpers kept separate from the GUI layout."""
+
+import ctypes
+import sys
+
+
+def install_graceful_close(app) -> None:
+    """Route window close through TranslationJob.stop() and wait for cleanup.
+
+    The translation worker is intentionally left responsible for cache saving and
+    PackWriter.close()/abort(). The Tk window stays alive until ``app._job`` is
+    cleared by the worker's existing ``finally`` block, so closing the window
+    cannot bypass partial-archive cleanup.
+    """
+    closing = False
+
+    def finish_close_when_idle() -> None:
+        if getattr(app, "_job", None) is not None:
+            app.after(50, finish_close_when_idle)
+            return
+        app.destroy()
+
+    def on_close() -> None:
+        nonlocal closing
+        if closing:
+            return
+        closing = True
+
+        active_job = getattr(app, "_job", None)
+        if active_job is not None:
+            active_job.stop()
+        else:
+            app.job_state.stop()
+
+        try:
+            app.set_status("🛑 Завершение работы...", 1.0)
+        except Exception:
+            pass
+        finish_close_when_idle()
+
+    app.protocol("WM_DELETE_WINDOW", on_close)
+
+
+def run() -> None:
+    if sys.platform == "win32":
+        try:
+            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
+                "MineAI.Translator"
+            )
+        except Exception:
+            pass
+
+    from mineai.gui.app import TranslatorApp
+
+    app = TranslatorApp()
+    install_graceful_close(app)
+    app.mainloop()

--- a/mineai/gui/migration.py
+++ b/mineai/gui/migration.py
@@ -77,6 +77,13 @@ class MigrationWindow(ctk.CTkToplevel):
 
         self.btn_run.configure(state="disabled", text="Выполнение...")
         cache_type = self.var_cache.get()
+        finished = threading.Event()
+
+        def poll_finished() -> None:
+            if finished.is_set():
+                self.destroy()
+                return
+            self.after(50, poll_finished)
 
         def task():
             try:
@@ -93,6 +100,7 @@ class MigrationWindow(ctk.CTkToplevel):
                     else:
                         self.cache_std.load_imported_caches()
             finally:
-                self.after(0, self.destroy)
+                finished.set()
 
-        threading.Thread(target=task, daemon=True).start()
+        self.after(50, poll_finished)
+        threading.Thread(target=task, daemon=False).start()

--- a/mineai/language_validation.py
+++ b/mineai/language_validation.py
@@ -1,0 +1,27 @@
+"""Helpers for validating target-language text without misclassifying Latin scripts."""
+
+
+_SAME_LATIN_SCRIPT_APIS = frozenset({
+    "en",
+    "es",
+    "de",
+    "fr",
+    "pt",
+    "it",
+    "pl",
+})
+
+
+def requires_target_script_marker(target_lang: dict) -> bool:
+    """Return True when the target language uses a script distinct from English.
+
+    For same-script Latin targets a regex made only of diacritics is not a reliable
+    language detector: valid translations such as ``Espada de hierro`` may contain
+    no target-specific accented characters at all. Unknown languages stay strict by
+    default so extending the language table cannot silently weaken validation.
+    """
+    return target_lang.get("api") not in _SAME_LATIN_SCRIPT_APIS
+
+
+def uses_same_latin_script(target_lang: dict) -> bool:
+    return not requires_target_script_marker(target_lang)

--- a/mineai/processors/bq_json.py
+++ b/mineai/processors/bq_json.py
@@ -5,10 +5,9 @@ import shutil
 from mineai.engines.base import EngineCallbacks
 from mineai.engines.service import TranslationService
 from mineai.io_utils import atomic_write_text
-from mineai.processors.selection import (
-    collect_bq_selection,
-    skip_threshold_reached,
-)
+from mineai.language_validation import uses_same_latin_script
+from mineai.processors.selection import skip_threshold_reached
+from mineai.processors.translation_state import collect_bq_selection_with_baseline
 from mineai.runtime.state import JobState
 
 
@@ -34,10 +33,20 @@ class BQProcessor:
         with open(source_path, "r", encoding="utf-8") as source_file:
             data = json.load(source_file)
 
-        selection = collect_bq_selection(
+        original_data = None
+        if mode != "force" and os.path.exists(backup):
+            try:
+                with open(backup, "r", encoding="utf-8") as backup_file:
+                    original_data = json.load(backup_file)
+            except (OSError, json.JSONDecodeError):
+                original_data = None
+
+        selection = collect_bq_selection_with_baseline(
             data,
             mode,
             target_lang["regex"],
+            original_data=original_data,
+            same_latin_script=uses_same_latin_script(target_lang),
         )
         if not selection.pending:
             return

--- a/mineai/processors/snbt.py
+++ b/mineai/processors/snbt.py
@@ -5,11 +5,10 @@ import shutil
 from mineai.engines.base import EngineCallbacks
 from mineai.engines.service import TranslationService
 from mineai.io_utils import atomic_write_text
-from mineai.processors.selection import (
-    collect_snbt_selection,
-    skip_threshold_reached,
-)
+from mineai.language_validation import uses_same_latin_script
+from mineai.processors.selection import skip_threshold_reached
 from mineai.processors.snbt_extract import apply_snbt_translations
+from mineai.processors.translation_state import collect_snbt_selection_with_baseline
 from mineai.runtime.state import JobState
 
 
@@ -94,11 +93,12 @@ class SnbtProcessor:
         with open(current_path, encoding="utf-8") as current_file:
             current_content = current_file.read()
 
-        selection = collect_snbt_selection(
+        selection = collect_snbt_selection_with_baseline(
             original_content,
             current_content,
             mode,
             target_lang["regex"],
+            same_latin_script=uses_same_latin_script(target_lang),
         )
         if not selection.pending:
             return

--- a/mineai/processors/translation_state.py
+++ b/mineai/processors/translation_state.py
@@ -1,0 +1,77 @@
+"""Shared completion detection for in-place quest formats.
+
+Russian/CJK targets can still use their distinct-script regex safely. Latin
+languages share the source script with English, so their accented-character
+regex cannot prove whether a value is translated. For those targets we compare
+against MineAI's existing ``.bak`` source baseline instead.
+"""
+
+from mineai.processors.selection import (
+    BQSelection,
+    SnbtSelection,
+    collect_bq_selection,
+    collect_snbt_selection,
+)
+from mineai.processors.snbt_extract import extract_snbt_strings
+
+
+def collect_bq_selection_with_baseline(
+    data: dict,
+    mode: str,
+    target_regex: str,
+    *,
+    original_data: dict | None,
+    same_latin_script: bool,
+) -> BQSelection:
+    if mode == "force" or not same_latin_script or original_data is None:
+        return collect_bq_selection(data, mode, target_regex)
+
+    current = collect_bq_selection(data, "force", target_regex)
+    original = collect_bq_selection(original_data, "force", target_regex)
+    original_fields = original.pending
+
+    pending = {
+        key: text
+        for key, text in current.pending.items()
+        if key not in original_fields or text == original_fields[key]
+    }
+    return BQSelection(
+        properties_key=current.properties_key,
+        betterquesting_key=current.betterquesting_key,
+        total_translatable=current.total_translatable,
+        pending=pending,
+    )
+
+
+def collect_snbt_selection_with_baseline(
+    original_content: str,
+    current_content: str,
+    mode: str,
+    target_regex: str,
+    *,
+    same_latin_script: bool,
+) -> SnbtSelection:
+    if mode == "force" or not same_latin_script:
+        return collect_snbt_selection(
+            original_content,
+            current_content,
+            mode,
+            target_regex,
+        )
+
+    original_strings = extract_snbt_strings(original_content)
+    current_strings = extract_snbt_strings(current_content)
+
+    # The backup and current file keep the same field order during MineAI's own
+    # in-place edits. An unchanged value is still source text; a changed value is
+    # a previous translation. Values appended after the backup was created are
+    # new source entries and must also be translated.
+    pending = [
+        text
+        for index, text in enumerate(current_strings)
+        if index >= len(original_strings) or text == original_strings[index]
+    ]
+    return SnbtSelection(
+        total_translatable=len(current_strings),
+        pending=list(dict.fromkeys(pending)),
+    )

--- a/tests/test_gui_active_job.py
+++ b/tests/test_gui_active_job.py
@@ -229,7 +229,6 @@ class TranslatorAppJobLifecycleTests(unittest.TestCase):
             [mock.call(state="disabled"), mock.call(state="normal")],
         )
 
-
     def test_open_log_file_uses_cross_platform_opener(self) -> None:
         app = self._bare_app()
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -250,7 +249,7 @@ class TranslatorAppJobLifecycleTests(unittest.TestCase):
         self.assertEqual(popen.call_args.args[0][0], "xdg-open")
         app.log.assert_not_called()
 
-    def test_migration_window_schedules_destroy_on_ui_thread(self) -> None:
+    def test_migration_window_polls_completion_on_ui_thread(self) -> None:
         migration_module = sys.modules[gui_app.MigrationWindow.__module__]
         window = object.__new__(gui_app.MigrationWindow)
         window.ent_zip = SimpleNamespace(get=lambda: "/tmp/translations.zip")
@@ -278,10 +277,21 @@ class TranslatorAppJobLifecycleTests(unittest.TestCase):
             window._run()
 
         self.assertTrue(created_threads[0].started)
+        self.assertFalse(created_threads[0].daemon)
         window.destroy.assert_not_called()
+        self.assertEqual(window.after.call_count, 1)
+        delay, poll_finished = window.after.call_args.args
+        self.assertEqual(delay, 50)
+
         created_threads[0].target()
+
+        # The worker only flips a threading.Event; it must not touch Tk.
+        self.assertEqual(window.after.call_count, 1)
         window.destroy.assert_not_called()
-        window.after.assert_called_once_with(0, window.destroy)
+
+        poll_finished()
+        window.destroy.assert_called_once_with()
+        self.assertEqual(window.after.call_count, 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_release_blockers.py
+++ b/tests/test_release_blockers.py
@@ -1,0 +1,209 @@
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+_original_cwd = os.getcwd()
+with tempfile.TemporaryDirectory() as _import_cwd:
+    os.chdir(_import_cwd)
+    try:
+        from mineai.engines.base import EngineItem
+        from mineai.engines.service import _validate_candidate
+        from mineai.gui.lifecycle import install_graceful_close
+        from mineai.processors.translation_state import (
+            collect_bq_selection_with_baseline,
+            collect_snbt_selection_with_baseline,
+        )
+    finally:
+        os.chdir(_original_cwd)
+
+
+class SameScriptValidationTests(unittest.TestCase):
+    def test_valid_latin_translations_without_diacritics_are_accepted(self) -> None:
+        item = EngineItem(
+            key="item",
+            original="Iron Sword",
+            masked="Iron Sword",
+        )
+        cases = [
+            ({"api": "es", "regex": r"[áéíóúüñÁÉÍÓÚÜÑ]"}, "Espada de hierro"),
+            ({"api": "de", "regex": r"[äöüßÄÖÜẞ]"}, "Eisenschwert"),
+            ({"api": "fr", "regex": r"[àâæçéèêëîïôœùûüÿÀÂÆÇÉÈÊËÎÏÔŒÙÛÜŸ]"}, "Epee en fer"),
+            ({"api": "pt", "regex": r"[ãõáéíóúâêôÃÕÁÉÍÓÚÂÊÔ]"}, "Espada de ferro"),
+            ({"api": "it", "regex": r"[àèéìíîòóùúÀÈÉÌÍÎÒÓÙÚ]"}, "Spada di ferro"),
+            ({"api": "pl", "regex": r"[ąćęłńóśźżĄĆĘŁŃÓŚŹŻ]"}, "Miecz z zelaza"),
+        ]
+
+        for target_lang, translated in cases:
+            with self.subTest(api=target_lang["api"]):
+                accepted, reason, identity = _validate_candidate(
+                    item,
+                    translated,
+                    target_lang,
+                )
+                self.assertTrue(accepted, reason)
+                self.assertIsNone(reason)
+                self.assertFalse(identity)
+
+    def test_same_script_translation_still_rejects_unchanged_source(self) -> None:
+        item = EngineItem(
+            key="item",
+            original="Iron Sword",
+            masked="Iron Sword",
+        )
+        accepted, reason, identity = _validate_candidate(
+            item,
+            "Iron Sword",
+            {"api": "es", "regex": r"[áéíóúüñÁÉÍÓÚÜÑ]"},
+        )
+        self.assertFalse(accepted)
+        self.assertEqual(reason, "ответ совпадает с оригиналом")
+        self.assertFalse(identity)
+
+    def test_same_script_translation_rejects_cjk_leakage(self) -> None:
+        item = EngineItem(
+            key="item",
+            original="Iron Sword",
+            masked="Iron Sword",
+        )
+        accepted, reason, identity = _validate_candidate(
+            item,
+            "Espada de hierro 村民",
+            {"api": "es", "regex": r"[áéíóúüñÁÉÍÓÚÜÑ]"},
+        )
+        self.assertFalse(accepted)
+        self.assertEqual(reason, "CJK-символы в латинском переводе")
+        self.assertFalse(identity)
+
+    def test_distinct_script_validation_remains_strict(self) -> None:
+        item = EngineItem(
+            key="item",
+            original="Iron Sword",
+            masked="Iron Sword",
+        )
+        accepted, reason, _identity = _validate_candidate(
+            item,
+            "Iron Blade",
+            {"api": "ru", "regex": r"[А-Яа-яЁё]"},
+        )
+        self.assertFalse(accepted)
+        self.assertEqual(reason, "нет символов целевого языка")
+
+
+class SameScriptQuestBaselineTests(unittest.TestCase):
+    @staticmethod
+    def _bq(name: str, desc: str) -> dict:
+        return {
+            "properties:10": {
+                "betterquesting:10": {
+                    "name:8": name,
+                    "desc:8": desc,
+                }
+            }
+        }
+
+    def test_bq_preserves_previous_latin_translation_without_accents(self) -> None:
+        original = self._bq("Iron Sword", "New description")
+        current = self._bq("Espada de hierro", "Nueva descripcion")
+        selection = collect_bq_selection_with_baseline(
+            current,
+            "append",
+            r"[áéíóúüñÁÉÍÓÚÜÑ]",
+            original_data=original,
+            same_latin_script=True,
+        )
+        self.assertEqual(selection.total_translatable, 2)
+        self.assertEqual(selection.pending, {})
+
+    def test_bq_still_picks_up_unchanged_source_field(self) -> None:
+        original = self._bq("Iron Sword", "New description")
+        current = self._bq("Espada de hierro", "New description")
+        selection = collect_bq_selection_with_baseline(
+            current,
+            "append",
+            r"[áéíóúüñÁÉÍÓÚÜÑ]",
+            original_data=original,
+            same_latin_script=True,
+        )
+        self.assertEqual(selection.pending, {"desc:8": "New description"})
+
+    def test_snbt_preserves_previous_latin_translation_without_accents(self) -> None:
+        original = '{title:"Iron Sword",description:["Old objective"]}'
+        current = '{title:"Espada de hierro",description:["Objetivo antiguo"]}'
+        selection = collect_snbt_selection_with_baseline(
+            original,
+            current,
+            "append",
+            r"[áéíóúüñÁÉÍÓÚÜÑ]",
+            same_latin_script=True,
+        )
+        self.assertEqual(selection.total_translatable, 2)
+        self.assertEqual(selection.pending, [])
+
+    def test_snbt_new_trailing_source_entry_is_still_pending(self) -> None:
+        original = '{title:"Iron Sword",description:["Old objective"]}'
+        current = (
+            '{title:"Espada de hierro",description:'
+            '["Objetivo antiguo","New objective"]}'
+        )
+        selection = collect_snbt_selection_with_baseline(
+            original,
+            current,
+            "append",
+            r"[áéíóúüñÁÉÍÓÚÜÑ]",
+            same_latin_script=True,
+        )
+        self.assertEqual(selection.total_translatable, 3)
+        self.assertEqual(selection.pending, ["New objective"])
+
+
+class GracefulCloseTests(unittest.TestCase):
+    @staticmethod
+    def _app(active_job):
+        app = SimpleNamespace()
+        app._job = active_job
+        app.protocol = mock.Mock()
+        app.after = mock.Mock()
+        app.destroy = mock.Mock()
+        app.set_status = mock.Mock()
+        app.job_state = mock.Mock()
+        return app
+
+    def test_window_close_stops_active_job_and_waits_for_cleanup(self) -> None:
+        active_job = mock.Mock()
+        app = self._app(active_job)
+        install_graceful_close(app)
+
+        app.protocol.assert_called_once()
+        protocol_name, on_close = app.protocol.call_args.args
+        self.assertEqual(protocol_name, "WM_DELETE_WINDOW")
+
+        on_close()
+        active_job.stop.assert_called_once_with()
+        app.job_state.stop.assert_not_called()
+        app.destroy.assert_not_called()
+        app.set_status.assert_called_once_with("🛑 Завершение работы...", 1.0)
+
+        app.after.assert_called_once()
+        delay, poll = app.after.call_args.args
+        self.assertEqual(delay, 50)
+
+        app._job = None
+        poll()
+        app.destroy.assert_called_once_with()
+
+    def test_idle_window_closes_immediately(self) -> None:
+        app = self._app(None)
+        install_graceful_close(app)
+        on_close = app.protocol.call_args.args[1]
+
+        on_close()
+
+        app.job_state.stop.assert_called_once_with()
+        app.destroy.assert_called_once_with()
+        app.after.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/translator.py
+++ b/translator.py
@@ -1,6 +1,6 @@
 """Entry point for MineAI Translator (python translator.py)."""
 
-from mineai.gui.app import run
+from mineai.gui import run
 
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
Что исправлено

Этот PR закрывает блокеры, найденные при финальной release-certification после #35.

Scope намеренно ограничен стабильностью перед beta → main: новых функций, редизайна GUI и архитектурных изменений здесь нет.

1. Исправлена валидация переводов для языков на латинице

Ранее TranslationService требовал наличия символов из target_lang["regex"].

Для Spanish / German / French / Portuguese / Italian / Polish это ненадёжно, потому что regex в основном содержит специфические диакритические символы.

Из-за этого полностью корректные переводы могли отклоняться, например:

* Iron Sword → Espada de hierro
* Iron Sword → Eisenschwert
* Iron Sword → Epee en fer
* Iron Sword → Spada di ferro

Теперь:

* same-script Latin targets не требуют обязательной диакритики;
* результат всё ещё должен отличаться от source;
* unchanged source по-прежнему отклоняется, кроме существующих разрешённых technical identity cases;
* проверки placeholders и protected fragments не ослаблены;
* CJK leakage для латинских target-языков отдельно отклоняется;
* Russian / Chinese / Japanese / Korean сохраняют строгую проверку своей письменности.

2. BetterQuesting и SNBT не переводят повторно уже готовые Latin translations

Для in-place форматов невозможно надёжно определить Spanish/German/etc. только по наличию специальных символов.

Поэтому для same-script языков используется уже существующий .bak как source baseline:

* значение, отличающееся от исходного backup, считается ранее переведённым;
* значение, совпадающее с source baseline, остаётся pending;
* новые SNBT source entries также остаются pending;
* force сохраняет прежнее поведение;
* для языков с отдельной письменностью прежняя regex-логика не меняется.

Новых файлов состояния или форматов cache не добавляется.

3. Закрытие GUI через X теперь проходит через штатный Stop/Cleanup

Раньше translation workers были daemon threads, а стандартное закрытие главного окна не проходило через TranslationJob.stop().

Это создавало путь, при котором закрытие приложения могло завершить процесс до штатного cleanup и обойти удаление незавершённого Resource Pack / Datapack.

Теперь стандартные entrypoints устанавливают WM_DELETE_WINDOW handler:

* активному TranslationJob вызывается stop();
* GUI остаётся живым до завершения worker;
* существующий TranslationJob.finally успевает сохранить cache;
* PackWriter.close() / PackWriter.abort() выполняются штатно;
* окно уничтожается только после завершения cleanup.

Обычная кнопка Stop и логика #35 не менялись.

4. MigrationWindow больше не вызывает Tk API из worker thread

Фоновый migration worker теперь только выставляет threading.Event.

UI thread самостоятельно polling’ом проверяет завершение и вызывает destroy().

Migration worker сделан non-daemon, чтобы закрытие GUI не могло молча оборвать файловую операцию посередине.

Regression tests

Добавлены проверки:

* valid Spanish translation without accents;
* valid German translation without umlauts;
* valid French translation without accents;
* valid Portuguese translation without accents;
* valid Italian translation without accents;
* valid Polish translation without Polish-specific characters;
* unchanged English source всё ещё отклоняется;
* CJK leakage в Latin targets отклоняется;
* Russian distinct-script validation остаётся строгой;
* BetterQuesting сохраняет предыдущий Latin translation без диакритики;
* unchanged BetterQuesting source остаётся pending;
* SNBT сохраняет предыдущий Latin translation без диакритики;
* новый SNBT source entry остаётся pending;
* закрытие окна останавливает active job и ждёт cleanup;
* idle close работает сразу;
* MigrationWindow не вызывает Tk API из worker thread.

Проверки

На кодовом дереве PR выполнена отдельная release-certification:

* Linux compileall — PASS
* Linux full unit suite — 113/113 PASS
* Windows Server 2025 / Python 3.10 compileall — PASS
* Windows full unit suite — 113/113 PASS
* PyInstaller 6.21 — PASS
* MineAI_Translator.exe — 11,757,521 bytes
* Windows EXE startup smoke — PASS

Перед финальным squash временный certification workflow был удалён; application/test code не менялся.

Финальная ветка:

* base: current beta after #35
* base SHA: 97f6db62d4ae6223cf1e69e1a71fb9243aa2b276
* head SHA: c0d63ba3af31893f5f1676fd3fe2771b0f68dad9
* commits: 1
* behind beta: 0

Что намеренно НЕ входит в PR

* новая функциональность;
* Smart Glossary;
* редизайн GUI;
* изменение cache format;
* изменения JSON hardening из #35;
* изменения HTTP retry/cancellation из #35;
* изменение версии приложения;
* подготовка main;
* косметические рефакторинги.

После merge этого PR следует получить новый exact SHA beta, дождаться CI именно на нём и выполнить финальный release smoke. Если новых P0/P1 не обнаружится, дальнейшие stabilization PR создавать не нужно — можно переходить к подготовке beta → main.