### PR TITLE
fix: protect loose locale source files from case-sensitive overwrite

### DIFF
--- a/mineai/processors/estimator.py
+++ b/mineai/processors/estimator.py
@@ -319,7 +319,12 @@ class StringEstimator:
                 source_data = load_lenient_json(
                     source_file.read().encode("utf-8")
                 )
-            target_path = path.replace("en_us.json", target_file)
+            target_path = re.sub(
+                r"en_us\.json$",
+                target_file,
+                path,
+                flags=re.IGNORECASE,
+            )
             target_data = {}
             if os.path.exists(target_path):
                 with open(target_path, encoding="utf-8") as target_handle:

--- a/mineai/processors/locale_paths.py
+++ b/mineai/processors/locale_paths.py
@@ -1,0 +1,24 @@
+import os
+import re
+
+
+_SOURCE_LOCALE_FILENAME = re.compile(r"en_us\.json$", re.IGNORECASE)
+
+
+def target_locale_path(path: str, target_filename: str) -> str:
+    """Replace only the trailing en_us.json locale filename, case-insensitively."""
+    return _SOURCE_LOCALE_FILENAME.sub(target_filename, path, count=1)
+
+
+def normalized_absolute_path(path: str) -> str:
+    """Normalize an absolute path for safe source/target comparisons."""
+    return os.path.normcase(os.path.abspath(path))
+
+
+def ensure_distinct_paths(source_path: str, target_path: str) -> None:
+    """Fail closed instead of ever allowing a target to overwrite its source."""
+    if normalized_absolute_path(source_path) == normalized_absolute_path(target_path):
+        raise RuntimeError(
+            "Refusing to overwrite source locale file: "
+            f"source and target resolve to the same path ({source_path})"
+        )

--- a/mineai/processors/loose_json.py
+++ b/mineai/processors/loose_json.py
@@ -10,6 +10,7 @@ from mineai.processors.locale_keys import (
     collect_lang_keys_to_translate,
     count_translatable_lang_entries,
 )
+from mineai.processors.locale_paths import ensure_distinct_paths, target_locale_path
 from mineai.processors.selection import skip_threshold_reached
 from mineai.runtime.state import JobState
 
@@ -36,8 +37,10 @@ class LooseJsonProcessor:
         else:
             internal = "assets/kubejs/lang/" + os.path.basename(file_path)
 
-        tr_internal = internal.replace("en_us.json", f"{target_lang['file']}.json")
-        tr_disk = file_path.replace("en_us.json", f"{target_lang['file']}.json")
+        target_filename = f"{target_lang['file']}.json"
+        tr_internal = target_locale_path(internal, target_filename)
+        tr_disk = target_locale_path(file_path, target_filename)
+        ensure_distinct_paths(file_path, tr_disk)
 
         with open(file_path, encoding="utf-8") as f:
             en_data = load_lenient_json(f.read().encode("utf-8"))

