### PR TITLE
design(gui): обновить интерфейс перед финальной сертификацией 10.0.0

### DIFF
--- a/mineai/config.py
+++ b/mineai/config.py
@@ -1,7 +1,5 @@
 import configparser
 import io
-import os
-
 from mineai.constants import SETTINGS_FILE
 from mineai.io_utils import atomic_write_text
 
@@ -11,7 +9,7 @@ class ConfigManager:
 
     _DEFAULTS = {
         "GENERAL": {
-            "mc_dir": os.getcwd(),
+            "mc_dir": "",
             "theme": "Dark",
             "color": "blue",
             "smart_glue": "True",
@@ -65,6 +63,14 @@ class ConfigManager:
 
     def set(self, section: str, key: str, value) -> None:
         self._config.set(section, key, str(value))
+        self.save()
+
+    def set_many(self, section: str, values: dict[str, object]) -> None:
+        """Persist related values with one atomic settings write."""
+        if not self._config.has_section(section):
+            self._config.add_section(section)
+        for key, value in values.items():
+            self._config.set(section, key, str(value))
         self.save()
 
     def getboolean(self, section: str, key: str) -> bool:

--- a/mineai/gui/app.py
+++ b/mineai/gui/app.py
@@ -18,6 +18,7 @@ from mineai.config import settings
 from mineai.constants import LANGUAGES, MC_VERSIONS
 from mineai.gui.migration import MigrationWindow
 from mineai.gui.settings import SettingsWindow
+from mineai.gui.style import UI, ToolTip
 from mineai.runtime.job import TranslationJob, TranslationOptions
 from mineai.runtime.state import JobState
 
@@ -68,190 +69,245 @@ class TranslatorApp(ctk.CTk):
             )
 
     def _build_ui(self) -> None:
-        left = ctk.CTkScrollableFrame(self, width=370)
-        left.pack(side="left", fill="y", padx=10, pady=10)
+        self.geometry("1320x860")
+        self.minsize(1080, 720)
+        self.configure(fg_color=UI.APP_BG)
+        self.grid_rowconfigure(0, weight=1)
+        self.grid_columnconfigure(0, weight=0)
+        self.grid_columnconfigure(1, weight=1)
 
+        def card(parent, title: str, subtitle: str | None = None):
+            frame = ctk.CTkFrame(
+                parent,
+                corner_radius=14,
+                fg_color=UI.CARD_BG,
+                border_width=1,
+                border_color=UI.BORDER,
+            )
+            ctk.CTkLabel(
+                frame, text=title.upper(), anchor="w",
+                font=("Segoe UI", 12, "bold"), text_color=UI.TEXT,
+            ).pack(fill="x", padx=14, pady=(12, 0))
+            if subtitle:
+                ctk.CTkLabel(
+                    frame, text=subtitle, anchor="w", justify="left", wraplength=335,
+                    font=("Segoe UI", 10), text_color=UI.MUTED,
+                ).pack(fill="x", padx=14, pady=(2, 4))
+            body = ctk.CTkFrame(frame, fg_color="transparent")
+            body.pack(fill="x", padx=14, pady=(8, 14))
+            return frame, body
+
+        def section_label(parent, text: str):
+            ctk.CTkLabel(
+                parent, text=text, anchor="w", font=("Segoe UI", 10, "bold"),
+                text_color=UI.MUTED,
+            ).pack(fill="x", pady=(8, 3))
+
+        sidebar = ctk.CTkScrollableFrame(
+            self, width=390, corner_radius=0, fg_color=UI.SIDEBAR_BG,
+            scrollbar_button_color=UI.NEUTRAL,
+        )
+        sidebar.grid(row=0, column=0, sticky="nsew")
+
+        brand = ctk.CTkFrame(sidebar, fg_color="transparent")
+        brand.pack(fill="x", padx=14, pady=(16, 12))
+        ctk.CTkLabel(
+            brand, text="MineAI Translator", anchor="w",
+            font=("Segoe UI", 22, "bold"), text_color=UI.TEXT,
+        ).pack(fill="x")
+        ctk.CTkLabel(
+            brand, text=__version__, anchor="w",
+            font=("Segoe UI", 11), text_color=UI.MUTED,
+        ).pack(fill="x", pady=(1, 8))
         self.btn_settings = ctk.CTkButton(
-            left,
-            text="⚙ НАСТРОЙКИ",
-            fg_color="#555",
+            brand, text="⚙  Настройки", height=32,
+            fg_color=UI.NEUTRAL, hover_color=UI.NEUTRAL_HOVER,
             command=self._open_settings,
         )
-        self.btn_settings.pack(fill="x", padx=10, pady=(0, 15))
+        self.btn_settings.pack(fill="x")
 
-        ctk.CTkLabel(left, text="ПАПКА MINECRAFT", font=("", 14, "bold")).pack(pady=(5, 5))
-        self.lbl_folder = ctk.CTkLabel(left, text="Не выбрана", text_color="gray")
-        self.lbl_folder.pack()
-        ctk.CTkButton(left, text="📁 Выбрать папку", fg_color="#444", command=self._select_folder).pack(
-            pady=5, fill="x", padx=20
+        project, body = card(sidebar, "Проект", "Источник, целевой язык и версия Minecraft")
+        project.pack(fill="x", padx=12, pady=6)
+        section_label(body, "ПАПКА MINECRAFT")
+        folder_row = ctk.CTkFrame(body, fg_color="transparent")
+        folder_row.pack(fill="x")
+        self.lbl_folder = ctk.CTkLabel(
+            folder_row, text="Не выбрана", anchor="w",
+            font=("Segoe UI", 11), text_color=UI.MUTED,
         )
+        self.lbl_folder.pack(side="left", fill="x", expand=True)
+        folder_button = ctk.CTkButton(
+            folder_row, text="Выбрать", width=82, height=28,
+            fg_color=UI.NEUTRAL, hover_color=UI.NEUTRAL_HOVER,
+            command=self._select_folder,
+        )
+        folder_button.pack(side="right", padx=(8, 0))
+        ToolTip(folder_button, "Minecraft instance", "Выберите корневую папку сборки/instance, где находятся mods и config.")
 
-        ctk.CTkLabel(left, text="ЦЕЛЕВОЙ ЯЗЫК", font=("", 14, "bold")).pack(pady=(15, 5))
+        selectors = ctk.CTkFrame(body, fg_color="transparent")
+        selectors.pack(fill="x", pady=(8, 0))
+
+        for col in (0, 1):
+            selectors.grid_columnconfigure(col, weight=1)
         self.var_lang = ctk.StringVar(value="Русский")
-        ctk.CTkOptionMenu(left, variable=self.var_lang, values=list(LANGUAGES.keys())).pack(fill="x", padx=20)
-
-        ctk.CTkLabel(left, text="ВЕРСИЯ ИГРЫ", font=("", 14, "bold")).pack(pady=(15, 5))
         self.var_mc_ver = ctk.StringVar(value="1.20.1")
-        ctk.CTkOptionMenu(left, variable=self.var_mc_ver, values=MC_VERSIONS).pack(fill="x", padx=20)
+        ctk.CTkLabel(selectors, text="Язык", anchor="w", font=("Segoe UI", 10), text_color=UI.MUTED).grid(row=0, column=0, sticky="ew", padx=(0, 4))
+        ctk.CTkLabel(selectors, text="Minecraft", anchor="w", font=("Segoe UI", 10), text_color=UI.MUTED).grid(row=0, column=1, sticky="ew", padx=(4, 0))
+        ctk.CTkOptionMenu(selectors, variable=self.var_lang, values=list(LANGUAGES.keys())).grid(row=1, column=0, sticky="ew", padx=(0, 4), pady=(2, 0))
+        ctk.CTkOptionMenu(selectors, variable=self.var_mc_ver, values=MC_VERSIONS).grid(row=1, column=1, sticky="ew", padx=(4, 0), pady=(2, 0))
 
-        ctk.CTkLabel(left, text="МЕТОД СОХРАНЕНИЯ", font=("", 14, "bold")).pack(pady=(15, 5))
+        output, body = card(sidebar, "Результат", "Resource Pack безопаснее; inplace меняет JAR")
+        output.pack(fill="x", padx=12, pady=6)
         self.var_output = ctk.StringVar(value="resourcepack")
         ctk.CTkRadioButton(
-            left,
-            text="📦 Resource Pack + Datapack (рекомендуется)",
-            variable=self.var_output,
-            value="resourcepack",
-            command=self._update_output_ui,
-        ).pack(anchor="w", padx=20, pady=5)
-        self.entry_rp_name = ctk.CTkEntry(left, placeholder_text="Имя zip-файлов...")
+            body, text="📦 Resource Pack + Datapack", variable=self.var_output,
+            value="resourcepack", command=self._update_output_ui,
+        ).pack(anchor="w", pady=3)
+        self.entry_rp_name = ctk.CTkEntry(body, placeholder_text="Имя пакета")
         self.entry_rp_name.insert(0, "MineAI_Pack")
-        self.entry_rp_name.pack(fill="x", padx=40, pady=(0, 5))
-        ctk.CTkRadioButton(
-            left,
-            text="⚠️ Перезаписать .jar (ломает подписи)",
-            variable=self.var_output,
-            value="inplace",
-            command=self._update_output_ui,
-        ).pack(anchor="w", padx=20, pady=5)
+        self.entry_rp_name.pack(fill="x", padx=(22, 0), pady=(2, 6))
+        inplace = ctk.CTkRadioButton(
+            body, text="⚠  Перезаписать .jar", variable=self.var_output,
+            value="inplace", command=self._update_output_ui,
+        )
+        inplace.pack(anchor="w", pady=3)
+        ToolTip(inplace, "In-place режим", "Изменяет JAR-файлы. Перед стартом MineAI дополнительно попросит подтверждение.")
 
-        ctk.CTkLabel(left, text="ЧТО ПЕРЕВОДИМ?", font=("", 14, "bold")).pack(pady=(15, 5))
+        scope, body = card(sidebar, "Что переводим")
+        scope.pack(fill="x", padx=12, pady=6)
         self.var_mods = ctk.BooleanVar(value=True)
         self.var_books = ctk.BooleanVar(value=True)
         self.var_quests = ctk.BooleanVar(value=True)
-        ctk.CTkCheckBox(left, text="Интерфейс (моды)", variable=self.var_mods).pack(anchor="w", padx=20, pady=2)
-        ctk.CTkCheckBox(left, text="Справочники и исследования", variable=self.var_books).pack(anchor="w", padx=20, pady=2)
-        ctk.CTkCheckBox(left, text="Квесты (FTB + KubeJS)", variable=self.var_quests).pack(anchor="w", padx=20, pady=2)
+        ctk.CTkCheckBox(body, text="Интерфейс модов", variable=self.var_mods).pack(anchor="w", pady=3)
+        ctk.CTkCheckBox(body, text="Книги и исследования", variable=self.var_books).pack(anchor="w", pady=3)
+        ctk.CTkCheckBox(body, text="Квесты (FTB + KubeJS)", variable=self.var_quests).pack(anchor="w", pady=3)
 
-        ctk.CTkLabel(left, text="ДВИЖОК ПЕРЕВОДА", font=("", 14, "bold")).pack(pady=(15, 5))
+        engine, body = card(sidebar, "Движок", "Переводчик и режим обработки")
+        engine.pack(fill="x", padx=12, pady=6)
         self.var_engine = ctk.StringVar(value="google")
-        self.frame_google = ctk.CTkFrame(left, fg_color="transparent")
         self.var_google_mode = ctk.StringVar(value="single")
-        ctk.CTkRadioButton(left, text="Google Translate", variable=self.var_engine, value="google", command=self._update_engine_ui).pack(
-            anchor="w", padx=20, pady=5
-        )
-        ctk.CTkRadioButton(self.frame_google, text="Построчно (точно)", variable=self.var_google_mode, value="single").pack(anchor="w", pady=2)
-        ctk.CTkRadioButton(self.frame_google, text="Пачками (быстро)", variable=self.var_google_mode, value="batch").pack(anchor="w", pady=2)
-        ctk.CTkRadioButton(left, text="DeepL API", variable=self.var_engine, value="deepl", command=self._update_engine_ui).pack(
-            anchor="w", padx=20, pady=5
-        )
-        self.frame_ai = ctk.CTkFrame(left, fg_color="transparent")
         self.var_ai_mode = ctk.StringVar(value="safe")
-        ctk.CTkRadioButton(left, text="Нейросеть (ИИ)", variable=self.var_engine, value="ai", command=self._update_engine_ui).pack(
-            anchor="w", padx=20, pady=5
-        )
         self.var_ai_provider = ctk.StringVar(value=settings.get("AI", "ai_provider") or "local")
-        ctk.CTkLabel(self.frame_ai, text="Провайдер:", font=("", 11, "bold")).pack(anchor="w", pady=(0, 2))
-        ctk.CTkRadioButton(
-            self.frame_ai, text="Локально (KoboldCPP)", variable=self.var_ai_provider, value="local"
-        ).pack(anchor="w", pady=1)
-        ctk.CTkRadioButton(
-            self.frame_ai, text="OpenRouter (облако)", variable=self.var_ai_provider, value="openrouter"
-        ).pack(anchor="w", pady=1)
-        
-        # --- НОВЫЙ БЛОК НАСТРОЕК ИИ С ПОЛЗУНКОМ ---
-        ctk.CTkLabel(self.frame_ai, text="Режим ИИ:", font=("", 11, "bold")).pack(anchor="w", pady=(6, 0))
+        ctk.CTkRadioButton(body, text="Google Translate", variable=self.var_engine, value="google", command=self._update_engine_ui).pack(anchor="w", pady=3)
+        self.frame_google = ctk.CTkFrame(body, fg_color="transparent")
+        ctk.CTkRadioButton(self.frame_google, text="Построчно", variable=self.var_google_mode, value="single").pack(anchor="w", pady=2)
+        ctk.CTkRadioButton(self.frame_google, text="Пачками", variable=self.var_google_mode, value="batch").pack(anchor="w", pady=2)
+        ctk.CTkRadioButton(body, text="DeepL API", variable=self.var_engine, value="deepl", command=self._update_engine_ui).pack(anchor="w", pady=3)
+        ctk.CTkRadioButton(body, text="Нейросеть (ИИ)", variable=self.var_engine, value="ai", command=self._update_engine_ui).pack(anchor="w", pady=3)
+        self.frame_ai = ctk.CTkFrame(body, fg_color="transparent")
+        ctk.CTkLabel(self.frame_ai, text="Провайдер", anchor="w", font=("Segoe UI", 10, "bold"), text_color=UI.MUTED).pack(fill="x", pady=(2, 2))
+        ctk.CTkRadioButton(self.frame_ai, text="Локальный KoboldCPP", variable=self.var_ai_provider, value="local", command=self._update_engine_ui).pack(anchor="w", pady=2)
+        ctk.CTkRadioButton(self.frame_ai, text="OpenRouter", variable=self.var_ai_provider, value="openrouter", command=self._update_engine_ui).pack(anchor="w", pady=2)
+        ctk.CTkLabel(self.frame_ai, text="Режим", anchor="w", font=("Segoe UI", 10, "bold"), text_color=UI.MUTED).pack(fill="x", pady=(7, 2))
         ctk.CTkRadioButton(self.frame_ai, text="Стандартный", variable=self.var_ai_mode, value="safe").pack(anchor="w", pady=2)
         ctk.CTkRadioButton(self.frame_ai, text="Контекст + лор", variable=self.var_ai_mode, value="context").pack(anchor="w", pady=2)
-        
-        # Динамический текст для ползунка
-        self.lbl_batch = ctk.CTkLabel(self.frame_ai, text="Размер пачки: 20 строк", font=("", 11, "bold"))
-        self.lbl_batch.pack(anchor="w", pady=(6, 0))
-        
-        # Сам ползунок (от 1 до 40 с шагом 1)
+        self.lbl_batch = ctk.CTkLabel(self.frame_ai, text="Размер пачки: 20 строк", anchor="w", font=("Segoe UI", 10, "bold"), text_color=UI.MUTED)
+        self.lbl_batch.pack(fill="x", pady=(7, 0))
         self.slider_ai_batch = ctk.CTkSlider(
             self.frame_ai, from_=1, to=40, number_of_steps=39,
-            command=lambda val: self.lbl_batch.configure(text=f"Размер пачки: {int(val)} строк")
+            command=lambda val: self.lbl_batch.configure(text=f"Размер пачки: {int(val)} строк"),
         )
         self.slider_ai_batch.set(20)
-        self.slider_ai_batch.pack(fill="x", pady=2)
-
-        # --- НОВАЯ ГАЛОЧКА ДЛЯ ПОДСТРАХОВКИ GOOGLE ---
+        self.slider_ai_batch.pack(fill="x", pady=3)
         try:
             fallback_val = settings.getboolean("AI", "fallback_google")
         except Exception:
             fallback_val = False
-            
         self.var_ai_fallback = ctk.BooleanVar(value=fallback_val)
         ctk.CTkCheckBox(
-            self.frame_ai, 
-            text="Переводить непереведенное через Google", 
-            variable=self.var_ai_fallback
-        ).pack(anchor="w", pady=(10, 0))
+            self.frame_ai, text="Fallback через Google", variable=self.var_ai_fallback,
+        ).pack(anchor="w", pady=(7, 2))
 
