### PR TITLE
fix: prevent stale BQ backups from replacing updated quests

### DIFF
--- a/mineai/processors/bq_baseline.py
+++ b/mineai/processors/bq_baseline.py
@@ -1,0 +1,218 @@
+"""Hash-verified BetterQuesting baselines for safe in-place Force mode."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+import shutil
+
+from mineai.io_utils import atomic_write_text
+
+
+_STATE_VERSION = 1
+_STATE_SUFFIX = ".bak.mineai"
+_TRANSLATABLE_SENTINEL = "<mineai-translatable>"
+
+
+@dataclass(frozen=True)
+class BQForceBaselineDecision:
+    source_path: str
+    backup_path: str
+    refresh_backup: bool
+    stale_backup_path: str | None
+    reason: str
+
+
+def _state_path(file_path: str) -> str:
+    return file_path + _STATE_SUFFIX
+
+
+def _sha256_file(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_state(file_path: str) -> dict[str, str | int] | None:
+    try:
+        with open(_state_path(file_path), encoding="utf-8") as handle:
+            state = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    if not isinstance(state, dict) or state.get("version") != _STATE_VERSION:
+        return None
+    baseline_hash = state.get("baseline_sha256")
+    output_hash = state.get("output_sha256")
+    if not isinstance(baseline_hash, str) or not isinstance(output_hash, str):
+        return None
+    return state
+
+
+def _load_json(path: str) -> dict | None:
+    try:
+        with open(path, encoding="utf-8") as handle:
+            value = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _without_bq_translatable_values(data: dict) -> dict:
+    """Return a copy where only BQ name/desc payloads are neutralized."""
+    normalized = deepcopy(data)
+    properties_key = next(
+        (key for key in normalized if key.startswith("properties")),
+        None,
+    )
+    if not properties_key or not isinstance(normalized.get(properties_key), dict):
+        return normalized
+
+    properties = normalized[properties_key]
+    bq_key = next(
+        (key for key in properties if key.startswith("betterquesting")),
+        None,
+    )
+    if not bq_key or not isinstance(properties.get(bq_key), dict):
+        return normalized
+
+    bq_data = properties[bq_key]
+    for key in list(bq_data):
+        if key.startswith("name") or key.startswith("desc"):
+            bq_data[key] = _TRANSLATABLE_SENTINEL
+    return normalized
+
+
+def _legacy_backup_has_same_structure(file_path: str, backup: str) -> bool:
+    """Recognize old MineAI backups when only translated fields differ."""
+    current = _load_json(file_path)
+    baseline = _load_json(backup)
+    if current is None or baseline is None:
+        return False
+    return (
+        _without_bq_translatable_values(current)
+        == _without_bq_translatable_values(baseline)
+    )
+
+
+def baseline_tracks_current(file_path: str) -> bool:
+    """Return True only when the current BQ file is tied to its backup safely."""
+    backup = file_path + ".bak"
+    if not os.path.exists(backup):
+        return False
+
+    try:
+        current_hash = _sha256_file(file_path)
+        backup_hash = _sha256_file(backup)
+    except OSError:
+        return False
+    if current_hash == backup_hash:
+        return True
+
+    state = _load_state(file_path)
+    if (
+        state
+        and state["baseline_sha256"] == backup_hash
+        and state["output_sha256"] == current_hash
+    ):
+        return True
+
+    # Compatibility for backups created before hash-state existed. Trust them
+    # only when all non-translatable JSON structure still matches exactly.
+    return state is None and _legacy_backup_has_same_structure(file_path, backup)
+
+
+def resolve_bq_force_baseline(file_path: str) -> BQForceBaselineDecision:
+    """Choose a Force source without blindly trusting an existing ``.bak``."""
+    backup = file_path + ".bak"
+    if not os.path.exists(backup):
+        return BQForceBaselineDecision(
+            source_path=file_path,
+            backup_path=backup,
+            refresh_backup=True,
+            stale_backup_path=None,
+            reason="backup missing",
+        )
+
+    current_hash = _sha256_file(file_path)
+    backup_hash = _sha256_file(backup)
+    if current_hash == backup_hash:
+        return BQForceBaselineDecision(
+            source_path=backup,
+            backup_path=backup,
+            refresh_backup=False,
+            stale_backup_path=None,
+            reason="backup matches current source",
+        )
+
+    state = _load_state(file_path)
+    if (
+        state
+        and state["baseline_sha256"] == backup_hash
+        and state["output_sha256"] == current_hash
+    ):
+        return BQForceBaselineDecision(
+            source_path=backup,
+            backup_path=backup,
+            refresh_backup=False,
+            stale_backup_path=None,
+            reason="backup matches recorded MineAI baseline",
+        )
+
+    if state is None and _legacy_backup_has_same_structure(file_path, backup):
+        return BQForceBaselineDecision(
+            source_path=backup,
+            backup_path=backup,
+            refresh_backup=False,
+            stale_backup_path=None,
+            reason="legacy backup matches current JSON structure",
+        )
+
+    return BQForceBaselineDecision(
+        source_path=file_path,
+        backup_path=backup,
+        refresh_backup=True,
+        stale_backup_path=f"{backup}.stale-{backup_hash[:12]}",
+        reason="existing backup cannot be proven current",
+    )
+
+
+def refresh_bq_force_baseline(
+    file_path: str,
+    decision: BQForceBaselineDecision,
+) -> None:
+    """Preserve an untrusted backup, then refresh the active baseline."""
+    if not decision.refresh_backup:
+        return
+
+    if os.path.exists(decision.backup_path) and decision.stale_backup_path:
+        if not os.path.exists(decision.stale_backup_path):
+            shutil.copy2(decision.backup_path, decision.stale_backup_path)
+
+    shutil.copy2(file_path, decision.backup_path)
+    try:
+        os.remove(_state_path(file_path))
+    except FileNotFoundError:
+        pass
+
+
+def write_bq_baseline_state(file_path: str) -> None:
+    """Record which output was produced from the active ``.bak`` baseline."""
+    backup = file_path + ".bak"
+    if not os.path.exists(backup):
+        raise FileNotFoundError(backup)
+
+    state = {
+        "version": _STATE_VERSION,
+        "baseline_sha256": _sha256_file(backup),
+        "output_sha256": _sha256_file(file_path),
+    }
+    atomic_write_text(
+        _state_path(file_path),
+        json.dumps(state, ensure_ascii=False, indent=2, sort_keys=True),
+    )

--- a/mineai/processors/bq_json.py
+++ b/mineai/processors/bq_json.py
@@ -6,6 +6,12 @@ from mineai.engines.base import EngineCallbacks
 from mineai.engines.service import TranslationService
 from mineai.io_utils import atomic_write_text
 from mineai.language_validation import uses_same_latin_script
+from mineai.processors.bq_baseline import (
+    baseline_tracks_current,
+    refresh_bq_force_baseline,
+    resolve_bq_force_baseline,
+    write_bq_baseline_state,
+)
 from mineai.processors.selection import skip_threshold_reached
 from mineai.processors.translation_state import collect_bq_selection_with_baseline
 from mineai.runtime.state import JobState
@@ -24,10 +30,20 @@ class BQProcessor:
 
     def process(self, file_path: str, *, target_lang: dict, mode: str) -> None:
         backup = file_path + ".bak"
+        force_baseline = (
+            resolve_bq_force_baseline(file_path)
+            if mode == "force"
+            else None
+        )
         source_path = (
-            backup
-            if mode == "force" and os.path.exists(backup)
+            force_baseline.source_path
+            if force_baseline is not None
             else file_path
+        )
+        baseline_trusted = (
+            not force_baseline.refresh_backup
+            if force_baseline is not None
+            else baseline_tracks_current(file_path)
         )
 
         with open(source_path, "r", encoding="utf-8") as source_file:
@@ -61,8 +77,19 @@ class BQProcessor:
             )
             return
 
-        if not os.path.exists(backup):
+        if force_baseline is not None and force_baseline.refresh_backup:
+            if os.path.exists(backup):
+                self.callbacks.on_log(
+                    f"⚠ BQ {os.path.basename(file_path)}: существующий .bak "
+                    "не подтверждён для текущего файла; baseline обновлён "
+                    "из current перед Force",
+                    "yellow",
+                )
+            refresh_bq_force_baseline(file_path, force_baseline)
+            baseline_trusted = True
+        elif not os.path.exists(backup):
             shutil.copy2(file_path, backup)
+            baseline_trusted = True
 
         name = (
             os.path.basename(os.path.dirname(file_path))
@@ -92,3 +119,12 @@ class BQProcessor:
 
         payload = json.dumps(data, indent=2, ensure_ascii=False)
         atomic_write_text(file_path, payload)
+        if baseline_trusted:
+            try:
+                write_bq_baseline_state(file_path)
+            except OSError as exc:
+                self.callbacks.on_log(
+                    f"⚠ Не удалось сохранить BQ baseline state для "
+                    f"{os.path.basename(file_path)}: {exc}",
+                    "yellow",
+                )

--- a/mineai/processors/estimator.py
+++ b/mineai/processors/estimator.py
@@ -9,6 +9,7 @@ from mineai.constants import (
     RESEARCH_PATH_MARKERS,
 )
 from mineai.json_utils import load_lenient_json
+from mineai.processors.bq_baseline import resolve_bq_force_baseline
 from mineai.processors.locale_keys import (
     collect_lang_keys_to_translate,
     count_translatable_lang_entries,
@@ -397,10 +398,9 @@ class StringEstimator:
         mode: str,
         target_regex: str,
     ) -> int:
-        backup = path + ".bak"
         source_path = (
-            backup
-            if mode == "force" and os.path.exists(backup)
+            resolve_bq_force_baseline(path).source_path
+            if mode == "force"
             else path
         )
         try:

--- a/tests/test_bq_force_baseline_safety.py
+++ b/tests/test_bq_force_baseline_safety.py
@@ -1,0 +1,286 @@
+import hashlib
+import json
+from pathlib import Path
+import shutil
+import tempfile
+import unittest
+
+from mineai.engines.base import EngineCallbacks
+from mineai.processors.bq_baseline import write_bq_baseline_state
+from mineai.processors.bq_json import BQProcessor
+from mineai.processors.estimator import StringEstimator
+from mineai.runtime.state import JobState
+
+
+TARGET_LANG = {
+    "api": "ru",
+    "file": "ru_ru",
+    "name": "Russian",
+    "regex": r"[А-Яа-яЁё]",
+}
+
+
+class _Service:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, str]] = []
+
+    def translate_dict(self, strings, _target_lang, _callbacks, **_kwargs):
+        self.calls.append(dict(strings))
+        return {
+            key: f"Перевод: {value}"
+            for key, value in strings.items()
+        }
+
+
+def _callbacks(state: JobState) -> EngineCallbacks:
+    return EngineCallbacks(
+        should_run=state.should_run,
+        wait_if_paused=state.wait_if_paused,
+        on_log=lambda *_args: None,
+        on_status=lambda *_args: None,
+    )
+
+
+def _quest(name: str, desc: str | None = None, *, version: int = 1) -> dict:
+    bq = {"name:8": name}
+    if desc is not None:
+        bq["desc:8"] = desc
+    return {
+        "properties:10": {"betterquesting:10": bq},
+        "modpack_version": version,
+        "preserved_payload": {"keep": version},
+    }
+
+
+def _write(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+
+
+class BetterQuestingForceBaselineSafetyTests(unittest.TestCase):
+    def test_tracked_stale_backup_uses_updated_current_and_preserves_structure(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "Quest.json"
+            backup = Path(str(path) + ".bak")
+
+            old_source = _quest("Old title", version=1)
+            _write(path, old_source)
+            shutil.copy2(path, backup)
+
+            _write(path, _quest("Старый перевод", version=1))
+            write_bq_baseline_state(str(path))
+
+            updated_source = _quest(
+                "Updated title",
+                "Brand new objective",
+                version=2,
+            )
+            updated_bytes = json.dumps(
+                updated_source,
+                ensure_ascii=False,
+            ).encode("utf-8")
+            path.write_bytes(updated_bytes)
+
+            state = JobState(is_running=True)
+            estimator = StringEstimator(state)
+            self.assertEqual(
+                estimator._estimate_bq(
+                    str(path),
+                    "force",
+                    TARGET_LANG["regex"],
+                ),
+                2,
+            )
+
+            service = _Service()
+            BQProcessor(service, state, _callbacks(state)).process(
+                str(path),
+                target_lang=TARGET_LANG,
+                mode="force",
+            )
+
+            self.assertEqual(
+                service.calls,
+                [{
+                    "name:8": "Updated title",
+                    "desc:8": "Brand new objective",
+                }],
+            )
+            output = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(output["modpack_version"], 2)
+            self.assertEqual(output["preserved_payload"], {"keep": 2})
+            bq = output["properties:10"]["betterquesting:10"]
+            self.assertEqual(bq["name:8"], "Перевод: Updated title")
+            self.assertEqual(
+                bq["desc:8"],
+                "Перевод: Brand new objective",
+            )
+
+            self.assertEqual(backup.read_bytes(), updated_bytes)
+            old_hash = hashlib.sha256(
+                json.dumps(old_source, ensure_ascii=False).encode("utf-8")
+            ).hexdigest()[:12]
+            stale = Path(f"{backup}.stale-{old_hash}")
+            self.assertTrue(stale.exists())
+            self.assertEqual(
+                json.loads(stale.read_text(encoding="utf-8")),
+                old_source,
+            )
+            self.assertTrue(Path(str(path) + ".bak.mineai").exists())
+
+            second_service = _Service()
+            BQProcessor(second_service, state, _callbacks(state)).process(
+                str(path),
+                target_lang=TARGET_LANG,
+                mode="force",
+            )
+            self.assertEqual(
+                second_service.calls,
+                [{
+                    "name:8": "Updated title",
+                    "desc:8": "Brand new objective",
+                }],
+            )
+
+    def test_legacy_structurally_matching_backup_keeps_force_semantics(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "Quest.json"
+            backup = Path(str(path) + ".bak")
+            source = _quest("Original title", "Original objective", version=1)
+            translated = _quest(
+                "Предыдущий перевод",
+                "Предыдущее описание",
+                version=1,
+            )
+            _write(backup, source)
+            _write(path, translated)
+
+            state = JobState(is_running=True)
+            service = _Service()
+            BQProcessor(service, state, _callbacks(state)).process(
+                str(path),
+                target_lang=TARGET_LANG,
+                mode="force",
+            )
+
+            self.assertEqual(
+                service.calls,
+                [{
+                    "name:8": "Original title",
+                    "desc:8": "Original objective",
+                }],
+            )
+            self.assertEqual(
+                json.loads(backup.read_text(encoding="utf-8")),
+                source,
+            )
+            self.assertEqual(
+                list(Path(temp_dir).glob("Quest.json.bak.stale-*")),
+                [],
+            )
+            self.assertTrue(Path(str(path) + ".bak.mineai").exists())
+
+    def test_legacy_unverified_backup_fails_safe_to_current_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "Quest.json"
+            backup = Path(str(path) + ".bak")
+            old_source = _quest("Legacy title", version=1)
+            updated_source = _quest(
+                "Current title",
+                "Current objective",
+                version=3,
+            )
+            _write(backup, old_source)
+            _write(path, updated_source)
+
+            state = JobState(is_running=True)
+            service = _Service()
+            BQProcessor(service, state, _callbacks(state)).process(
+                str(path),
+                target_lang=TARGET_LANG,
+                mode="force",
+            )
+
+            self.assertEqual(
+                service.calls[0],
+                {
+                    "name:8": "Current title",
+                    "desc:8": "Current objective",
+                },
+            )
+            self.assertEqual(
+                json.loads(backup.read_text(encoding="utf-8")),
+                updated_source,
+            )
+            stale_files = list(Path(temp_dir).glob("Quest.json.bak.stale-*"))
+            self.assertEqual(len(stale_files), 1)
+            self.assertEqual(
+                json.loads(stale_files[0].read_text(encoding="utf-8")),
+                old_source,
+            )
+
+    def test_unchanged_tracked_output_still_forces_from_english_backup(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "Quest.json"
+            backup = Path(str(path) + ".bak")
+            source = _quest("Original title", "Original objective")
+            _write(backup, source)
+            _write(
+                path,
+                _quest("Предыдущий перевод", "Предыдущее описание"),
+            )
+            write_bq_baseline_state(str(path))
+
+            state = JobState(is_running=True)
+            service = _Service()
+            BQProcessor(service, state, _callbacks(state)).process(
+                str(path),
+                target_lang=TARGET_LANG,
+                mode="force",
+            )
+
+            self.assertEqual(
+                service.calls,
+                [{
+                    "name:8": "Original title",
+                    "desc:8": "Original objective",
+                }],
+            )
+            self.assertEqual(
+                list(Path(temp_dir).glob("Quest.json.bak.stale-*")),
+                [],
+            )
+
+    def test_corrupt_state_never_restores_structurally_stale_backup(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "Quest.json"
+            backup = Path(str(path) + ".bak")
+            _write(backup, _quest("Old title"))
+            _write(path, _quest("Updated title", "New field", version=2))
+            Path(str(path) + ".bak.mineai").write_text(
+                "not-json",
+                encoding="utf-8",
+            )
+
+            state = JobState(is_running=True)
+            service = _Service()
+            BQProcessor(service, state, _callbacks(state)).process(
+                str(path),
+                target_lang=TARGET_LANG,
+                mode="force",
+            )
+
+            self.assertEqual(
+                service.calls[0],
+                {
+                    "name:8": "Updated title",
+                    "desc:8": "New field",
+                },
+            )
+            self.assertEqual(
+                json.loads(backup.read_text(encoding="utf-8"))["modpack_version"],
+                2,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
PR исправляет критический риск потери данных в BetterQuesting при режиме Force.

Раньше MineAI безусловно использовал существующий .bak как исходник. Если модпак обновлялся, а .bak оставался от старой версии, программа могла загрузить старую структуру квестов и записать её поверх актуального Quest.json, удалив новые квесты, поля или metadata.

Теперь .bak проверяется через hash-based baseline. Если backup подтверждён — Force работает как раньше, переводя из оригинального source. Если backup устарел — он сохраняется как stale-копия, а новый baseline создаётся из актуального файла.

Также estimator использует ту же логику, чтобы подсчёт и реальная обработка не расходились.

Итог: безопаснее обновления модпаков, надёжнее Force, меньше риска скрытой потери BetterQuesting-данных, без изменения движков перевода и GUI.