--- a/tests/test_loose_locale_path_safety.py
+++ b/tests/test_loose_locale_path_safety.py
@@ -1,0 +1,179 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from mineai.constants import LANGUAGES
+from mineai.engines.base import EngineCallbacks
+from mineai.processors.discovery import discover_loose_lang_files
+from mineai.processors.estimator import StringEstimator
+from mineai.processors.locale_paths import target_locale_path
+from mineai.processors.loose_json import LooseJsonProcessor
+from mineai.runtime.state import JobState
+
+
+TARGET_LANG = LANGUAGES["Русский"]
+
+
+class _FakeService:
+    def translate_dict(
+        self,
+        pending,
+        _target_lang,
+        _callbacks,
+        **_kwargs,
+    ):
+        return {key: "Перевод" for key in pending}
+
+
+class _MemoryPackWriter:
+    def __init__(self) -> None:
+        self.writes: dict[str, bytes] = {}
+
+    def write(self, path: str, payload: bytes) -> None:
+        self.writes[path] = payload
+
+
+def _callbacks() -> EngineCallbacks:
+    return EngineCallbacks(
+        should_run=lambda: True,
+        wait_if_paused=lambda: None,
+        on_log=lambda *_args: None,
+        on_status=lambda *_args: None,
+    )
+
+
+def _make_source(root: str, filename: str) -> tuple[Path, bytes]:
+    lang_dir = Path(root) / "kubejs" / "assets" / "example" / "lang"
+    lang_dir.mkdir(parents=True)
+    source = lang_dir / filename
+    original = b'{"message":"Original text"}'
+    source.write_bytes(original)
+    return source, original
+
+
+class LooseLocalePathSafetyTests(unittest.TestCase):
+    def _processor(self) -> LooseJsonProcessor:
+        return LooseJsonProcessor(
+            _FakeService(),
+            JobState(is_running=True),
+            _callbacks(),
+        )
+
+    def test_inplace_preserves_source_for_case_variants(self) -> None:
+        for filename in ("en_us.json", "EN_US.JSON", "En_Us.Json"):
+            with self.subTest(filename=filename), tempfile.TemporaryDirectory() as tmp:
+                source, original = _make_source(tmp, filename)
+
+                self.assertIn(str(source), discover_loose_lang_files(tmp))
+                self._processor().process(
+                    str(source),
+                    tmp,
+                    target_lang=TARGET_LANG,
+                    mode="append",
+                    output_mode="inplace",
+                    pack_writer=None,
+                )
+
+                target = source.with_name("ru_ru.json")
+                self.assertTrue(source.exists())
+                self.assertEqual(source.read_bytes(), original)
+                self.assertTrue(target.exists())
+                self.assertNotEqual(
+                    os.path.normcase(os.path.abspath(source)),
+                    os.path.normcase(os.path.abspath(target)),
+                )
+                self.assertEqual(
+                    json.loads(target.read_text(encoding="utf-8"))["message"],
+                    "Перевод",
+                )
+
+    def test_resourcepack_uses_target_locale_name_for_uppercase_source(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source, original = _make_source(tmp, "EN_US.JSON")
+            writer = _MemoryPackWriter()
+
+            self._processor().process(
+                str(source),
+                tmp,
+                target_lang=TARGET_LANG,
+                mode="append",
+                output_mode="resourcepack",
+                pack_writer=writer,
+            )
+
+            self.assertEqual(source.read_bytes(), original)
+            self.assertIn("assets/example/lang/ru_ru.json", writer.writes)
+            self.assertNotIn("assets/example/lang/EN_US.JSON", writer.writes)
+            self.assertEqual(
+                json.loads(
+                    writer.writes["assets/example/lang/ru_ru.json"].decode("utf-8")
+                )["message"],
+                "Перевод",
+            )
+
+    def test_estimator_uses_same_case_insensitive_target_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source, _original = _make_source(tmp, "En_Us.Json")
+            estimator = StringEstimator(JobState(is_running=True))
+
+            self.assertEqual(
+                estimator._estimate_loose(
+                    str(source),
+                    "ru_ru.json",
+                    "append",
+                    TARGET_LANG["regex"],
+                ),
+                1,
+            )
+
+            source.with_name("ru_ru.json").write_text(
+                json.dumps({"message": "Перевод"}, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                estimator._estimate_loose(
+                    str(source),
+                    "ru_ru.json",
+                    "append",
+                    TARGET_LANG["regex"],
+                ),
+                0,
+            )
+
+    def test_self_overwrite_guard_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source, original = _make_source(tmp, "EN_US.JSON")
+
+            with mock.patch(
+                "mineai.processors.loose_json.target_locale_path",
+                side_effect=lambda path, _target: path,
+            ):
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "Refusing to overwrite source locale file",
+                ):
+                    self._processor().process(
+                        str(source),
+                        tmp,
+                        target_lang=TARGET_LANG,
+                        mode="append",
+                        output_mode="inplace",
+                        pack_writer=None,
+                    )
+
+            self.assertEqual(source.read_bytes(), original)
+            self.assertFalse(source.with_name("ru_ru.json").exists())
+
+    def test_target_locale_path_replaces_only_trailing_locale_filename(self) -> None:
+        source = "root/en_us.json_backup/assets/example/lang/EN_US.JSON"
+        self.assertEqual(
+            target_locale_path(source, "ru_ru.json"),
+            "root/en_us.json_backup/assets/example/lang/ru_ru.json",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Что исправляет этот PR

Этот PR устраняет потенциально критическую проблему обработки loose language-файлов Minecraft с нестандартным регистром имени исходной английской локали.

MineAI уже умел находить такие файлы регистронезависимо:

- `en_us.json`
- `EN_US.JSON`
- `En_Us.Json`
- другие комбинации регистра

Однако после обнаружения файла `LooseJsonProcessor` строил путь целевой локализации через обычный регистрозависимый `str.replace("en_us.json", ...)`.

Из-за этого для файла, например:

`config/.../lang/EN_US.JSON`

замена не происходила.

Вместо ожидаемого:

`EN_US.JSON -> ru_ru.json`

получалось:

`source = .../EN_US.JSON`
`target = .../EN_US.JSON`

То есть source и target становились одним и тем же файлом.

## Почему это было опасно

В режиме `output_mode="inplace"` после перевода MineAI записывает сформированный JSON непосредственно в target path.

До исправления при uppercase/mixed-case source target path мог совпасть с source path.

Сценарий выглядел так:

`EN_US.JSON`
↓
MineAI корректно находит файл как английскую локаль
↓
case-sensitive `replace()` не меняет имя
↓
target path остаётся равным source path
↓
перевод выполняется
↓
translated payload записывается обратно в `EN_US.JSON`

Таким образом исходная английская локализация могла быть заменена переводом.

Для `inplace` это особенно опасно, потому что пользователь ожидает создание отдельного файла целевой локали, а не изменение исходного English locale-файла.

Проблема также затрагивала режим Resource Pack.

В этом режиме исходный файл на диске не уничтожался, но неправильный target path всё равно использовался.

Например:

`assets/example/lang/EN_US.JSON`

мог попасть в создаваемый resource pack под именем:

`assets/example/lang/EN_US.JSON`

хотя его содержимое уже являлось переводом.

Ожидаемый путь должен быть:

`assets/example/lang/ru_ru.json`

Из-за неправильного locale filename Minecraft мог не увидеть перевод как `ru_ru` или воспринимать переведённый файл как английскую локализацию.

Таким образом ошибка влияла одновременно на безопасность `inplace` и на корректность создаваемых Resource Packs.

## Root cause

Discovery и processor использовали разные правила обработки регистра.

Discovery уже корректно использовал регистронезависимую проверку:

```python
name.lower() == "en_us.json"