-        ctk.CTkLabel(left, text="РЕЖИМ ОБРАБОТКИ", font=("", 14, "bold")).pack(pady=(15, 5))
+        readiness = ctk.CTkFrame(body, corner_radius=9, fg_color=UI.INFO_BG)
+        readiness.pack(fill="x", pady=(9, 0))
+        self.lbl_engine_ready = ctk.CTkLabel(
+            readiness, text="Проверка...", anchor="w",
+            font=("Segoe UI", 10, "bold"), text_color=UI.INFO_TEXT,
+        )
+        self.lbl_engine_ready.pack(side="left", fill="x", expand=True, padx=9, pady=7)
+        self.btn_engine_settings = ctk.CTkButton(
+            readiness, text="Настроить", width=82, height=26,
+            fg_color=UI.NEUTRAL, hover_color=UI.NEUTRAL_HOVER, command=self._open_settings,
+        )
+        self.btn_engine_settings.pack(side="right", padx=6, pady=5)
+
+        mode, body = card(sidebar, "Режим обработки")
+        mode.pack(fill="x", padx=12, pady=6)
         self.var_mode = ctk.StringVar(value="append")
-        ctk.CTkRadioButton(left, text="Доперевод (сохранить старое)", variable=self.var_mode, value="append").pack(anchor="w", padx=20, pady=2)
-        ctk.CTkRadioButton(left, text="Пропуск (от 90%)", variable=self.var_mode, value="skip").pack(anchor="w", padx=20, pady=2)
-        ctk.CTkRadioButton(left, text="С нуля (перезапись)", variable=self.var_mode, value="force").pack(anchor="w", padx=20, pady=2)
+        ctk.CTkRadioButton(body, text="Доперевод · сохранить готовое", variable=self.var_mode, value="append").pack(anchor="w", pady=3)
+        ctk.CTkRadioButton(body, text="Пропуск · готовность ≥90%", variable=self.var_mode, value="skip").pack(anchor="w", pady=3)
+        ctk.CTkRadioButton(body, text="С нуля · перезапись", variable=self.var_mode, value="force").pack(anchor="w", pady=3)
 
-        self.btn_migrate = ctk.CTkButton(
-            left,
-            text="📦 Миграция ресурс-пака",
-            fg_color="#17a2b8",
-            hover_color="#138496",
-            command=self._open_migration,
-        )
-        self.btn_migrate.pack(pady=(20, 0), fill="x", padx=20)
+        actions = ctk.CTkFrame(sidebar, corner_radius=14, fg_color=UI.CARD_BG, border_width=1, border_color=UI.BORDER)
+        actions.pack(fill="x", padx=12, pady=(6, 16))
+        self.btn_migrate = ctk.CTkButton(actions, text="📦 Миграция ресурс-пака", fg_color=UI.CYAN, hover_color=UI.CYAN_HOVER, command=self._open_migration)
+        self.btn_migrate.pack(fill="x", padx=12, pady=(12, 5))
+        self.btn_analyze = ctk.CTkButton(actions, text="Анализ сборки", fg_color=UI.PRIMARY, hover_color=UI.PRIMARY_HOVER, command=self._start_analysis)
+        self.btn_analyze.pack(fill="x", padx=12, pady=5)
+        self.btn_start = ctk.CTkButton(actions, text="▶  НАЧАТЬ ПЕРЕВОД", height=42, font=("Segoe UI", 13, "bold"), fg_color=UI.SUCCESS, hover_color=UI.SUCCESS_HOVER, command=self._start_translation)
+        self.btn_start.pack(fill="x", padx=12, pady=5)
+        run_controls = ctk.CTkFrame(actions, fg_color="transparent")
+        run_controls.pack(fill="x", padx=12, pady=(5, 12))
 
-        self.btn_analyze = ctk.CTkButton(
-            left,
-            text="Анализ сборки",
-            fg_color="#0066cc",
-            hover_color="#004c99",
-            command=self._start_analysis,
-        )
-        self.btn_analyze.pack(pady=(10, 10), fill="x", padx=20)
-        self.btn_start = ctk.CTkButton(
-            left,
-            text="▶ НАЧАТЬ ПЕРЕВОД",
-            fg_color="#28a745",
-            hover_color="#218838",
-            height=40,
-            font=("", 14, "bold"),
-            command=self._start_translation,
-        )
-        self.btn_start.pack(pady=5, fill="x", padx=20)
-        self.btn_pause = ctk.CTkButton(
-            left,
-            text="⏸ ПАУЗА",
-            fg_color="#ffc107",
-            text_color="black",
-            hover_color="#e0a800",
-            height=40,
-            command=self._toggle_pause,
-            state="disabled",
-        )
-        self.btn_pause.pack(pady=5, fill="x", padx=20)
-        self.btn_stop = ctk.CTkButton(
-            left,
-            text="⏹ ОСТАНОВИТЬ",
-            fg_color="#dc3545",
-            hover_color="#c82333",
-            height=40,
-            command=self._stop,
-            state="disabled",
-        )
-        self.btn_stop.pack(pady=(5, 10), fill="x", padx=20)
-        
-        # --- НОВАЯ КНОПКА ЛОГОВ ---
-        self.btn_log = ctk.CTkButton(
-            left,
-            text="📜 ОТКРЫТЬ ЛОГ",
-            fg_color="#555",
-            hover_color="#444",
-            height=30,
-            command=self._open_log_file,
-        )
-        self.btn_log.pack(pady=(0, 10), fill="x", padx=20)
-        
-        right = ctk.CTkFrame(self)
-        right.pack(side="right", fill="both", expand=True, padx=(0, 10), pady=10)
-        self.textbox = ctk.CTkTextbox(right, font=("Consolas", 13)) # Убрали state="disabled"
-        self.textbox.pack(fill="both", expand=True, padx=10, pady=10)
+        for col in (0, 1):
+            run_controls.grid_columnconfigure(col, weight=1)
+        self.btn_pause = ctk.CTkButton(run_controls, text="⏸ ПАУЗА", height=36, fg_color=UI.WARNING, hover_color=UI.WARNING_HOVER, text_color="black", command=self._toggle_pause, state="disabled")
+        self.btn_pause.grid(row=0, column=0, sticky="ew", padx=(0, 4))
+        self.btn_stop = ctk.CTkButton(run_controls, text="⏹ СТОП", height=36, fg_color=UI.DANGER, hover_color=UI.DANGER_HOVER, command=self._stop, state="disabled")
+        self.btn_stop.grid(row=0, column=1, sticky="ew", padx=(4, 0))
 
-        # Функция для защиты от печати, но с разрешением на копирование
+        content = ctk.CTkFrame(self, fg_color="transparent")
+        content.grid(row=0, column=1, sticky="nsew", padx=16, pady=16)
+        content.grid_rowconfigure(1, weight=1)
+        content.grid_columnconfigure(0, weight=1)
+
+        status_card = ctk.CTkFrame(content, corner_radius=16, fg_color=UI.CARD_BG, border_width=1, border_color=UI.BORDER)
+        status_card.grid(row=0, column=0, sticky="ew", pady=(0, 12))
+        status_card.grid_columnconfigure(0, weight=1)
+        status_header = ctk.CTkFrame(status_card, fg_color="transparent")
+        status_header.grid(row=0, column=0, sticky="ew", padx=16, pady=(14, 6))
+        status_header.grid_columnconfigure(0, weight=1)
+        ctk.CTkLabel(status_header, text="СТАТУС", anchor="w", font=("Segoe UI", 12, "bold"), text_color=UI.TEXT).grid(row=0, column=0, sticky="w")
+        self.lbl_status = ctk.CTkLabel(status_header, text="Ожидание...", anchor="e", font=("Segoe UI", 12), text_color=UI.MUTED)
+        self.lbl_status.grid(row=0, column=1, sticky="e")
+
+        metrics = ctk.CTkFrame(status_card, fg_color="transparent")
+        metrics.grid(row=1, column=0, sticky="ew", padx=12, pady=4)
+        for col in range(4):
+            metrics.grid_columnconfigure(col, weight=1)
+
+        def metric(col: int, title: str):
+            frame = ctk.CTkFrame(metrics, corner_radius=11, fg_color=UI.CARD_ALT_BG, border_width=1, border_color=UI.BORDER)
+            frame.grid(row=0, column=col, sticky="ew", padx=4)
+            ctk.CTkLabel(frame, text=title.upper(), anchor="w", font=("Segoe UI", 9, "bold"), text_color=UI.MUTED).pack(fill="x", padx=10, pady=(8, 1))
+            value = ctk.CTkLabel(frame, text="—", anchor="w", font=("Segoe UI", 17, "bold"), text_color=UI.TEXT)
+            value.pack(fill="x", padx=10, pady=(0, 8))
+            return value
+
+        self.lbl_kpi_processed = metric(0, "Обработано")
+        self.lbl_kpi_ok = metric(1, "Успешно")
+        self.lbl_kpi_errors = metric(2, "Ошибки")
+        self.lbl_kpi_eta = metric(3, "Осталось")
+        self.progress = ctk.CTkProgressBar(status_card, height=10, progress_color=UI.PRIMARY)
+        self.progress.grid(row=2, column=0, sticky="ew", padx=16, pady=(10, 16))
+        self.progress.set(0)
+
+        log_card = ctk.CTkFrame(content, corner_radius=16, fg_color=UI.CARD_BG, border_width=1, border_color=UI.BORDER)
+        log_card.grid(row=1, column=0, sticky="nsew")
+        log_card.grid_rowconfigure(1, weight=1)
+        log_card.grid_columnconfigure(0, weight=1)
+        log_header = ctk.CTkFrame(log_card, fg_color="transparent")
+        log_header.grid(row=0, column=0, sticky="ew", padx=14, pady=(12, 6))
+        log_header.grid_columnconfigure(0, weight=1)
+        ctk.CTkLabel(log_header, text="ЖУРНАЛ", anchor="w", font=("Segoe UI", 12, "bold"), text_color=UI.TEXT).grid(row=0, column=0, sticky="w")
+        self.btn_log = ctk.CTkButton(log_header, text="Открыть файл", width=105, height=28, fg_color=UI.NEUTRAL, hover_color=UI.NEUTRAL_HOVER, command=self._open_log_file)
+        self.btn_log.grid(row=0, column=1, padx=(8, 0))
+        ctk.CTkButton(log_header, text="Очистить", width=82, height=28, fg_color="transparent", border_width=1, border_color=UI.BORDER, command=self._clear_log).grid(row=0, column=2, padx=(8, 0))
+
+        self.textbox = ctk.CTkTextbox(log_card, font=("Consolas", 12), fg_color=UI.LOG_BG, corner_radius=10, wrap="none")
+        self.textbox.grid(row=1, column=0, sticky="nsew", padx=12, pady=(0, 12))
+
         def _is_ctrl_pressed() -> bool:
-            """Надёжная проверка Ctrl на Windows — не зависит от раскладки."""
             if sys.platform == "win32":
                 try:
                     return bool(ctypes.windll.user32.GetAsyncKeyState(0x11) & 0x8000)
@@ -259,19 +315,15 @@ class TranslatorApp(ctk.CTk):
                     return False
             return False
 
-        # Функция для защиты от печати, но с разрешением на копирование
         def prevent_typing(event):
-            # Разрешаем системные сочетания с Ctrl (например, Ctrl+C, Ctrl+A)
             if event.state & 4 or _is_ctrl_pressed():
                 return None
-            # Разрешаем стрелочки для навигации
             if event.keysym in ["Up", "Down", "Left", "Right", "Prior", "Next", "Home", "End"]:
                 return None
-            return "break" # Блокируем всё остальное
+            return "break"
 
         self.textbox.bind("<Key>", prevent_typing)
 
-        # Фикс Ctrl+C/A для кириллицы на внутреннем виджете
         def _fix_ctrl_copy(event):
             ctrl = bool(event.state & 4)
             if sys.platform == "win32":
@@ -281,41 +333,146 @@ class TranslatorApp(ctk.CTk):
                     pass
             if not ctrl:
                 return None
-            KEY_ACTIONS = {67: "<<Copy>>", 65: "<<SelectAll>>"}
-            if event.keycode in KEY_ACTIONS:
-                event.widget.event_generate(KEY_ACTIONS[event.keycode])
+            actions = {67: "<<Copy>>", 65: "<<SelectAll>>"}
+            if event.keycode in actions:
+                event.widget.event_generate(actions[event.keycode])
                 return "break"
             return None
 
-        _inner = getattr(self.textbox, "_textbox", self.textbox)
-        _inner.bind("<Key>", _fix_ctrl_copy, add="+")
+        inner = getattr(self.textbox, "_textbox", self.textbox)
+        inner.bind("<Key>", _fix_ctrl_copy, add="+")
         for tag, color in [
-            ("green", "#2ecc71"),
-            ("lime", "#7bed9f"),
-            ("yellow", "#f1c40f"),
-            ("gold", "#ffd700"),
-            ("orange", "#ff9f43"),
-            ("red", "#ff4d4d"),
-            ("pink", "#ff6b81"),
-            ("cyan", "#00e5ff"),
-            ("blue", "#54a0ff"),
-            ("magenta", "#b000ff"),
-            ("dim", "#7f8c8d"),
-            ("gray", "#b2bec3"),
+            ("green", "#2ecc71"), ("lime", "#7bed9f"), ("yellow", "#f1c40f"),
+            ("gold", "#ffd700"), ("orange", "#ff9f43"), ("red", "#ff4d4d"),
+            ("pink", "#ff6b81"), ("cyan", "#00e5ff"), ("blue", "#54a0ff"),
+            ("magenta", "#c084fc"), ("dim", "#7f8c8d"), ("gray", "#b2bec3"),
             ("white", "#ffffff"),
         ]:
             self.textbox.tag_config(tag, foreground=color)
         self.textbox.bind("<Button-1>", lambda _e: self._on_scroll_interaction())
         self.textbox.bind("<MouseWheel>", lambda _e: self._on_scroll_interaction())
 
-        self.progress = ctk.CTkProgressBar(right)
-        self.progress.pack(fill="x", padx=10, pady=(0, 5))
-        self.progress.set(0)
-        self.lbl_status = ctk.CTkLabel(right, text="Ожидание...", font=("", 14))
-        self.lbl_status.pack(pady=(0, 10))
-
         self._update_engine_ui()
         self._update_output_ui()
+        self._refresh_kpis()
+
+    def _refresh_kpis(self) -> None:
+        required = (
+            "lbl_kpi_processed",
+            "lbl_kpi_ok",
+            "lbl_kpi_errors",
+            "lbl_kpi_eta",
+        )
+        if not all(hasattr(self, name) for name in required):
+            return
+        snapshot = self.job_state.snapshot()
+        if snapshot.total_strings > 0:
+            processed = min(snapshot.translated_strings, snapshot.total_strings)
+            processed_text = f"{processed:,} / {snapshot.total_strings:,}".replace(",", " ")
+        else:
+            processed_text = "—"
+        self.lbl_kpi_processed.configure(text=processed_text)
+        self.lbl_kpi_ok.configure(text=f"{snapshot.ok_strings:,}".replace(",", " "))
+        self.lbl_kpi_errors.configure(text=f"{snapshot.failed_strings:,}".replace(",", " "))
+        self.lbl_kpi_eta.configure(text=self.job_state.eta_text())
+
+    def _validate_minecraft_dir(self, *, require_mods: bool = False) -> bool:
+        raw = settings.get("GENERAL", "mc_dir").strip()
+        if not raw:
+            messagebox.showwarning(
+                "Папка Minecraft не выбрана",
+                "Сначала выберите папку Minecraft instance/сборки.",
+            )
+            return False
+        root = Path(raw)
+        if not root.is_dir():
+            messagebox.showwarning(
+                "Папка недоступна",
+                f"Каталог не существует:\n{root}",
+            )
+            return False
+        if require_mods and not (root / "mods").is_dir():
+            messagebox.showwarning(
+                "Папка mods не найдена",
+                "Для миграции выбранный instance должен содержать папку mods.",
+            )
+            return False
+        return True
+
+    def _validate_scope(self) -> bool:
+        if self.var_mods.get() or self.var_books.get() or self.var_quests.get():
+            return True
+        messagebox.showwarning(
+            "Нечего обрабатывать",
+            "Выберите хотя бы одну область: моды, книги или квесты.",
+        )
+        return False
+
+    def _engine_readiness(self) -> tuple[bool, str]:
+        engine = self.var_engine.get()
+        if engine == "google":
+            return True, "Google готов"
+        if engine == "deepl":
+            if settings.get("API", "deepl_key").strip():
+                return True, "DeepL настроен"
+            return False, "Не указан API-ключ DeepL"
+        if engine == "ai":
+            if self.var_ai_provider.get() == "openrouter":
+                if not settings.get("OPENROUTER", "api_key").strip():
+                    return False, "Не указан ключ OpenRouter"
+                model = settings.get("OPENROUTER", "model").strip()
+                if not model:
+                    return False, "Не выбрана модель OpenRouter"
+                return True, f"OpenRouter · {model}"
+            model_path = settings.get("AI", "model_path").strip()
+            if not model_path:
+                return False, "Не выбрана локальная GGUF-модель"
+            if not Path(model_path).is_file():
+                return False, "Файл GGUF-модели недоступен"
+            return True, f"KoboldCPP · {Path(model_path).name}"
+        return False, "Неизвестный движок"
+
+    def _refresh_engine_readiness(self) -> None:
+        if not hasattr(self, "lbl_engine_ready"):
+            return
+        ready, text = self._engine_readiness()
+        self.lbl_engine_ready.configure(
+            text=("✓ " if ready else "⚠ ") + text,
+            text_color=("#79d89a" if ready else "#f6c85f"),
+        )
+        if hasattr(self, "btn_engine_settings"):
+            self.btn_engine_settings.configure(state="disabled" if ready else "normal")
+
+    def _validate_engine_ready(self) -> bool:
+        ready, text = self._engine_readiness()
+        if ready:
+            return True
+        messagebox.showwarning(
+            "Движок не настроен",
+            text + "\n\nПроверьте настройки перед запуском.",
+        )
+        return False
+
+    def _confirm_inplace(self) -> bool:
+        if self.var_output.get() != "inplace":
+            return True
+        return messagebox.askyesno(
+            "Подтвердить изменение JAR",
+            "Режим inplace изменяет файлы модов напрямую.\n\n"
+            "Безопасный Resource Pack рекомендуется для финального релиза.\n\n"
+            "Продолжить?",
+            icon="warning",
+        )
+
+    def _reset_run_ui(self) -> None:
+        self._clear_log()
+        self.progress.set(0.0)
+        self.lbl_status.configure(text="Подготовка...")
+        self._refresh_kpis()
+
+    def _after_settings_saved(self) -> None:
+        self._refresh_folder_label()
+        self._refresh_engine_readiness()
 
     def _job_instance(self) -> TranslationJob:
         return TranslationJob(
@@ -347,11 +504,16 @@ class TranslatorApp(ctk.CTk):
         )
 
     def _open_settings(self) -> None:
-        SettingsWindow(self, settings, self._refresh_folder_label)
+        SettingsWindow(self, settings, self._after_settings_saved)
 
     def _refresh_folder_label(self) -> None:
         path = settings.get("GENERAL", "mc_dir")
-        self.lbl_folder.configure(text=f"...{path[-25:]}" if len(path) > 25 else path)
+
+        if not path:
+            self.lbl_folder.configure(text="Не выбрана", text_color=UI.MUTED)
+            return
+        display = f"...{path[-32:]}" if len(path) > 32 else path
+        self.lbl_folder.configure(text=display, text_color=UI.TEXT)
 
     def _select_folder(self) -> None:
         path = filedialog.askdirectory()
@@ -367,9 +529,10 @@ class TranslatorApp(ctk.CTk):
         self.frame_ai.pack_forget()
         self.frame_google.pack_forget()
         if self.var_engine.get() == "ai":
-            self.frame_ai.pack(fill="x", padx=40, pady=5)
+            self.frame_ai.pack(fill="x", padx=(22, 0), pady=(2, 4))
         elif self.var_engine.get() == "google":
-            self.frame_google.pack(fill="x", padx=40, pady=0)
+            self.frame_google.pack(fill="x", padx=(22, 0), pady=(2, 4))
+        self._refresh_engine_readiness()
 
     def _on_scroll_interaction(self) -> None:
         self.auto_scroll = self.textbox.yview()[1] >= 0.99
@@ -401,13 +564,13 @@ class TranslatorApp(ctk.CTk):
     def log(self, message: str, tag: str = "white") -> None:
         if not self._ensure_ui_thread(self.log, message, tag):
             return
-        
+
         at_bottom = self.textbox.yview()[1] >= 0.99
         self.textbox.insert("end", message + "\n", tag)
         if self.auto_scroll or at_bottom:
             self.textbox.see("end")
-        
-        
+
+
         # Запись в общий текстовый лог
         try:
             with open("mineai_log.txt", "a", encoding="utf-8") as f:
@@ -426,7 +589,7 @@ class TranslatorApp(ctk.CTk):
             pct,
         ):
             return
-        
+
         at_bottom = self.textbox.yview()[1] >= 0.99
         self.textbox.insert("end", f"{icon} {name[:34]:<35}", "cyan")
         self.textbox.insert("end", f"[{kind}]".ljust(15), "magenta")
@@ -435,7 +598,7 @@ class TranslatorApp(ctk.CTk):
         self.textbox.insert("end", f"{pct}%\n", color)
         if self.auto_scroll or at_bottom:
             self.textbox.see("end")
-        
+
 
     def set_status(self, text: str, progress: float | None) -> None:
         if not self._ensure_ui_thread(self.set_status, text, progress):
@@ -443,6 +606,7 @@ class TranslatorApp(ctk.CTk):
         if progress is not None:
             self.progress.set(progress)
         self.lbl_status.configure(text=text)
+        self._refresh_kpis()
 
     def _lock_ui(self, locked: bool) -> None:
         if not self._ensure_ui_thread(self._lock_ui, locked):
@@ -454,14 +618,21 @@ class TranslatorApp(ctk.CTk):
         self.btn_start.configure(state=state)
         self.btn_stop.configure(state=rev)
         self.btn_pause.configure(state=rev)
+        if hasattr(self, "btn_migrate"):
+            self.btn_migrate.configure(state=state)
+        if hasattr(self, "btn_engine_settings"):
+            if locked:
+                self.btn_engine_settings.configure(state="disabled")
+            else:
+                self._refresh_engine_readiness()
 
     def _toggle_pause(self) -> None:
         is_paused = self.job_state.toggle_pause()
         if is_paused:
-            self.btn_pause.configure(text="▶ ПРОДОЛЖИТЬ", fg_color="#17a2b8", text_color="white")
+            self.btn_pause.configure(text="▶ ПРОДОЛЖИТЬ", fg_color=UI.CYAN, text_color="white")
             self.log("⏸ Пауза", "yellow")
         else:
-            self.btn_pause.configure(text="⏸ ПАУЗА", fg_color="#ffc107", text_color="black")
+            self.btn_pause.configure(text="⏸ ПАУЗА", fg_color=UI.WARNING, text_color="black")
             self.log("▶ Продолжение", "green")
 
     def _stop(self) -> None:
@@ -472,17 +643,21 @@ class TranslatorApp(ctk.CTk):
             self.job_state.stop()
         self.btn_stop.configure(state="disabled")
         self.btn_pause.configure(state="disabled")
-        self.set_status("🛑 Остановка...", 1.0)
+        self.set_status("🛑 Остановка...", None)
 
     def _clear_log(self) -> None:
-        
+
         self.textbox.delete("1.0", "end")
-        
+
 
     def _start_analysis(self) -> None:
+        if not self._validate_minecraft_dir():
+            return
+        if not self._validate_scope():
+            return
         self._lock_ui(True)
         self.job_state.start()
-        self._clear_log()
+        self._reset_run_ui()
         self._job = self._job_instance()
         options = self._translation_options()
         threading.Thread(
@@ -504,24 +679,29 @@ class TranslatorApp(ctk.CTk):
             self._lock_ui(False)
 
     def _start_translation(self) -> None:
-        if not settings.get("GENERAL", "mc_dir"):
-            messagebox.showerror("Ошибка", "Выберите папку Minecraft!")
+        if not self._validate_minecraft_dir():
+            return
+        if not self._validate_scope():
+            return
+        if not self._validate_engine_ready():
+            return
+        if not self._confirm_inplace():
             return
         if self.var_engine.get() == "ai":
             settings.set("AI", "ai_provider", self.var_ai_provider.get())
-            settings.set("AI", "fallback_google", self.var_ai_fallback.get()) # <-- СОХРАНЯЕМ ВЫБОР
+            settings.set("AI", "fallback_google", self.var_ai_fallback.get())
         self._lock_ui(True)
         self.job_state.start()
-        self.btn_pause.configure(text="⏸ ПАУЗА", fg_color="#ffc107", text_color="black")
-        self._clear_log()
+        self.btn_pause.configure(text="⏸ ПАУЗА", fg_color=UI.WARNING, text_color="black")
+        self._reset_run_ui()
         self._job = self._job_instance()
         options = self._translation_options()
         threading.Thread(
             target=lambda: self._run_translation_thread(options),
             daemon=True,
         ).start()
-    
-    
+
+
     def _open_log_file(self) -> None:
         log_path = Path("mineai_log.txt").resolve()
         if not log_path.exists():
@@ -556,10 +736,9 @@ class TranslatorApp(ctk.CTk):
             self._lock_ui(False)
 
     def _open_migration(self) -> None:
-        mc_dir = settings.get("GENERAL", "mc_dir")
-        if not mc_dir:
-            messagebox.showerror("Ошибка", "Сначала выберите папку Minecraft!")
+        if not self._validate_minecraft_dir(require_mods=True):
             return
+        mc_dir = settings.get("GENERAL", "mc_dir")
         MigrationWindow(
             self,
             mc_dir,
@@ -571,12 +750,7 @@ class TranslatorApp(ctk.CTk):
 
 
 def run() -> None:
-    if sys.platform == "win32":
-        try:
-            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
-                "MineAI.Translator"
-            )
-        except Exception:
-            pass
-    app = TranslatorApp()
-    app.mainloop()
+    # Keep legacy callers safe: lifecycle owns WM_DELETE_WINDOW and cleanup.
+    from mineai.gui.lifecycle import run as lifecycle_run
+
+    lifecycle_run()

--- a/mineai/gui/lifecycle.py
+++ b/mineai/gui/lifecycle.py
@@ -33,7 +33,7 @@ def install_graceful_close(app) -> None:
             app.job_state.stop()
 
         try:
-            app.set_status("🛑 Завершение работы...", 1.0)
+            app.set_status("🛑 Завершение работы...", None)
         except Exception:
             pass
         finish_close_when_idle()

--- a/mineai/gui/migration.py
+++ b/mineai/gui/migration.py
@@ -1,10 +1,12 @@
 import os
 import threading
+import traceback
 
 import customtkinter as ctk
 from tkinter import filedialog, messagebox
 
 from mineai.constants import LANGUAGES
+from mineai.gui.style import UI
 from mineai.processors.migration import run_migration
 
 
@@ -12,8 +14,10 @@ class MigrationWindow(ctk.CTkToplevel):
     def __init__(self, parent, mc_dir: str, lang_label: str, cache_std, cache_ai, log_callback):
         super().__init__(parent)
         self.title("📦 Миграция перевода")
-        self.geometry("450x320")
-        self.resizable(False, False)
+        self.geometry("620x500")
+        self.minsize(520, 420)
+        self.resizable(True, True)
+        self.configure(fg_color=UI.APP_BG)
         self.grab_set()
 
         self.mc_dir = mc_dir
@@ -22,46 +26,110 @@ class MigrationWindow(ctk.CTkToplevel):
         self.cache_ai = cache_ai
         self.log_callback = log_callback
 
-        ctk.CTkLabel(
+        card = ctk.CTkFrame(
             self,
-            text="Выберите ресурс-пак с переводом (.zip):",
-            font=("", 12, "bold"),
-        ).pack(pady=(15, 5), padx=20, anchor="w")
-
-        self.ent_zip = ctk.CTkEntry(self, width=300)
-        self.ent_zip.pack(side="top", fill="x", padx=20, pady=5)
-
-        ctk.CTkButton(self, text="Обзор", command=self._browse).pack(
-            pady=5, padx=20, anchor="e"
+            corner_radius=14,
+            fg_color=UI.CARD_BG,
+            border_width=1,
+            border_color=UI.BORDER,
         )
+        card.pack(fill="both", expand=True, padx=16, pady=16)
 
         ctk.CTkLabel(
-            self,
-            text="Для какого движка использовать этот архив?",
-            font=("", 12, "bold"),
-        ).pack(pady=(10, 5), padx=20, anchor="w")
+            card,
+            text="Миграция готового перевода",
+            anchor="w",
+            font=("Segoe UI", 18, "bold"),
+            text_color=UI.TEXT,
+        ).pack(fill="x", padx=16, pady=(16, 2))
+        ctk.CTkLabel(
+            card,
+            text=(
+                "Импортирует строки из существующего Resource Pack в отдельный imported cache. "
+                "Исходный ZIP не изменяется."
+            ),
+            anchor="w",
+            justify="left",
+            wraplength=540,
+            font=("Segoe UI", 10),
+            text_color=UI.MUTED,
+        ).pack(fill="x", padx=16, pady=(0, 12))
+
+        ctk.CTkLabel(
+            card,
+            text="RESOURCE PACK (.ZIP)",
+            anchor="w",
+            font=("Segoe UI", 10, "bold"),
+            text_color=UI.MUTED,
+        ).pack(fill="x", padx=16)
+        zip_row = ctk.CTkFrame(card, fg_color="transparent")
+        zip_row.pack(fill="x", padx=16, pady=(4, 12))
+        self.ent_zip = ctk.CTkEntry(zip_row)
+        self.ent_zip.pack(side="left", fill="x", expand=True)
+        ctk.CTkButton(
+            zip_row,
+            text="Обзор",
+            width=82,
+            fg_color=UI.NEUTRAL,
+            hover_color=UI.NEUTRAL_HOVER,
+            command=self._browse,
+        ).pack(side="right", padx=(8, 0))
+
+        ctk.CTkLabel(
+            card,
+            text="КЭШ НАЗНАЧЕНИЯ",
+            anchor="w",
+            font=("Segoe UI", 10, "bold"),
+            text_color=UI.MUTED,
+        ).pack(fill="x", padx=16)
         self.var_cache = ctk.StringVar(value="ai")
         ctk.CTkRadioButton(
-            self,
-            text="Для Нейросетей (папка imported_caches/ai)",
+            card,
+            text="Нейросети · imported_caches/ai",
             variable=self.var_cache,
             value="ai",
-        ).pack(anchor="w", padx=20, pady=2)
+        ).pack(anchor="w", padx=16, pady=(6, 3))
         ctk.CTkRadioButton(
-            self,
-            text="Для Google/DeepL (папка imported_caches/std)",
+            card,
+            text="Google / DeepL · imported_caches/std",
             variable=self.var_cache,
             value="std",
-        ).pack(anchor="w", padx=20, pady=2)
+        ).pack(anchor="w", padx=16, pady=3)
+
+        self.result_frame = ctk.CTkFrame(
+            card,
+            corner_radius=10,
+            fg_color=UI.CARD_ALT_BG,
+            border_width=1,
+            border_color=UI.BORDER,
+        )
+        self.lbl_result_title = ctk.CTkLabel(
+            self.result_frame,
+            text="",
+            anchor="w",
+            font=("Segoe UI", 12, "bold"),
+        )
+        self.lbl_result_title.pack(fill="x", padx=12, pady=(10, 2))
+        self.lbl_result_details = ctk.CTkLabel(
+            self.result_frame,
+            text="",
+            anchor="w",
+            justify="left",
+            wraplength=520,
+            font=("Segoe UI", 10),
+            text_color=UI.MUTED,
+        )
+        self.lbl_result_details.pack(fill="x", padx=12, pady=(0, 10))
 
         self.btn_run = ctk.CTkButton(
-            self,
+            card,
             text="Начать миграцию",
-            fg_color="#28a745",
-            hover_color="#218838",
+            height=38,
+            fg_color=UI.SUCCESS,
+            hover_color=UI.SUCCESS_HOVER,
             command=self._run,
         )
-        self.btn_run.pack(pady=15, fill="x", padx=20)
+        self.btn_run.pack(side="bottom", fill="x", padx=16, pady=16)
 
     def _browse(self):
         path = filedialog.askopenfilename(filetypes=[("ZIP Archives", "*.zip")])
@@ -76,12 +144,18 @@ class MigrationWindow(ctk.CTkToplevel):
             return
 
         self.btn_run.configure(state="disabled", text="Выполнение...")
+        self.result_frame.pack_forget()
         cache_type = self.var_cache.get()
         finished = threading.Event()
+        result = {"count": 0, "error": None}
 
         def poll_finished() -> None:
             if finished.is_set():
-                self.destroy()
+                self._show_result(
+                    count=result["count"],
+                    error=result["error"],
+                    cache_type=cache_type,
+                )
                 return
             self.after(50, poll_finished)
 
@@ -94,13 +168,40 @@ class MigrationWindow(ctk.CTkToplevel):
                     self.lang_api_code,
                     self.log_callback,
                 )
+                result["count"] = count
                 if count > 0:
                     if cache_type == "ai":
                         self.cache_ai.load_imported_caches()
                     else:
                         self.cache_std.load_imported_caches()
+            except Exception:
+                result["error"] = traceback.format_exc()
             finally:
+                # Worker thread deliberately touches no Tk object.
                 finished.set()
 
         self.after(50, poll_finished)
         threading.Thread(target=task, daemon=False).start()
+
+    def _show_result(self, *, count: int, error: str | None, cache_type: str) -> None:
+        self.result_frame.pack(fill="x", padx=16, pady=(14, 0), before=self.btn_run)
+        if error:
+            self.lbl_result_title.configure(
+                text="❌ Миграция завершилась с ошибкой",
+                text_color="#ff7373",
+            )
+            self.lbl_result_details.configure(text=error)
+        else:
+            destination = "Нейросети" if cache_type == "ai" else "Google / DeepL"
+            self.lbl_result_title.configure(
+                text="✓ Миграция завершена",
+                text_color="#79d89a",
+            )
+            self.lbl_result_details.configure(
+                text=(
+                    f"Импортировано: {count} уникальных строк\n"
+                    f"Кэш назначения: {destination}\n"
+                    "Детализация пропусков/конфликтов недоступна в текущем migration API."
+                )
+            )
+        self.btn_run.configure(state="normal", text="Запустить снова")

--- a/mineai/gui/settings.py
+++ b/mineai/gui/settings.py
@@ -2,11 +2,13 @@ import ctypes
 import sys
 
 import customtkinter as ctk
-from tkinter import filedialog
+from tkinter import filedialog, messagebox
 
 from mineai.config import ConfigManager
 from mineai.constants import DEFAULT_OPENROUTER_MODEL
-from mineai.engines.llm_common import load_prompts, save_prompts, get_default_prompts
+from mineai.engines.llm_common import get_default_prompts, load_prompts, save_prompts
+from mineai.gui.style import UI
+
 
 class SettingsWindow(ctk.CTkToplevel):
     def __init__(self, parent, config: ConfigManager, on_saved) -> None:
@@ -14,37 +16,41 @@ class SettingsWindow(ctk.CTkToplevel):
         self.config = config
         self.on_saved = on_saved
         self.title("⚙ Настройки MineAI")
-        self.geometry("540x720")
-        self.resizable(False, False)
+        self.geometry("720x780")
+        self.minsize(620, 620)
+        self.resizable(True, True)
+        self.configure(fg_color=UI.APP_BG)
         self.grab_set()
 
-        tabs = ctk.CTkTabview(self)
-        tabs.pack(fill="both", expand=True, padx=10, pady=10)
-        tab_ai = tabs.add("Локальный ИИ")
-        tab_or = tabs.add("OpenRouter")
-        tab_gen = tabs.add("Общие и API")
+        tabs = ctk.CTkTabview(self, fg_color=UI.CARD_BG)
+        tabs.pack(fill="both", expand=True, padx=14, pady=(14, 8))
+        tab_ai = self._scroll_tab(tabs, "Локальный ИИ")
+        tab_or = self._scroll_tab(tabs, "OpenRouter")
+        tab_gen = self._scroll_tab(tabs, "Общие и API")
 
-        ctk.CTkLabel(tab_ai, text="Исполняемый файл KoboldCPP (.exe):", font=("", 12, "bold")).pack(
-            anchor="w", pady=(10, 0), padx=10
+        self._field_label(tab_ai, "Исполняемый файл KoboldCPP (.exe)")
+        self.ent_ai_exe = self._entry_with_browse(
+            tab_ai,
+            config.get("AI", "exe_path"),
+            [("Executables", "*.exe")],
         )
-        self.ent_ai_exe = ctk.CTkEntry(tab_ai, width=360)
-        self.ent_ai_exe.insert(0, config.get("AI", "exe_path"))
-        self.ent_ai_exe.pack(fill="x", padx=10, pady=5)
-        ctk.CTkButton(
-            tab_ai, text="Обзор", width=80, command=lambda: self._browse(self.ent_ai_exe, [("Executables", "*.exe")])
-        ).pack(anchor="e", padx=10)
 
-        ctk.CTkLabel(tab_ai, text="Модель (.gguf):", font=("", 12, "bold")).pack(anchor="w", pady=(10, 0), padx=10)
-        self.ent_ai_mod = ctk.CTkEntry(tab_ai, width=360)
-        self.ent_ai_mod.insert(0, config.get("AI", "model_path"))
-        self.ent_ai_mod.pack(fill="x", padx=10, pady=5)
-        ctk.CTkButton(
-            tab_ai, text="Обзор", width=80, command=lambda: self._browse(self.ent_ai_mod, [("GGUF Models", "*.gguf")])
-        ).pack(anchor="e", padx=10)
+        self._field_label(tab_ai, "Модель (.gguf)")
+        self.ent_ai_mod = self._entry_with_browse(
+            tab_ai,
+            config.get("AI", "model_path"),
+            [("GGUF Models", "*.gguf")],
+        )
 
         gpu_val = config.getint("AI", "gpu_layers", 99)
-        self.lbl_gpu = ctk.CTkLabel(tab_ai, text=f"Слои GPU: {gpu_val}", font=("", 12, "bold"))
-        self.lbl_gpu.pack(anchor="w", pady=(10, 0), padx=10)
+        self.lbl_gpu = ctk.CTkLabel(
+            tab_ai,
+            text=f"Слои GPU: {gpu_val}",
+            anchor="w",
+            font=("Segoe UI", 12, "bold"),
+            text_color=UI.TEXT,
+        )
+        self.lbl_gpu.pack(fill="x", padx=12, pady=(14, 2))
         self.slider_gpu = ctk.CTkSlider(
             tab_ai,
             from_=0,
@@ -53,105 +59,150 @@ class SettingsWindow(ctk.CTkToplevel):
             command=lambda v: self.lbl_gpu.configure(text=f"Слои GPU: {int(v)}"),
         )
         self.slider_gpu.set(gpu_val)
-        self.slider_gpu.pack(fill="x", padx=10, pady=5)
+        self.slider_gpu.pack(fill="x", padx=12, pady=(2, 10))
 
         ctk.CTkLabel(
             tab_or,
-            text="Ключ: openrouter.ai/keys",
-            font=("", 11),
-            text_color="gray",
-        ).pack(anchor="w", padx=10, pady=(10, 0))
-        
-        ctk.CTkLabel(tab_or, text="API URL (для Ollama, vLLM и др.):", font=("", 12, "bold")).pack(anchor="w", padx=10, pady=(10, 0))
-        self.ent_or_url = ctk.CTkEntry(tab_or)
-        self.ent_or_url.insert(0, config.get("OPENROUTER", "api_url"))
-        self.ent_or_url.pack(fill="x", padx=10, pady=5)
+            text="Ключ можно создать на openrouter.ai/keys. API URL также подходит для OpenAI-compatible шлюзов.",
+            anchor="w",
+            justify="left",
+            wraplength=570,
+            font=("Segoe UI", 10),
+            text_color=UI.MUTED,
+        ).pack(fill="x", padx=12, pady=(10, 4))
 
-        ctk.CTkLabel(tab_or, text="API ключ OpenRouter:", font=("", 12, "bold")).pack(anchor="w", padx=10, pady=(5, 0))
-        self.ent_or_key = ctk.CTkEntry(tab_or, show="*")
-        self.ent_or_key.insert(0, config.get("OPENROUTER", "api_key"))
-        self.ent_or_key.pack(fill="x", padx=10, pady=5)
-
-        ctk.CTkLabel(tab_or, text="ID модели (напр. qwen/qwen-2.5-72b-instruct):", font=("", 12, "bold")).pack(
-            anchor="w", padx=10, pady=(10, 0)
+        self._field_label(tab_or, "API URL")
+        self.ent_or_url = self._plain_entry(tab_or, config.get("OPENROUTER", "api_url"))
+        self._field_label(tab_or, "API ключ OpenRouter")
+        self.ent_or_key = self._plain_entry(tab_or, config.get("OPENROUTER", "api_key"), show="*")
+        self._field_label(tab_or, "ID модели")
+        self.ent_or_model = self._plain_entry(
+            tab_or,
+            config.get("OPENROUTER", "model") or DEFAULT_OPENROUTER_MODEL,
         )
-        self.ent_or_model = ctk.CTkEntry(tab_or)
-        self.ent_or_model.insert(0, config.get("OPENROUTER", "model") or DEFAULT_OPENROUTER_MODEL)
-        self.ent_or_model.pack(fill="x", padx=10, pady=5)
-
-        ctk.CTkLabel(tab_or, text="Site URL (необязательно, для статистики):", font=("", 12, "bold")).pack(
-            anchor="w", padx=10, pady=(10, 0)
-        )
-        self.ent_or_site = ctk.CTkEntry(tab_or)
-        self.ent_or_site.insert(0, config.get("OPENROUTER", "site_url"))
-        self.ent_or_site.pack(fill="x", padx=10, pady=5)
-
-        ctk.CTkLabel(tab_or, text="Название приложения (X-Title):", font=("", 12, "bold")).pack(
-            anchor="w", padx=10, pady=(10, 0)
-        )
-        self.ent_or_app = ctk.CTkEntry(tab_or)
-        self.ent_or_app.insert(0, config.get("OPENROUTER", "app_name"))
-        self.ent_or_app.pack(fill="x", padx=10, pady=5)
+        self._field_label(tab_or, "Site URL (необязательно)")
+        self.ent_or_site = self._plain_entry(tab_or, config.get("OPENROUTER", "site_url"))
+        self._field_label(tab_or, "Название приложения (X-Title)")
+        self.ent_or_app = self._plain_entry(tab_or, config.get("OPENROUTER", "app_name"))
 
         self.var_smart = ctk.BooleanVar(value=config.getboolean("GENERAL", "smart_glue"))
-        ctk.CTkSwitch(tab_gen, text="✨ Умный склейщик предложений", variable=self.var_smart).pack(
-            anchor="w", padx=10, pady=15
-        )
+        ctk.CTkSwitch(
+            tab_gen,
+            text="✨ Умный склейщик предложений",
+            variable=self.var_smart,
+        ).pack(anchor="w", padx=12, pady=(14, 16))
 
-        # --- БЕЗОПАСНЫЙ БЛОК ЧТЕНИЯ НАСТРОЕК ---
-        try:
-            retries_val = config.getint("AI", "ai_retries")
-        except Exception:
-            retries_val = 3
-            
+        retries_val = config.getint("AI", "ai_retries", 3)
         self.lbl_retries = ctk.CTkLabel(
-            tab_gen, 
-            text=f"Повторы ИИ при ошибке: {retries_val}" if retries_val > 0 else "Повторы ИИ при ошибке: Отключены", 
-            font=("", 12, "bold")
+            tab_gen,
+            text=self._retry_text(retries_val),
+            anchor="w",
+            font=("Segoe UI", 12, "bold"),
+            text_color=UI.TEXT,
         )
-        self.lbl_retries.pack(anchor="w", padx=10)
+        self.lbl_retries.pack(fill="x", padx=12)
         self.slider_retries = ctk.CTkSlider(
-            tab_gen, from_=0, to=5, number_of_steps=5,
-            command=lambda v: self.lbl_retries.configure(text=f"Повторы ИИ при ошибке: {int(v)}" if int(v) > 0 else "Повторы ИИ при ошибке: Отключены")
+            tab_gen,
+            from_=0,
+            to=5,
+            number_of_steps=5,
+            command=lambda v: self.lbl_retries.configure(text=self._retry_text(int(v))),
         )
         self.slider_retries.set(retries_val)
-        self.slider_retries.pack(fill="x", padx=10, pady=(5, 15))
+        self.slider_retries.pack(fill="x", padx=12, pady=(5, 16))
 
-        # Здесь мы тоже убрали fallback, заменив на безопасный подход, который используется в твоем проекте
-        try:
-            workers = config.getint("GENERAL", "google_workers")
-        except Exception:
-            workers = 5
-            
-        ctk.CTkLabel(tab_gen, text="Потоки Google Translate:", font=("", 12, "bold")).pack(anchor="w", padx=10)
-        self.slider_thr = ctk.CTkSlider(tab_gen, from_=1, to=10, number_of_steps=9)
+        workers = config.getint("GENERAL", "google_workers", 5)
+        self.lbl_workers = ctk.CTkLabel(
+            tab_gen,
+            text=f"Потоки Google Translate: {workers}",
+            anchor="w",
+            font=("Segoe UI", 12, "bold"),
+            text_color=UI.TEXT,
+        )
+        self.lbl_workers.pack(fill="x", padx=12)
+        self.slider_thr = ctk.CTkSlider(
+            tab_gen,
+            from_=1,
+            to=10,
+            number_of_steps=9,
+            command=lambda v: self.lbl_workers.configure(
+                text=f"Потоки Google Translate: {int(v)}"
+            ),
+        )
         self.slider_thr.set(workers)
-        self.slider_thr.pack(fill="x", padx=10, pady=5)
+        self.slider_thr.pack(fill="x", padx=12, pady=(5, 16))
 
-        ctk.CTkLabel(tab_gen, text="API ключ DeepL:", font=("", 12, "bold")).pack(anchor="w", pady=(10, 0), padx=10)
-        self.ent_deepl = ctk.CTkEntry(tab_gen, show="*")
-        self.ent_deepl.insert(0, config.get("API", "deepl_key"))
-        self.ent_deepl.pack(fill="x", padx=10, pady=5)
-        
+        self._field_label(tab_gen, "API ключ DeepL")
+        self.ent_deepl = self._plain_entry(tab_gen, config.get("API", "deepl_key"), show="*")
+
+        footer = ctk.CTkFrame(self, fg_color="transparent")
+        footer.pack(fill="x", padx=14, pady=(0, 14))
         ctk.CTkButton(
-            self,
+            footer,
             text="📝 Редактор промптов ИИ",
-            fg_color="#17a2b8",
-            hover_color="#138496",
+            fg_color=UI.CYAN,
+            hover_color=UI.CYAN_HOVER,
             command=self._open_prompt_editor,
-        ).pack(fill="x", padx=20, pady=(10, 0))
-        
+        ).pack(side="left", fill="x", expand=True, padx=(0, 6))
         ctk.CTkButton(
-            self,
+            footer,
             text="💾 Сохранить настройки",
-            fg_color="#28a745",
-            hover_color="#218838",
+            fg_color=UI.SUCCESS,
+            hover_color=UI.SUCCESS_HOVER,
             command=self._save,
-        ).pack(fill="x", padx=20, pady=10)
-    
+        ).pack(side="right", fill="x", expand=True, padx=(6, 0))
+
+    @staticmethod
+    def _retry_text(value: int) -> str:
+        return (
+            f"Повторы ИИ при ошибке: {value}"
+            if value > 0
+            else "Повторы ИИ при ошибке: отключены"
+        )
+
+    @staticmethod
+    def _scroll_tab(tabs, title: str):
+        root = tabs.add(title)
+        frame = ctk.CTkScrollableFrame(root, fg_color="transparent")
+        frame.pack(fill="both", expand=True)
+        return frame
+
+    @staticmethod
+    def _field_label(parent, text: str) -> None:
+        ctk.CTkLabel(
+            parent,
+            text=text,
+            anchor="w",
+            font=("Segoe UI", 12, "bold"),
+            text_color=UI.TEXT,
+        ).pack(fill="x", padx=12, pady=(12, 2))
+
+    @staticmethod
+    def _plain_entry(parent, value: str, *, show: str | None = None):
+        entry = ctk.CTkEntry(parent, show=show)
+        entry.insert(0, value)
+        entry.pack(fill="x", padx=12, pady=(2, 4))
+        return entry
+
+    def _entry_with_browse(self, parent, value: str, filetypes):
+        row = ctk.CTkFrame(parent, fg_color="transparent")
+        row.pack(fill="x", padx=12, pady=(2, 4))
+        entry = ctk.CTkEntry(row)
+        entry.insert(0, value)
+        entry.pack(side="left", fill="x", expand=True)
+        ctk.CTkButton(
+            row,
+            text="Обзор",
+            width=82,
+            fg_color=UI.NEUTRAL,
+            hover_color=UI.NEUTRAL_HOVER,
+            command=lambda: self._browse(entry, filetypes),
+        ).pack(side="right", padx=(8, 0))
+        return entry
+
     def _open_prompt_editor(self) -> None:
         PromptEditorWindow(self)
-        
+
     def _browse(self, entry: ctk.CTkEntry, filetypes) -> None:
         path = filedialog.askopenfilename(filetypes=filetypes)
         if path:
@@ -159,116 +210,218 @@ class SettingsWindow(ctk.CTkToplevel):
             entry.insert(0, path)
 
     def _save(self) -> None:
-        self.config.set("AI", "exe_path", self.ent_ai_exe.get())
-        self.config.set("AI", "model_path", self.ent_ai_mod.get())
-        self.config.set("AI", "gpu_layers", int(self.slider_gpu.get()))
-        self.config.set("OPENROUTER", "api_key", self.ent_or_key.get())
-        self.config.set("OPENROUTER", "api_url", self.ent_or_url.get().strip())
-        self.config.set("OPENROUTER", "model", self.ent_or_model.get().strip())
-        self.config.set("OPENROUTER", "site_url", self.ent_or_site.get().strip())
-        self.config.set("OPENROUTER", "app_name", self.ent_or_app.get().strip())
-        self.config.set("GENERAL", "smart_glue", self.var_smart.get())
-        self.config.set("AI", "ai_retries", int(self.slider_retries.get()))
-        self.config.set("GENERAL", "google_workers", int(self.slider_thr.get()))
-        self.config.set("API", "deepl_key", self.ent_deepl.get())
+        self.config.set_many(
+            "AI",
+            {
+                "exe_path": self.ent_ai_exe.get(),
+                "model_path": self.ent_ai_mod.get(),
+                "gpu_layers": int(self.slider_gpu.get()),
+                "ai_retries": int(self.slider_retries.get()),
+            },
+        )
+        self.config.set_many(
+            "OPENROUTER",
+            {
+                "api_key": self.ent_or_key.get(),
+                "api_url": self.ent_or_url.get().strip(),
+                "model": self.ent_or_model.get().strip(),
+                "site_url": self.ent_or_site.get().strip(),
+                "app_name": self.ent_or_app.get().strip(),
+            },
+        )
+        self.config.set_many(
+            "GENERAL",
+            {
+                "smart_glue": self.var_smart.get(),
+                "google_workers": int(self.slider_thr.get()),
+            },
+        )
+        self.config.set_many("API", {"deepl_key": self.ent_deepl.get()})
         self.on_saved()
         self.destroy()
+
 
 class PromptEditorWindow(ctk.CTkToplevel):
     def __init__(self, parent):
         super().__init__(parent)
         self.title("📝 Редактор промптов ИИ")
-        self.geometry("750x550")
+        self.geometry("900x650")
+        self.minsize(700, 500)
+        self.resizable(True, True)
+        self.configure(fg_color=UI.APP_BG)
         self.grab_set()
+        self.protocol("WM_DELETE_WINDOW", self._request_close)
 
         self.prompts = load_prompts()
+        self._dirty = False
 
-        tabs = ctk.CTkTabview(self)
-        tabs.pack(fill="both", expand=True, padx=10, pady=10)
-        
+        tabs = ctk.CTkTabview(self, fg_color=UI.CARD_BG)
+        tabs.pack(fill="both", expand=True, padx=14, pady=(14, 8))
         self.txt_mods = self._create_tab(tabs, "mods", "Интерфейс (Моды)")
         self.txt_books = self._create_tab(tabs, "books", "Книги / Справочники")
         self.txt_quests = self._create_tab(tabs, "quests", "Квесты")
-        
-        # --- ВКЛАДКА "РИСКОВАННЫЙ РЕЖИМ" ---
+
         tab_tech = tabs.add("⚙️ Тех. правила (ОПАСНО)")
-        lbl_warn = ctk.CTkLabel(
-            tab_tech,
-            text="ВНИМАНИЕ: Изменение этих правил может сломать парсинг JSON и маркеров!\nИспользуйте только для экспериментов с нестандартными моделями.",
-            text_color="#e74c3c",
-            font=("", 12, "bold"),
-            justify="left"
-        )
-        lbl_warn.pack(anchor="w", pady=(0, 5))
-        # --- ПОДСКАЗКА ПРО ПЕРЕМЕННУЮ {markers} ---
-        lbl_vars = ctk.CTkLabel(
+        ctk.CTkLabel(
             tab_tech,
             text=(
-                "Переменная: {markers} — точный список маркеров [#N#] текущего запроса.\n"
-                "Вставь её туда, где модель должна увидеть чек-лист. Если не указать —\n"
-                "список будет автоматически дописан в конец правил."
+                "ВНИМАНИЕ: изменение технических правил может сломать JSON и маркеры.\n"
+                "Используйте этот раздел только для осознанных экспериментов."
             ),
-            text_color="gray",
-            font=("", 11),
+            text_color="#ff7373",
+            font=("Segoe UI", 12, "bold"),
             justify="left",
+        ).pack(anchor="w", pady=(2, 5), padx=4)
+        ctk.CTkLabel(
+            tab_tech,
+            text=(
+                "{markers} — точный список [#N#] текущего запроса. Если переменная не указана, "
+                "список добавляется автоматически."
+            ),
+            text_color=UI.MUTED,
+            font=("Segoe UI", 10),
+            justify="left",
+            wraplength=760,
+        ).pack(anchor="w", pady=(0, 6), padx=4)
+        self.txt_tech = ctk.CTkTextbox(tab_tech, wrap="word", font=("Consolas", 12))
+        self.txt_tech.pack(fill="both", expand=True, padx=4, pady=(0, 4))
+        self.txt_tech.insert(
+            "1.0",
+            self.prompts.get("technical", get_default_prompts()["technical"]),
         )
-        lbl_vars.pack(anchor="w", pady=(0, 5))
-        self.txt_tech = ctk.CTkTextbox(tab_tech, wrap="word", font=("Consolas", 13))
-        self.txt_tech.pack(fill="both", expand=True)
-        self.txt_tech.insert("1.0", self.prompts.get("technical", get_default_prompts()["technical"]))
-
-        # Фикс Ctrl+C/V/A/X для кириллической раскладки
-        def _fix_ctrl_for_textbox(widget):
-            def handler(event):
-                ctrl = bool(event.state & 4)
-                if sys.platform == "win32":
-                    try:
-                        ctrl = ctrl or bool(ctypes.windll.user32.GetAsyncKeyState(0x11) & 0x8000)
-                    except Exception:
-                        pass
-                if not ctrl:
-                    return None
-                KEY_ACTIONS = {67: "<<Copy>>", 86: "<<Paste>>", 65: "<<SelectAll>>", 88: "<<Cut>>"}
-                if event.keycode in KEY_ACTIONS:
-                    event.widget.event_generate(KEY_ACTIONS[event.keycode])
-                    return "break"
-                return None
-            target = getattr(widget, "_textbox", widget)
-            target.bind("<Key>", handler, add="+")
 
         for widget in [self.txt_mods, self.txt_books, self.txt_quests, self.txt_tech]:
-            _fix_ctrl_for_textbox(widget)
+            self._fix_ctrl_for_textbox(widget)
+            self._track_changes(widget)
 
-        btn_frame = ctk.CTkFrame(self, fg_color="transparent")
-        btn_frame.pack(fill="x", padx=10, pady=10)
-
-        ctk.CTkButton(btn_frame, text="Сбросить всё по умолчанию", fg_color="#dc3545", hover_color="#c82333", command=self._reset).pack(side="left")
-        ctk.CTkButton(btn_frame, text="💾 Сохранить", fg_color="#28a745", hover_color="#218838", command=self._save).pack(side="right")
+        footer = ctk.CTkFrame(self, fg_color="transparent")
+        footer.pack(fill="x", padx=14, pady=(0, 14))
+        self.lbl_dirty = ctk.CTkLabel(
+            footer,
+            text="Все изменения сохранены",
+            text_color=UI.MUTED,
+            anchor="w",
+        )
+        self.lbl_dirty.pack(side="left", fill="x", expand=True)
+        ctk.CTkButton(
+            footer,
+            text="Сбросить",
+            width=110,
+            fg_color=UI.DANGER,
+            hover_color=UI.DANGER_HOVER,
+            command=self._reset,
+        ).pack(side="right", padx=(6, 0))
+        ctk.CTkButton(
+            footer,
+            text="💾 Сохранить",
+            width=130,
+            fg_color=UI.SUCCESS,
+            hover_color=UI.SUCCESS_HOVER,
+            command=self._save,
+        ).pack(side="right", padx=(6, 0))
 
     def _create_tab(self, tabs, key, title):
         tab = tabs.add(title)
-        lbl = ctk.CTkLabel(tab, text="Переменные: {lang_name} (язык), {context} (название мода/файла)", text_color="gray")
-        lbl.pack(anchor="w", pady=(0, 5))
-        txt = ctk.CTkTextbox(tab, wrap="word", font=("", 14))
-        txt.pack(fill="both", expand=True)
+        ctk.CTkLabel(
+            tab,
+            text="Переменные: {lang_name} (язык), {context} (название мода/файла)",
+            text_color=UI.MUTED,
+            anchor="w",
+        ).pack(fill="x", pady=(2, 5), padx=4)
+        txt = ctk.CTkTextbox(tab, wrap="word", font=("Segoe UI", 13))
+        txt.pack(fill="both", expand=True, padx=4, pady=(0, 4))
         txt.insert("1.0", self.prompts.get(key, get_default_prompts()[key]))
         return txt
 
-    def _reset(self):
-        defaults = get_default_prompts()
-        self.txt_mods.delete("1.0", "end")
-        self.txt_mods.insert("1.0", defaults["mods"])
-        self.txt_books.delete("1.0", "end")
-        self.txt_books.insert("1.0", defaults["books"])
-        self.txt_quests.delete("1.0", "end")
-        self.txt_quests.insert("1.0", defaults["quests"])
-        self.txt_tech.delete("1.0", "end")
-        self.txt_tech.insert("1.0", defaults["technical"])
+    @staticmethod
+    def _fix_ctrl_for_textbox(widget) -> None:
+        def handler(event):
+            ctrl = bool(event.state & 4)
+            if sys.platform == "win32":
+                try:
+                    ctrl = ctrl or bool(
+                        ctypes.windll.user32.GetAsyncKeyState(0x11) & 0x8000
+                    )
+                except Exception:
+                    pass
+            if not ctrl:
+                return None
+            actions = {67: "<<Copy>>", 86: "<<Paste>>", 65: "<<SelectAll>>", 88: "<<Cut>>"}
+            if event.keycode in actions:
+                event.widget.event_generate(actions[event.keycode])
+                return "break"
+            return None
 
-    def _save(self):
+        target = getattr(widget, "_textbox", widget)
+        target.bind("<Key>", handler, add="+")
+
+    def _track_changes(self, widget) -> None:
+        target = getattr(widget, "_textbox", widget)
+        try:
+            target.edit_modified(False)
+        except Exception:
+            return
+
+        def modified(_event=None):
+            try:
+                if not target.edit_modified():
+                    return
+                target.edit_modified(False)
+            except Exception:
+                return
+            self._set_dirty(True)
+
+        target.bind("<<Modified>>", modified, add="+")
+
+    def _set_dirty(self, dirty: bool) -> None:
+        self._dirty = dirty
+        if not hasattr(self, "lbl_dirty"):
+            return
+        self.lbl_dirty.configure(
+            text="● Есть несохранённые изменения" if dirty else "Все изменения сохранены",
+            text_color="#f6c85f" if dirty else UI.MUTED,
+        )
+
+    def _reset(self) -> None:
+        if not messagebox.askyesno(
+            "Сбросить промпты?",
+            "Все четыре промпта будут заменены значениями по умолчанию. Продолжить?",
+            parent=self,
+            icon="warning",
+        ):
+            return
+        defaults = get_default_prompts()
+        for widget, key in (
+            (self.txt_mods, "mods"),
+            (self.txt_books, "books"),
+            (self.txt_quests, "quests"),
+            (self.txt_tech, "technical"),
+        ):
+            widget.delete("1.0", "end")
+            widget.insert("1.0", defaults[key])
+        self._set_dirty(True)
+
+    def _save(self, *, close: bool = True) -> None:
         self.prompts["mods"] = self.txt_mods.get("1.0", "end").strip()
         self.prompts["books"] = self.txt_books.get("1.0", "end").strip()
         self.prompts["quests"] = self.txt_quests.get("1.0", "end").strip()
         self.prompts["technical"] = self.txt_tech.get("1.0", "end").strip()
         save_prompts(self.prompts)
+        self._set_dirty(False)
+        if close:
+            self.destroy()
+
+    def _request_close(self) -> None:
+        if not self._dirty:
+            self.destroy()
+            return
+        answer = messagebox.askyesnocancel(
+            "Сохранить изменения?",
+            "В редакторе промптов есть несохранённые изменения.",
+            parent=self,
+        )
+        if answer is None:
+            return
+        if answer:
+            self._save(close=False)
         self.destroy()

--- a/mineai/gui/style.py
+++ b/mineai/gui/style.py
@@ -1,0 +1,136 @@
+"""Shared visual tokens and lightweight accessibility helpers for MineAI GUI."""
+
+from __future__ import annotations
+
+import customtkinter as ctk
+
+
+class UI:
+    APP_BG = ("#e8edf5", "#070b14")
+    SIDEBAR_BG = ("#eef2f7", "#0a0f1b")
+    CARD_BG = ("#ffffff", "#0f1626")
+    CARD_ALT_BG = ("#f7f9fc", "#111b2e")
+    BORDER = ("#d9e0ea", "#223049")
+    TEXT = ("#111827", "#eef2ff")
+    MUTED = ("#5b6472", "#93a4bd")
+    INFO_BG = ("#e5edff", "#182b47")
+    INFO_TEXT = ("#2b5db2", "#7db4ff")
+
+    LOG_BG = "#0b1020"
+    PRIMARY = "#2f81f7"
+    PRIMARY_HOVER = "#1f6fd8"
+    SUCCESS = "#28a745"
+    SUCCESS_HOVER = "#218838"
+    WARNING = "#ffc107"
+    WARNING_HOVER = "#e0a800"
+    DANGER = "#dc3545"
+    DANGER_HOVER = "#c82333"
+    CYAN = "#17a2b8"
+    CYAN_HOVER = "#138496"
+    NEUTRAL = "#445064"
+    NEUTRAL_HOVER = "#364154"
+
+
+class ToolTip(ctk.CTkToplevel):
+    """Small mouse/focus tooltip that stays within the active monitor."""
+
+    def __init__(self, widget, title: str, text: str, *, delay_ms: int = 300) -> None:
+        parent = getattr(widget, "master", None) or getattr(widget, "_parent", None)
+        super().__init__(master=parent)
+        self._tip_widget = widget
+        self._delay_ms = delay_ms
+        self._after_id = None
+        self.withdraw()
+        try:
+            self.overrideredirect(True)
+            self.attributes("-topmost", True)
+        except Exception:
+            pass
+
+        frame = ctk.CTkFrame(
+            self,
+            corner_radius=10,
+            fg_color="#0b1220",
+            border_width=1,
+            border_color="#2b3a55",
+        )
+        frame.pack(fill="both", expand=True)
+        ctk.CTkLabel(
+            frame,
+            text=title,
+            anchor="w",
+            justify="left",
+            font=("Segoe UI", 12, "bold"),
+            text_color="#e8efff",
+        ).pack(anchor="w", padx=10, pady=(8, 0))
+        ctk.CTkLabel(
+            frame,
+            text=text,
+            anchor="w",
+            justify="left",
+            wraplength=310,
+            font=("Segoe UI", 11),
+            text_color="#b7c6e0",
+        ).pack(anchor="w", padx=10, pady=(2, 8))
+        self._bind_targets()
+
+    def _bind_targets(self) -> None:
+        targets = [self._tip_widget]
+        for attr in ("_entry", "_textbox"):
+            target = getattr(self._tip_widget, attr, None)
+            if target is not None:
+                targets.append(target)
+        seen: set[int] = set()
+        for target in targets:
+            if id(target) in seen:
+                continue
+            seen.add(id(target))
+            target.bind("<Enter>", self._schedule, add="+")
+            target.bind("<Leave>", self._hide, add="+")
+            target.bind("<FocusIn>", self._schedule, add="+")
+            target.bind("<FocusOut>", self._hide, add="+")
+            target.bind("<ButtonPress>", self._hide, add="+")
+
+    def _schedule(self, _event=None) -> None:
+        self._hide()
+        try:
+            self._after_id = self._tip_widget.after(self._delay_ms, self._show)
+        except Exception:
+            self._after_id = None
+
+    def _show(self) -> None:
+        try:
+            if not self._tip_widget.winfo_exists():
+                return
+            self.update_idletasks()
+            tip_w = max(self.winfo_reqwidth(), 220)
+            tip_h = max(self.winfo_reqheight(), 60)
+            root_x = self._tip_widget.winfo_rootx()
+            root_y = self._tip_widget.winfo_rooty()
+            widget_w = self._tip_widget.winfo_width()
+            widget_h = self._tip_widget.winfo_height()
+            screen_w = self.winfo_screenwidth()
+            screen_h = self.winfo_screenheight()
+            margin = 10
+            right_x = root_x + widget_w + margin
+            left_x = root_x - tip_w - margin
+            x = right_x if right_x + tip_w <= screen_w - margin else max(margin, left_x)
+            below_y = root_y + widget_h + margin
+            above_y = root_y - tip_h - margin
+            y = below_y if below_y + tip_h <= screen_h - margin else max(margin, above_y)
+            self.geometry(f"+{int(x)}+{int(y)}")
+            self.deiconify()
+        except Exception:
+            self.withdraw()
+
+    def _hide(self, _event=None) -> None:
+        if self._after_id is not None:
+            try:
+                self._tip_widget.after_cancel(self._after_id)
+            except Exception:
+                pass
+            self._after_id = None
+        try:
+            self.withdraw()
+        except Exception:
+            pass

--- a/mineai/runtime/job.py
+++ b/mineai/runtime/job.py
@@ -131,6 +131,8 @@ class TranslationJob:
         self.on_log("-" * 75, "dim")
         if not self.state.should_run():
             self.on_log("🛑 АНАЛИЗ ПРЕРВАН", "red")
+            self.on_status("Остановлено", self.state.line_progress())
+            return
         elif total_en > 0:
             pct = int(total_tr / total_en * 100)
             color = "green" if pct >= 90 else ("yellow" if pct >= 50 else "red")
@@ -355,7 +357,7 @@ class TranslationJob:
             self.on_status("Ошибка перевода", 1.0)
         elif not self.state.should_run():
             self.on_log("\n🛑 ОСТАНОВЛЕНО.", "red")
-            self.on_status("Остановлено", 1.0)
+            self.on_status("Остановлено", self.state.line_progress())
         elif failed_files:
             self.on_log(
                 f"\n⚠️ ЗАВЕРШЕНО С ОШИБКАМИ: пропущено файлов — {failed_files}.",

--- a/tests/test_gui_active_job.py
+++ b/tests/test_gui_active_job.py
@@ -78,6 +78,13 @@ class TranslatorAppJobLifecycleTests(unittest.TestCase):
         state.finish = mock.Mock(side_effect=finish)
         state.stop = mock.Mock(side_effect=finish)
         state.toggle_pause = mock.Mock(side_effect=toggle_pause)
+        state.snapshot = mock.Mock(
+            return_value=SimpleNamespace(
+                total_strings=0, translated_strings=0, ok_strings=0, failed_strings=0
+            )
+        )
+        state.eta_text = mock.Mock(return_value="расчёт...")
+        state.line_progress = mock.Mock(return_value=0.25)
         app.job_state = state
         app._ui_thread_id = threading.get_ident()
         app._ui_queue = queue.Queue()
@@ -89,8 +96,16 @@ class TranslatorAppJobLifecycleTests(unittest.TestCase):
         app.btn_start = mock.Mock()
         app.btn_pause = mock.Mock()
         app.btn_stop = mock.Mock()
+        app.btn_migrate = mock.Mock()
+        app.btn_engine_settings = mock.Mock()
         app.log = mock.Mock()
         app.set_status = mock.Mock()
+        app._validate_minecraft_dir = mock.Mock(return_value=True)
+        app._validate_scope = mock.Mock(return_value=True)
+        app._validate_engine_ready = mock.Mock(return_value=True)
+        app._confirm_inplace = mock.Mock(return_value=True)
+        app._reset_run_ui = mock.Mock()
+        app._refresh_engine_readiness = mock.Mock()
         return app
 
     def test_stop_targets_the_retained_translation_job(self) -> None:
@@ -183,6 +198,7 @@ class TranslatorAppJobLifecycleTests(unittest.TestCase):
         app.job_state.stop.assert_called_once_with()
         app.btn_stop.configure.assert_called_once_with(state="disabled")
         app.btn_pause.configure.assert_called_once_with(state="disabled")
+        app.set_status.assert_called_once_with("🛑 Остановка...", None)
 
     def test_worker_ui_update_is_queued_without_calling_tk(self) -> None:
         app = object.__new__(gui_app.TranslatorApp)
@@ -229,6 +245,44 @@ class TranslatorAppJobLifecycleTests(unittest.TestCase):
             [mock.call(state="disabled"), mock.call(state="normal")],
         )
 
+    def test_lock_ui_also_locks_migration_button(self) -> None:
+        app = self._bare_app()
+        app._lock_ui = gui_app.TranslatorApp._lock_ui.__get__(
+            app, gui_app.TranslatorApp
+        )
+
+        app._lock_ui(True)
+        app._lock_ui(False)
+
+        self.assertEqual(
+            app.btn_migrate.configure.call_args_list,
+            [mock.call(state="disabled"), mock.call(state="normal")],
+        )
+
+    def test_failed_preflight_does_not_start_translation_worker(self) -> None:
+        app = self._bare_app()
+        app._validate_minecraft_dir.return_value = False
+        app.var_engine = SimpleNamespace(get=lambda: "google")
+
+        with mock.patch.object(gui_app.threading, "Thread") as thread:
+            app._start_translation()
+
+        thread.assert_not_called()
+        app._lock_ui.assert_not_called()
+        app.job_state.start.assert_not_called()
+
+    def test_inplace_cancel_does_not_start_translation_worker(self) -> None:
+        app = self._bare_app()
+        app._confirm_inplace.return_value = False
+        app.var_engine = SimpleNamespace(get=lambda: "google")
+
+        with mock.patch.object(gui_app.threading, "Thread") as thread:
+            app._start_translation()
+
+        thread.assert_not_called()
+        app._lock_ui.assert_not_called()
+        app.job_state.start.assert_not_called()
+
     def test_open_log_file_uses_cross_platform_opener(self) -> None:
         app = self._bare_app()
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -262,6 +316,8 @@ class TranslatorAppJobLifecycleTests(unittest.TestCase):
         window.cache_std = mock.Mock()
         window.after = mock.Mock()
         window.destroy = mock.Mock()
+        window.result_frame = mock.Mock()
+        window._show_result = mock.Mock()
         created_threads = []
 
         def make_thread(*, target, daemon):
@@ -290,7 +346,12 @@ class TranslatorAppJobLifecycleTests(unittest.TestCase):
         window.destroy.assert_not_called()
 
         poll_finished()
-        window.destroy.assert_called_once_with()
+        window._show_result.assert_called_once_with(
+            count=0,
+            error=None,
+            cache_type="ai",
+        )
+        window.destroy.assert_not_called()
         self.assertEqual(window.after.call_count, 1)
 
 

--- a/tests/test_job_terminal_status.py
+++ b/tests/test_job_terminal_status.py
@@ -1,0 +1,92 @@
+import unittest
+from unittest import mock
+
+from mineai.runtime.job import TranslationJob, TranslationOptions
+
+
+class TerminalStopStatusTests(unittest.TestCase):
+    @staticmethod
+    def _options() -> TranslationOptions:
+        return TranslationOptions(
+            mc_dir="C:/Minecraft",
+            language_label="Русский",
+            mc_version="1.20.1",
+            output_mode="inplace",
+            pack_name="MineAI_Pack",
+            engine="google",
+            google_mode="single",
+            ai_mode="safe",
+            ai_batch=20,
+            ai_provider="local",
+            process_mode="append",
+            translate_mods=False,
+            translate_books=False,
+            translate_quests=True,
+        )
+
+    @staticmethod
+    def _job(*, progress: float):
+        config = mock.Mock()
+        config.getboolean.return_value = True
+        state = mock.Mock()
+        state.should_run.return_value = False
+        state.line_progress.return_value = progress
+        state.get_full_status.return_value = "status"
+        cache_std = mock.Mock()
+        cache_ai = mock.Mock()
+        on_log = mock.Mock()
+        on_status = mock.Mock()
+        job = TranslationJob(
+            config,
+            cache_std,
+            cache_ai,
+            state,
+            on_log=on_log,
+            on_status=on_status,
+            on_row=mock.Mock(),
+        )
+        return job, state, cache_std, on_log, on_status
+
+    def test_stopped_analysis_preserves_current_progress(self) -> None:
+        job, _state, _cache, _log, on_status = self._job(progress=0.37)
+        analyzer = mock.Mock()
+        analyzer.analyze.return_value = (100, 25)
+
+        with mock.patch("mineai.runtime.job.ModpackAnalyzer", return_value=analyzer):
+            job.run_analysis(self._options())
+
+        on_status.assert_called_with("Остановлено", 0.37)
+        self.assertNotIn(mock.call("Готово", 1.0), on_status.call_args_list)
+
+    def test_stopped_translation_preserves_current_progress(self) -> None:
+        job, state, cache_std, _log, on_status = self._job(progress=0.42)
+
+        with (
+            mock.patch("mineai.runtime.job.discover_jar_files", return_value=[]),
+            mock.patch(
+                "mineai.runtime.job.discover_loose_lang_files",
+                return_value=["dummy.json"],
+            ),
+            mock.patch("mineai.runtime.job.discover_snbt_files", return_value=[]),
+            mock.patch("mineai.runtime.job.discover_bq_files", return_value=[]),
+            mock.patch("mineai.runtime.job.StringEstimator") as estimator_cls,
+            mock.patch("mineai.runtime.job.TranslationService"),
+            mock.patch("mineai.runtime.job.JarProcessor"),
+            mock.patch("mineai.runtime.job.LooseJsonProcessor"),
+            mock.patch("mineai.runtime.job.SnbtProcessor"),
+            mock.patch("mineai.runtime.job.BQProcessor"),
+        ):
+            estimator_cls.return_value.estimate.return_value = 10
+            job.run_translation(self._options())
+
+        cache_std.save.assert_called_once_with()
+        state.line_progress.assert_called()
+        on_status.assert_called_with("Остановлено", 0.42)
+        self.assertNotIn(
+            mock.call("Все задачи выполнены!", 1.0),
+            on_status.call_args_list,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prompt_editor_state.py
+++ b/tests/test_prompt_editor_state.py
@@ -1,0 +1,63 @@
+import sys
+import types
+import unittest
+from unittest import mock
+
+_customtkinter = types.ModuleType("customtkinter")
+_customtkinter.CTkToplevel = object
+_customtkinter.CTkEntry = object
+_tkinter = types.ModuleType("tkinter")
+_tkinter.filedialog = types.SimpleNamespace()
+_tkinter.messagebox = types.SimpleNamespace()
+_previous = {name: sys.modules.get(name) for name in ("customtkinter", "tkinter")}
+sys.modules["customtkinter"] = _customtkinter
+sys.modules["tkinter"] = _tkinter
+try:
+    from mineai.gui import settings as gui_settings
+finally:
+    for name, previous in _previous.items():
+        if previous is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
+
+
+class PromptEditorStateTests(unittest.TestCase):
+    @staticmethod
+    def _editor(dirty: bool = True):
+        editor = object.__new__(gui_settings.PromptEditorWindow)
+        editor._dirty = dirty
+        editor.destroy = mock.Mock()
+        editor._save = mock.Mock()
+        return editor
+
+    def test_clean_close_destroys_immediately(self) -> None:
+        editor = self._editor(dirty=False)
+        editor._request_close()
+        editor.destroy.assert_called_once_with()
+        editor._save.assert_not_called()
+
+    def test_dirty_close_cancel_keeps_editor_open(self) -> None:
+        editor = self._editor()
+        with mock.patch.object(gui_settings.messagebox, "askyesnocancel", return_value=None, create=True):
+            editor._request_close()
+        editor.destroy.assert_not_called()
+        editor._save.assert_not_called()
+
+    def test_dirty_close_save_persists_before_destroy(self) -> None:
+        editor = self._editor()
+        with mock.patch.object(gui_settings.messagebox, "askyesnocancel", return_value=True, create=True):
+            editor._request_close()
+        editor._save.assert_called_once_with(close=False)
+        editor.destroy.assert_called_once_with()
+
+    def test_dirty_close_discard_destroys_without_save(self) -> None:
+        editor = self._editor()
+        with mock.patch.object(gui_settings.messagebox, "askyesnocancel", return_value=False, create=True):
+            editor._request_close()
+        editor._save.assert_not_called()
+        editor.destroy.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_blockers.py
+++ b/tests/test_release_blockers.py
@@ -183,7 +183,7 @@ class GracefulCloseTests(unittest.TestCase):
         active_job.stop.assert_called_once_with()
         app.job_state.stop.assert_not_called()
         app.destroy.assert_not_called()
-        app.set_status.assert_called_once_with("🛑 Завершение работы...", 1.0)
+        app.set_status.assert_called_once_with("🛑 Завершение работы...", None)
 
         app.after.assert_called_once()
         delay, poll = app.after.call_args.args


### PR DESCRIPTION
Статус

Draft / release candidate для финальной сертификации. Пока не merge.

PR построен прямо от актуального beta:

* base SHA: 161b702665c805ca18c0a70d0e47841299afc7ac
* head SHA: 0fa6b6ed49a746ce66fda858738f8969366dc961
* commits: 1
* behind beta: 0

Свежие AI/LLM изменения текущей beta намеренно не изменяются этим PR.

Цель

Обновить desktop GUI перед финальным beta → main, сохранив все runtime/safety contracts текущей beta.

Новый интерфейс адаптирован под актуальную архитектуру проекта — существующий app.py не заменялся старым UI-кандидатом целиком.

Основные изменения

Главное окно переработано в card-based dashboard:

* Project / Output / Scope / Engine / Processing / Actions cards;
* отдельная Status Card;
* KPI: обработано / успешно / ошибки / ETA;
* отдельный Journal/Log card;
* единая визуальная система в mineai/gui/style.py;
* responsive layout;
* contextual tooltips.

Добавлен GUI preflight:

* проверка Minecraft directory;
* проверка выбранных областей;
* readiness DeepL/OpenRouter/local AI;
* подтверждение перед inplace.

Обновлены Settings, Prompt Editor и Migration.

Settings стали resizeable/scrollable, slider values отображаются динамически.

Prompt Editor получил dirty-state, подтверждение Reset и Save / Don’t Save / Cancel при закрытии.

Migration сохраняет post-#36 Event/polling/non-daemon contract, но после завершения показывает result card вместо мгновенного закрытия.

Safety

Сохранены существующие гарантии:

* TranslationJob удерживается до завершения worker;
* UI callbacks работают через существующую thread-safe queue;
* traceback/exception boundaries сохранены;
* WM_DELETE_WINDOW остаётся за gui/lifecycle.py;
* X выполняет Stop → cleanup → destroy;
* Migration worker не вызывает Tk API;
* Settings и Migration блокируются при активной задаче;
* PackWriter / cache / HTTP cancellation не изменялись.

Исправлено только отображение Stop: остановка больше не делает ложный визуальный скачок на 100%.

Что НЕ меняется

Не изменялись:

mineai/engines/*, processors, estimator, cache format, append/skip/force, PackWriter semantics, HTTP retry/cancellation, language validation и свежий LLM overhaul автора.

Validation

На latest-beta baseline:

113/113 tests — PASS

На GUI candidate:

122/122 tests — PASS

Отдельная Windows certification:

Windows Server 2025 / Python 3.10 — PASS

122/122 tests — PASS

Main / Settings / Prompt Editor / Migration construction smoke — PASS

PyInstaller 6.21 — PASS

MineAI_Translator.exe — 11 767 331 bytes

EXE startup smoke — PASS

Перед merge

PR намеренно оставляется Draft.

После открытия PR требуется финальная ручная сертификация на Windows:

DPI 100/125/150%, Settings/Prompt/Migration, Analyze → Stop, Start → Pause → Resume → Stop, Start → X, Resource Pack cleanup, inplace Cancel/Confirm и один реальный крупный modpack.

Если эти проверки проходят и новых P0/P1 нет — этот GUI можно считать финальным release candidate для 10.0.0.