### PR TITLE
fix(markdown): preserve AE2 guide discovery and Markdown structure

### DIFF
--- a/mineai/processors/analyzer.py
+++ b/mineai/processors/analyzer.py
@@ -3,9 +3,15 @@ import os
 import re
 import zipfile
 
-from mineai.constants import BOOK_PATH_MARKERS, MD_PATH_MARKERS, RESEARCH_PATH_MARKERS
+from mineai.constants import BOOK_PATH_MARKERS, RESEARCH_PATH_MARKERS
 from mineai.json_utils import iter_translatable_strings, load_lenient_json
 from mineai.mod_names import get_mod_name
+from mineai.processors.markdown_guides import (
+    get_markdown_target_path,
+    is_source_markdown_guide,
+    is_target_markdown_locale_path,
+)
+from mineai.processors.selection import collect_book_markdown_selection
 from mineai.processors.snbt_extract import extract_snbt_strings
 from mineai.runtime.state import JobState
 from mineai.text_processing import (
@@ -109,13 +115,15 @@ class ModpackAnalyzer:
     def _analyze_jar(self, path, target_file, target_regex, translate_mods, translate_books, on_row, mod_name):
         total_en = 0
         total_tr = 0
+        target_code = target_file.replace(".json", "")
         try:
             with zipfile.ZipFile(path, "r") as zin:
                 locale = {
                     i.filename.lower(): i
                     for i in zin.infolist()
                     if target_file in i.filename.lower()
-                    or f"/{target_file.replace('.json','')}/" in i.filename.lower()
+                    or f"/{target_code}/" in i.filename.lower()
+                    or is_target_markdown_locale_path(i.filename, target_code)
                 }
                 if translate_mods:
                     en, tr = self._analyze_mods_ui(zin, locale, target_file, mod_name, on_row)
@@ -154,6 +162,7 @@ class ModpackAnalyzer:
 
     def _analyze_books(self, zin, locale, target_file, target_regex, mod_name, on_row):
         b_en = b_tr = m_en = m_tr = 0
+        target_code = target_file.replace(".json", "")
         for item in zin.infolist():
             fl = item.filename.lower()
             is_jb = (
@@ -164,15 +173,11 @@ class ModpackAnalyzer:
                     or any(x in fl for x in RESEARCH_PATH_MARKERS)
                 )
             )
-            is_mb = (
-                (fl.endswith(".md") or fl.endswith(".txt"))
-                and "/en_us/" in fl
-                and any(x in fl for x in MD_PATH_MARKERS)
-            )
+            is_mb = is_source_markdown_guide(item.filename)
             if is_jb:
                 try:
                     en = load_lenient_json(zin.read(item))
-                    tr_path = fl.replace("/en_us/", f"/{target_file.replace('.json','')}/")
+                    tr_path = fl.replace("/en_us/", f"/{target_code}/")
                     tr = load_lenient_json(zin.read(locale[tr_path])) if tr_path in locale else {}
                     en_s = [s for p, s in iter_translatable_strings(en) if s.strip() and looks_like_source_language(s)]
                     tr_s = [s for p, s in iter_translatable_strings(tr)] if tr else []
@@ -185,27 +190,21 @@ class ModpackAnalyzer:
             elif is_mb:
                 try:
                     en_t = zin.read(item).decode("utf-8-sig", errors="ignore")
-                    tr_path = fl.replace("/en_us/", f"/{target_file.replace('.json','')}/") if "/en_us/" in fl else fl
-                    tr_t = zin.read(locale[tr_path]).decode("utf-8-sig", errors="ignore") if tr_path in locale else ""
-                    tr_lines = tr_t.split("\n")
-                    in_yaml = False
-                    for idx, line in enumerate(en_t.split("\n")):
-                        if line.strip() == "---":
-                            in_yaml = not in_yaml
-                            continue
-                        if in_yaml:
-                            m = re.match(r'^(\s*title\s*:\s*[\'"]?)(.*?)([\'"]?)$', line, re.IGNORECASE)
-                            if m and looks_like_source_language(m.group(2)):
-                                m_en += 1
-                                if idx < len(tr_lines) and already_translated(tr_lines[idx], target_regex):
-                                    m_tr += 1
-                            continue
-                        if line.strip().startswith("<") or line.strip().startswith("!["):
-                            continue
-                        if line.strip() and looks_like_source_language(line) and not is_technical_term(line):
-                            m_en += 1
-                            if idx < len(tr_lines) and already_translated(tr_lines[idx], target_regex):
-                                m_tr += 1
+                    tr_path = get_markdown_target_path(item.filename, target_code)
+                    tr_key = tr_path.lower()
+                    tr_t = (
+                        zin.read(locale[tr_key]).decode("utf-8-sig", errors="ignore")
+                        if tr_key in locale
+                        else ""
+                    )
+                    selection = collect_book_markdown_selection(
+                        en_t,
+                        tr_t,
+                        "append",
+                        smart_glue=False,
+                    )
+                    m_en += selection.total_translatable
+                    m_tr += selection.total_translatable - len(selection.pending)
                 except OSError:
                     pass
         if b_en:

--- a/mineai/processors/estimator.py
+++ b/mineai/processors/estimator.py
@@ -5,7 +5,6 @@ import zipfile
 
 from mineai.constants import (
     BOOK_PATH_MARKERS,
-    MD_PATH_MARKERS,
     RESEARCH_PATH_MARKERS,
 )
 from mineai.json_utils import load_lenient_json
@@ -13,6 +12,11 @@ from mineai.processors.bq_baseline import resolve_bq_force_baseline
 from mineai.processors.locale_keys import (
     collect_lang_keys_to_translate,
     count_translatable_lang_entries,
+)
+from mineai.processors.markdown_guides import (
+    get_markdown_target_path,
+    is_source_markdown_guide,
+    is_target_markdown_locale_path,
 )
 from mineai.processors.selection import (
     collect_book_json_selection,
@@ -113,6 +117,10 @@ class StringEstimator:
                     for item in archive.infolist()
                     if target_file in item.filename.lower()
                     or f"/{target_lang['file']}/" in item.filename.lower()
+                    or is_target_markdown_locale_path(
+                        item.filename,
+                        target_lang["file"],
+                    )
                 }
                 for item in archive.infolist():
                     file_lower = item.filename.lower()
@@ -130,17 +138,7 @@ class StringEstimator:
                             )
                         )
                     )
-                    is_book_md = (
-                        (
-                            file_lower.endswith(".md")
-                            or file_lower.endswith(".txt")
-                        )
-                        and "/en_us/" in file_lower
-                        and any(
-                            marker in file_lower
-                            for marker in MD_PATH_MARKERS
-                        )
-                    )
+                    is_book_md = is_source_markdown_guide(item.filename)
                     is_lang = (
                         file_lower.endswith("en_us.json")
                         and not is_book_json
@@ -278,11 +276,9 @@ class StringEstimator:
         except OSError:
             return 0
 
-        target_path = re.sub(
-            r"/en_us/",
-            f"/{target_lang['file']}/",
+        target_path = get_markdown_target_path(
             item.filename,
-            flags=re.IGNORECASE,
+            target_lang["file"],
         )
         target_text = ""
         target_key = target_path.lower()

--- a/mineai/processors/jar.py
+++ b/mineai/processors/jar.py
@@ -3,7 +3,7 @@ import os
 import re
 import zipfile
 
-from mineai.constants import BOOK_PATH_MARKERS, MD_PATH_MARKERS, RESEARCH_PATH_MARKERS
+from mineai.constants import BOOK_PATH_MARKERS, RESEARCH_PATH_MARKERS
 from mineai.engines.base import EngineCallbacks
 from mineai.engines.service import TranslationService
 from mineai.json_utils import (
@@ -17,6 +17,11 @@ from mineai.output.pack_writer import PackWriter
 from mineai.processors.locale_keys import (
     collect_lang_keys_to_translate,
     count_translatable_lang_entries,
+)
+from mineai.processors.markdown_guides import (
+    get_markdown_target_path,
+    is_source_markdown_guide,
+    is_target_markdown_locale_path,
 )
 from mineai.processors.selection import (
     build_book_json_output,
@@ -75,6 +80,10 @@ class JarProcessor:
                     for item in zin.infolist()
                     if target_file in item.filename.lower()
                     or f"/{target_lang['file']}/" in item.filename.lower()
+                    or is_target_markdown_locale_path(
+                        item.filename,
+                        target_lang["file"],
+                    )
                 }
 
                 try:
@@ -90,6 +99,10 @@ class JarProcessor:
                             if (
                                 target_file not in fl
                                 and f"/{target_lang['file']}/" not in fl
+                                and not is_target_markdown_locale_path(
+                                    item.filename,
+                                    target_lang["file"],
+                                )
                             ):
                                 zout.writestr(item, zin.read(item))
 
@@ -101,11 +114,7 @@ class JarProcessor:
                                 or any(m in fl for m in RESEARCH_PATH_MARKERS)
                             )
                         )
-                        is_book_md = (
-                            (fl.endswith(".md") or fl.endswith(".txt"))
-                            and "/en_us/" in fl
-                            and any(m in fl for m in MD_PATH_MARKERS)
-                        )
+                        is_book_md = is_source_markdown_guide(item.filename)
                         is_lang = fl.endswith("en_us.json") and not is_book_json
 
                         if translate_mods and is_lang:
@@ -155,6 +164,10 @@ class JarProcessor:
                             is_target = (
                                 target_file in fl
                                 or f"/{target_lang['file']}/" in fl
+                                or is_target_markdown_locale_path(
+                                    item.filename,
+                                    target_lang["file"],
+                                )
                             )
                             if is_target and item.filename not in written_inplace:
                                 zout.writestr(item, zin.read(item))
@@ -363,16 +376,9 @@ class JarProcessor:
         self, zin, zout, item, locale_files, target_lang, mode,
         output_mode, pack_writer, mod_name, written_inplace,
     ) -> bool:
-        fl = item.filename.lower()
-        tr_path = (
-            re.sub(
-                r"/en_us/",
-                f"/{target_lang['file']}/",
-                item.filename,
-                flags=re.IGNORECASE,
-            )
-            if "/en_us/" in fl
-            else item.filename
+        tr_path = get_markdown_target_path(
+            item.filename,
+            target_lang["file"],
         )
         tr_key = tr_path.lower()
         try:
@@ -459,4 +465,3 @@ class JarProcessor:
             written_inplace.add(tr_path)
             return True
         return False
-

--- a/mineai/processors/markdown_guides.py
+++ b/mineai/processors/markdown_guides.py
@@ -8,7 +8,7 @@ from mineai.constants import MD_PATH_MARKERS
 
 
 _GUIDEME_ROOT = "/ae2guide/"
-_GUIDEME_LOCALE_DIR_RE = re.compile(r"^_[a-z]{2}_[a-z]{2}$", re.IGNORECASE)
+_GUIDEME_LOCALE_DIR_RE = re.compile(r"^_?[a-z]{2}_[a-z]{2}$", re.IGNORECASE)
 _GUIDEME_ROOT_RE = re.compile(r"(^|/)(ae2guide/)", re.IGNORECASE)
 _SOURCE_LOCALE_RE = re.compile(r"/en_us/", re.IGNORECASE)
 

--- a/mineai/processors/markdown_guides.py
+++ b/mineai/processors/markdown_guides.py
@@ -1,0 +1,67 @@
+"""Shared Markdown guide classification and locale-path helpers."""
+
+from __future__ import annotations
+
+import re
+
+from mineai.constants import MD_PATH_MARKERS
+
+
+_GUIDEME_ROOT = "/ae2guide/"
+_GUIDEME_LOCALE_DIR_RE = re.compile(r"^_[a-z]{2}_[a-z]{2}$", re.IGNORECASE)
+_GUIDEME_ROOT_RE = re.compile(r"(^|/)(ae2guide/)", re.IGNORECASE)
+_SOURCE_LOCALE_RE = re.compile(r"/en_us/", re.IGNORECASE)
+
+
+def _slash_path(path: str) -> str:
+    return path.replace("\\", "/")
+
+
+def _normalized(path: str) -> str:
+    return "/" + _slash_path(path).lstrip("/").lower()
+
+
+def is_source_markdown_guide(path: str) -> bool:
+    """Return whether a JAR entry is a supported source-language MD/TXT guide."""
+    normalized = _normalized(path)
+    if not normalized.endswith((".md", ".txt")):
+        return False
+
+    # Preserve the project's existing /en_us/ guide support exactly.
+    if "/en_us/" in normalized:
+        return any(marker in normalized for marker in MD_PATH_MARKERS)
+
+    # GuideME/AE2 stores its default-language pages directly below ae2guide,
+    # while translations live below _<language_code>/.
+    if _GUIDEME_ROOT not in normalized:
+        return False
+
+    tail = normalized.split(_GUIDEME_ROOT, 1)[1]
+    first_segment = tail.split("/", 1)[0]
+    return not _GUIDEME_LOCALE_DIR_RE.fullmatch(first_segment)
+
+
+def get_markdown_target_path(path: str, target_code: str) -> str:
+    """Resolve a supported source guide path to its target-locale path."""
+    slash_path = _slash_path(path)
+    if _SOURCE_LOCALE_RE.search(slash_path):
+        return _SOURCE_LOCALE_RE.sub(
+            f"/{target_code}/",
+            slash_path,
+            count=1,
+        )
+
+    if _GUIDEME_ROOT_RE.search(slash_path):
+        return _GUIDEME_ROOT_RE.sub(
+            lambda match: f"{match.group(1)}{match.group(2)}_{target_code}/",
+            slash_path,
+            count=1,
+        )
+
+    raise ValueError(f"Unsupported Markdown guide source path: {path}")
+
+
+def is_target_markdown_locale_path(path: str, target_code: str) -> bool:
+    """Return whether a path belongs to a GuideME target-locale subtree."""
+    normalized = _normalized(path)
+    return f"/_{target_code.lower()}/" in normalized

--- a/mineai/processors/selection.py
+++ b/mineai/processors/selection.py
@@ -9,16 +9,23 @@ from mineai.json_utils import (
     path_to_key,
 )
 from mineai.text_processing import (
-    apply_smart_glue,
+    PLACEHOLDER_PATTERN,
     is_technical_term,
     looks_like_source_language,
+    mask_protected_fragments,
 )
 
 
 YAML_TITLE_RE = re.compile(
-    r'^(\s*title\s*:\s*[\'"]?)(.*?)([\'"]?)$',
+    r'^(\s*title\s*:\s*[\'\"]?)(.*?)([\'\"]?)$',
     re.IGNORECASE,
 )
+_MARKDOWN_BLOCK_MARKER_RE = re.compile(
+    r"^(?:#{1,6}[ \t]+|[-+*][ \t]+|\d+[.)][ \t]+|>[ \t]*)"
+)
+_MARKDOWN_LIST_MARKER_RE = re.compile(r"^(?:[-+*]|\d+[.)])[ \t]+$")
+_MARKDOWN_TASK_MARKER_RE = re.compile(r"^\[[ xX]\][ \t]+")
+_FENCED_CODE_RE = re.compile(r"^[ \t]{0,3}(?P<fence>`{3,}|~{3,})")
 
 
 def skip_threshold_reached(total_translatable: int, pending_count: int) -> bool:
@@ -93,6 +100,9 @@ class MarkdownSelection:
     source_text: str
     lines_out: list[str]
     pending: dict[str, str]
+    # Exact structural affixes reconstructed by JarProcessor after translation.
+    # The historical field name is kept so the writer does not need a parallel
+    # Markdown-only translation path.
     title_meta: dict[str, tuple[str, str]]
     total_translatable: int
 
@@ -104,6 +114,72 @@ def _extract_yaml_title(line: str) -> tuple[str, str, str] | None:
     return match.group(1), match.group(2), match.group(3)
 
 
+def split_markdown_block_structure(line: str) -> tuple[str, str, str]:
+    """Return exact ``(prefix, payload, suffix)`` for a Markdown prose line.
+
+    Block-level syntax is kept out of TranslationService. This is deliberately
+    lightweight rather than an AST: preserve leading indentation, consume
+    heading/list/quote/task markers, and preserve trailing whitespace/hard-break
+    syntax. The remaining payload can safely use the shared inline masker.
+    """
+    leading = re.match(r"^[ \t]*", line)
+    prefix = leading.group(0) if leading else ""
+    payload = line[len(prefix) :]
+
+    for _ in range(8):
+        marker_match = _MARKDOWN_BLOCK_MARKER_RE.match(payload)
+        if not marker_match:
+            break
+        marker = marker_match.group(0)
+        prefix += marker
+        payload = payload[len(marker) :]
+
+        if _MARKDOWN_LIST_MARKER_RE.fullmatch(marker):
+            task_match = _MARKDOWN_TASK_MARKER_RE.match(payload)
+            if task_match:
+                task_marker = task_match.group(0)
+                prefix += task_marker
+                payload = payload[len(task_marker) :]
+
+    suffix = ""
+
+    # Closing ATX heading markers are structural as well, e.g. ``## Title ##``.
+    if re.match(r"^[ \t]*#{1,6}[ \t]+", prefix):
+        closing = re.match(r"^(.*?)([ \t]+#+[ \t]*)$", payload)
+        if closing:
+            payload, suffix = closing.group(1), closing.group(2)
+
+    # Preserve trailing spaces/tabs exactly. In Markdown, two trailing spaces are
+    # a hard line break and must never be normalized by the translation service.
+    if not suffix:
+        trailing = re.match(r"^(.*?)([ \t]+)$", payload)
+        if trailing:
+            payload, suffix = trailing.group(1), trailing.group(2)
+
+    return prefix, payload, suffix
+
+
+def _markdown_payload_has_translatable_prose(payload: str) -> bool:
+    if not payload.strip():
+        return False
+
+    # At this point block-level Markdown structure has already been removed.
+    # Titanium Shield therefore only needs to hide inline technical fragments.
+    masked, _mapping = mask_protected_fragments(payload)
+    residual = PLACEHOLDER_PATTERN.sub("", masked).strip()
+    return bool(
+        residual
+        and looks_like_source_language(residual)
+        and not is_technical_term(residual)
+    )
+
+
+def markdown_line_has_translatable_prose(line: str) -> bool:
+    """Return True when a Markdown line contains human-readable source prose."""
+    _prefix, payload, _suffix = split_markdown_block_structure(line)
+    return _markdown_payload_has_translatable_prose(payload)
+
+
 def collect_book_markdown_selection(
     source_text: str,
     target_text: str,
@@ -112,26 +188,37 @@ def collect_book_markdown_selection(
     smart_glue: bool,
 ) -> MarkdownSelection:
     """Build one shared Markdown/YAML translation plan for estimator and writer."""
-    if smart_glue:
-        source_text = apply_smart_glue(source_text)
-
+    # Do not apply smart glue to the complete Markdown document. TranslationService
+    # applies it to selected payloads, while gluing a whole document can join YAML
+    # fences, images, tables, lists or component lines and change structure.
     source_lines = source_text.split("\n")
     target_lines = target_text.split("\n") if target_text else []
     lines_out = list(source_lines)
     pending: dict[str, str] = {}
-    title_meta: dict[str, tuple[str, str]] = {}
+    structural_meta: dict[str, tuple[str, str]] = {}
     total_translatable = 0
-    in_yaml = False
+
+    # YAML front matter is structural only when it starts the document. A later
+    # ``---`` is a horizontal rule and must not accidentally reopen YAML mode.
+    has_frontmatter = bool(
+        source_lines
+        and source_lines[0].lstrip("\ufeff").strip() == "---"
+    )
+    in_yaml = has_frontmatter
+    in_fenced_code = False
+    fence_char = ""
+    fence_len = 0
 
     for index, line in enumerate(source_lines):
         stripped = line.strip()
-        if stripped == "---":
-            in_yaml = not in_yaml
+
+        if has_frontmatter and index == 0 and stripped == "---":
             continue
 
-        existing_line = target_lines[index] if index < len(target_lines) else ""
-
         if in_yaml:
+            if stripped == "---":
+                in_yaml = False
+                continue
             if not stripped.lower().startswith("title:"):
                 continue
             source_title = _extract_yaml_title(line)
@@ -146,7 +233,8 @@ def collect_book_markdown_selection(
                 continue
 
             total_translatable += 1
-            title_meta[str(index)] = (prefix, suffix)
+            structural_meta[str(index)] = (prefix, suffix)
+            existing_line = target_lines[index] if index < len(target_lines) else ""
             existing_title_parts = _extract_yaml_title(existing_line)
             existing_title = (
                 existing_title_parts[1] if existing_title_parts else ""
@@ -157,18 +245,31 @@ def collect_book_markdown_selection(
                 lines_out[index] = existing_line
             continue
 
-        if stripped.startswith("<") or stripped.startswith("!["):
+        fence_match = _FENCED_CODE_RE.match(line)
+        if fence_match:
+            fence = fence_match.group("fence")
+            if not in_fenced_code:
+                in_fenced_code = True
+                fence_char = fence[0]
+                fence_len = len(fence)
+            elif fence[0] == fence_char and len(fence) >= fence_len:
+                in_fenced_code = False
+                fence_char = ""
+                fence_len = 0
             continue
-        if (
-            not stripped
-            or not looks_like_source_language(line)
-            or is_technical_term(line)
-        ):
+        if in_fenced_code:
+            continue
+
+        block_prefix, payload, block_suffix = split_markdown_block_structure(line)
+        if not _markdown_payload_has_translatable_prose(payload):
             continue
 
         total_translatable += 1
+        existing_line = target_lines[index] if index < len(target_lines) else ""
         if _needs_translation(line, existing_line, mode):
-            pending[str(index)] = line
+            pending[str(index)] = payload
+            if block_prefix or block_suffix:
+                structural_meta[str(index)] = (block_prefix, block_suffix)
         else:
             lines_out[index] = existing_line
 
@@ -176,7 +277,7 @@ def collect_book_markdown_selection(
         source_text=source_text,
         lines_out=lines_out,
         pending=pending,
-        title_meta=title_meta,
+        title_meta=structural_meta,
         total_translatable=total_translatable,
     )
 

--- a/mineai/text_processing.py
+++ b/mineai/text_processing.py
@@ -19,14 +19,17 @@ FORMAT_PATTERN = re.compile(
     r"[&§][0-9a-fk-orlmn]|"
     r"<[^>]+>|"
     r"\{[^\}]+\}|"
+    r"(?<=\])\([^)]+\)|"
     r"\]\([^)]+\)|"
     r"!\[[^\]]*\]|"
     r"\[[a-z0-9_.-]+:[a-z0-9_./-]+\]|"
+    r"\[(?=[^\]\n]+\]\([^)]+\))|"
     r"\([a-z0-9_.-]+:[a-z0-9_./-]+\)|"
     r"\([A-Za-z0-9_./-]+\.md[#a-zA-Z0-9_-]*\)|"
+    r"\||"
     r"\\[nrt]|"
     r"\n|"
-    r"\\+(?![\"])|"
+    r"\\+(?![\\\"])|"
     r"%[0-9.,]*\$?[a-zA-Z%]"
     r")",
     flags=re.IGNORECASE,
@@ -109,7 +112,12 @@ def polish_translation(text: str) -> str:
 
 
 def mask_protected_fragments(text: str) -> tuple[str, dict[str, str]]:
-    """Replace format codes and protected terms with collision-free placeholders."""
+    """Replace inline format codes and protected terms with placeholders.
+
+    Format-level structure (for example Markdown list/heading prefixes) must be
+    removed by its processor before calling TranslationService. This function
+    intentionally protects only fragments that can occur inside text payloads.
+    """
     mapping: dict[str, str] = {}
     reserved_ids = set(PLACEHOLDER_PATTERN.findall(text))
     next_id = 0
@@ -131,7 +139,11 @@ def mask_protected_fragments(text: str) -> tuple[str, dict[str, str]]:
 def unmask_translation(text: str, mapping: dict[str, str]) -> str:
     for token, original in mapping.items():
         idx = token.strip("#[]")
-        text = re.sub(rf"\[\s*#\s*{re.escape(idx)}\s*#\s*\]", lambda _m, o=original: o, text)
+        text = re.sub(
+            rf"\[\s*#\s*{re.escape(idx)}\s*#\s*\]",
+            lambda _m, o=original: o,
+            text,
+        )
     return text
 
 

--- a/tests/test_markdown_guide_locale_classification.py
+++ b/tests/test_markdown_guide_locale_classification.py
@@ -1,0 +1,25 @@
+import unittest
+
+from mineai.processors.markdown_guides import is_source_markdown_guide
+
+
+class MarkdownGuideLocaleClassificationTests(unittest.TestCase):
+    def test_guideme_localized_subdirectories_are_not_sources(self) -> None:
+        for locale_dir in ("_ru_ru", "ru_ru"):
+            with self.subTest(locale_dir=locale_dir):
+                self.assertFalse(
+                    is_source_markdown_guide(
+                        f"assets/ae2/ae2guide/{locale_dir}/getting-started.md"
+                    )
+                )
+
+    def test_guideme_root_page_remains_a_source(self) -> None:
+        self.assertTrue(
+            is_source_markdown_guide(
+                "assets/ae2/ae2guide/getting-started.md"
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_markdown_guide_safety.py
+++ b/tests/test_markdown_guide_safety.py
@@ -1,0 +1,394 @@
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from mineai.engines.base import EngineCallbacks
+from mineai.processors.analyzer import ModpackAnalyzer
+from mineai.processors.estimator import StringEstimator
+from mineai.processors.jar import JarProcessor
+from mineai.processors.markdown_guides import (
+    get_markdown_target_path,
+    is_source_markdown_guide,
+)
+from mineai.processors.selection import (
+    collect_book_markdown_selection,
+    markdown_line_has_translatable_prose,
+)
+from mineai.runtime.state import JobState
+from mineai.text_processing import mask_protected_fragments, unmask_translation
+
+
+TARGET_LANG = {
+    "file": "ru_ru",
+    "api": "ru",
+    "name": "Russian",
+    "regex": r"[А-Яа-яЁё]",
+}
+
+
+class _Config:
+    def __init__(self, smart_glue: bool = False) -> None:
+        self.smart_glue = smart_glue
+
+    def getboolean(self, _section: str, key: str) -> bool:
+        return self.smart_glue if key == "smart_glue" else False
+
+
+class _ShieldingService:
+    def __init__(self, smart_glue: bool = False) -> None:
+        self.config = _Config(smart_glue)
+        self.calls: list[dict[str, str]] = []
+
+    def translate_dict(self, strings, _target_lang, _callbacks, **_kwargs):
+        self.calls.append(dict(strings))
+        translated: dict[str, str] = {}
+        for key, source in strings.items():
+            masked, mapping = mask_protected_fragments(source)
+            translated_masked = masked
+            translated_masked = translated_masked.replace(
+                "is used to store items.",
+                "используется для хранения предметов.",
+            )
+            translated_masked = translated_masked.replace(
+                "This machine stores energy.",
+                "Эта машина хранит энергию.",
+            )
+            translated_masked = translated_masked.replace(
+                "New paragraph",
+                "Новый абзац",
+            )
+            translated[key] = unmask_translation(translated_masked, mapping)
+        return translated
+
+
+class _Writer:
+    def __init__(self) -> None:
+        self.files: dict[str, bytes] = {}
+
+    def write(self, path: str, payload: bytes) -> None:
+        self.files[path] = payload
+
+
+def _callbacks() -> EngineCallbacks:
+    return EngineCallbacks(
+        should_run=lambda: True,
+        wait_if_paused=lambda: None,
+        on_log=lambda *_args: None,
+        on_status=lambda *_args: None,
+        on_progress=lambda *_args: None,
+    )
+
+
+def _state() -> JobState:
+    state = JobState()
+    state.start()
+    return state
+
+
+class MarkdownSelectionSafetyTests(unittest.TestCase):
+    def _selection(self, text: str, *, smart_glue: bool = False):
+        return collect_book_markdown_selection(
+            text,
+            "",
+            "append",
+            smart_glue=smart_glue,
+        )
+
+    def test_markup_only_component_is_not_selected(self) -> None:
+        source = '<ItemLink id="foo" />'
+        selection = self._selection(source)
+
+        self.assertEqual(selection.pending, {})
+        self.assertEqual(selection.total_translatable, 0)
+        self.assertFalse(markdown_line_has_translatable_prose(source))
+
+    def test_itemlink_plus_prose_is_selected_and_tag_round_trips(self) -> None:
+        source = '<ItemLink id="foo" /> is used to store items.'
+        selection = self._selection(source)
+
+        self.assertEqual(selection.pending, {"0": source})
+        self.assertTrue(markdown_line_has_translatable_prose(source))
+
+        masked, mapping = mask_protected_fragments(source)
+        self.assertNotIn("ItemLink", masked)
+        self.assertIn('<ItemLink id="foo" />', mapping.values())
+        translated = unmask_translation(
+            masked.replace(
+                "is used to store items.",
+                "используется для хранения предметов.",
+            ),
+            mapping,
+        )
+        self.assertEqual(
+            translated,
+            '<ItemLink id="foo" /> используется для хранения предметов.',
+        )
+
+    def test_html_markup_plus_prose_is_selected_and_href_is_protected(self) -> None:
+        source = '<a href="facades.md">Facades</a> will be hidden when disabled.'
+        selection = self._selection(source)
+
+        self.assertEqual(selection.pending, {"0": source})
+        masked, mapping = mask_protected_fragments(source)
+        self.assertNotIn("facades.md", masked)
+        self.assertIn('<a href="facades.md">', mapping.values())
+        self.assertIn("</a>", mapping.values())
+        restored = unmask_translation(masked, mapping)
+        self.assertEqual(restored, source)
+
+    def test_normal_markdown_text_is_still_selected(self) -> None:
+        source = "This machine stores energy."
+        selection = self._selection(source)
+
+        self.assertEqual(selection.pending, {"0": source})
+        self.assertEqual(selection.total_translatable, 1)
+
+    def test_image_and_markup_only_lines_do_not_create_translation_work(self) -> None:
+        source = "\n".join(
+            [
+                "![image](foo.png)",
+                '<SomeComponent foo="bar" />',
+                "![image](foo.png) Some caption text",
+            ]
+        )
+        selection = self._selection(source)
+
+        self.assertEqual(
+            selection.pending,
+            {"2": "![image](foo.png) Some caption text"},
+        )
+        self.assertEqual(selection.total_translatable, 1)
+
+        image = "![image](foo.png)"
+        masked, mapping = mask_protected_fragments(image)
+        self.assertNotIn("foo.png", masked)
+        self.assertIn("![image]", mapping.values())
+        self.assertIn("(foo.png)", mapping.values())
+        self.assertEqual(unmask_translation(masked, mapping), image)
+
+    def test_edge_case_markup_lines_detect_only_real_prose(self) -> None:
+        translatable = [
+            '<ItemLink id="foo" />Text immediately after tag',
+            '<ItemLink id="foo" /> Text after tag',
+            "<strong>Important:</strong> Do not break this.",
+            '<a href="../path/file.md">Click here</a> to continue.',
+            "![image](foo.png) Some caption text",
+        ]
+        technical_only = [
+            "![image](foo.png)",
+            '<SomeComponent foo="bar" />',
+            "<item:minecraft:dirt>",
+        ]
+
+        for line in translatable:
+            with self.subTest(line=line):
+                self.assertTrue(markdown_line_has_translatable_prose(line))
+        for line in technical_only:
+            with self.subTest(line=line):
+                self.assertFalse(markdown_line_has_translatable_prose(line))
+
+    def test_smart_glue_does_not_merge_markdown_structure(self) -> None:
+        source = "\n".join(
+            [
+                "---",
+                "navigation:",
+                "  title: Index/Table of Contents",
+                "  position: 0",
+                "---",
+                "![Logo](assets/logo.png)",
+                "This machine stores energy.",
+            ]
+        )
+        selection = self._selection(source, smart_glue=True)
+
+        self.assertEqual(selection.total_translatable, 2)
+        self.assertEqual(
+            selection.pending,
+            {
+                "2": "Index/Table of Contents",
+                "6": "This machine stores energy.",
+            },
+        )
+        self.assertIn("---\n![Logo](assets/logo.png)", selection.source_text)
+
+
+class MarkdownGuidePathTests(unittest.TestCase):
+    def test_direct_ae2_guide_without_en_us_is_source_markdown(self) -> None:
+        self.assertTrue(
+            is_source_markdown_guide(
+                "assets/ae2/ae2guide/getting-started.md"
+            )
+        )
+
+    def test_existing_en_us_guide_support_is_preserved(self) -> None:
+        self.assertTrue(
+            is_source_markdown_guide(
+                "assets/demo/guide/en_us/getting-started.md"
+            )
+        )
+
+    def test_unrelated_or_already_localized_markdown_is_not_source(self) -> None:
+        self.assertFalse(
+            is_source_markdown_guide("assets/demo/docs/readme.md")
+        )
+        self.assertFalse(
+            is_source_markdown_guide(
+                "assets/ae2/ae2guide/_ru_ru/getting-started.md"
+            )
+        )
+
+    def test_target_path_uses_guideme_locale_subdirectory(self) -> None:
+        source = "assets/ae2/ae2guide/getting-started.md"
+        target = get_markdown_target_path(source, "ru_ru")
+
+        self.assertEqual(
+            target,
+            "assets/ae2/ae2guide/_ru_ru/getting-started.md",
+        )
+        self.assertNotEqual(source, target)
+        self.assertEqual(
+            get_markdown_target_path(
+                "assets/demo/guide/en_us/page.md",
+                "ru_ru",
+            ),
+            "assets/demo/guide/ru_ru/page.md",
+        )
+
+
+class MarkdownGuidePipelineTests(unittest.TestCase):
+    @staticmethod
+    def _write_jar(path: Path, files: dict[str, str]) -> None:
+        with zipfile.ZipFile(path, "w") as archive:
+            for internal, content in files.items():
+                archive.writestr(internal, content.encode("utf-8"))
+
+    def test_direct_ae2_fixture_matches_analyzer_estimator_and_processor(self) -> None:
+        source_path = "assets/ae2/ae2guide/getting-started.md"
+        target_path = "assets/ae2/ae2guide/_ru_ru/getting-started.md"
+        source = "\n".join(
+            [
+                '<ItemLink id="foo" /> is used to store items.',
+                '<SomeComponent foo="bar" />',
+                "This machine stores energy.",
+            ]
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            jar_path = Path(temp_dir) / "ae2.jar"
+            self._write_jar(jar_path, {source_path: source})
+            source_jar_bytes = jar_path.read_bytes()
+
+            state = _state()
+            analyzer_rows: list[tuple] = []
+            analyzer = ModpackAnalyzer(state)
+            analyzed, translated = analyzer._analyze_jar(
+                str(jar_path),
+                "ru_ru.json",
+                TARGET_LANG["regex"],
+                False,
+                True,
+                lambda *row: analyzer_rows.append(row),
+                "AE2",
+            )
+
+            estimator = StringEstimator(state)
+            estimated = estimator.estimate(
+                [str(jar_path)],
+                [],
+                [],
+                [],
+                target_lang=TARGET_LANG,
+                mode="append",
+                translate_mods=False,
+                translate_books=True,
+                translate_quests=False,
+                smart_glue=False,
+            )
+
+            service = _ShieldingService()
+            writer = _Writer()
+            JarProcessor(service, state, _callbacks()).process(
+                str(jar_path),
+                target_lang=TARGET_LANG,
+                mode="append",
+                output_mode="resourcepack",
+                translate_mods=False,
+                translate_books=True,
+                pack_writer=writer,
+            )
+
+            self.assertEqual(analyzed, 2)
+            self.assertEqual(translated, 0)
+            self.assertEqual(estimated, 2)
+            self.assertEqual(len(service.calls), 1)
+            self.assertEqual(
+                service.calls[0],
+                {
+                    "0": '<ItemLink id="foo" /> is used to store items.',
+                    "2": "This machine stores energy.",
+                },
+            )
+            self.assertIn(target_path, writer.files)
+            self.assertNotIn(source_path, writer.files)
+            output = writer.files[target_path].decode("utf-8")
+            self.assertIn(
+                '<ItemLink id="foo" /> используется для хранения предметов.',
+                output,
+            )
+            self.assertIn("Эта машина хранит энергию.", output)
+            self.assertEqual(jar_path.read_bytes(), source_jar_bytes)
+            self.assertTrue(analyzer_rows)
+
+    def test_direct_ae2_append_skip_force_keep_estimator_processor_parity(self) -> None:
+        source_path = "assets/ae2/ae2guide/page.md"
+        target_path = "assets/ae2/ae2guide/_ru_ru/page.md"
+        source = "Existing paragraph\nNew paragraph"
+        target = "Существующий абзац\nNew paragraph"
+
+        expected = {"append": 1, "skip": 1, "force": 2}
+        for mode, expected_count in expected.items():
+            with self.subTest(mode=mode), tempfile.TemporaryDirectory() as temp_dir:
+                jar_path = Path(temp_dir) / "ae2.jar"
+                self._write_jar(
+                    jar_path,
+                    {
+                        source_path: source,
+                        target_path: target,
+                    },
+                )
+                state = _state()
+                estimator = StringEstimator(state)
+                estimated = estimator.estimate(
+                    [str(jar_path)],
+                    [],
+                    [],
+                    [],
+                    target_lang=TARGET_LANG,
+                    mode=mode,
+                    translate_mods=False,
+                    translate_books=True,
+                    translate_quests=False,
+                    smart_glue=False,
+                )
+
+                service = _ShieldingService()
+                writer = _Writer()
+                JarProcessor(service, state, _callbacks()).process(
+                    str(jar_path),
+                    target_lang=TARGET_LANG,
+                    mode=mode,
+                    output_mode="resourcepack",
+                    translate_mods=False,
+                    translate_books=True,
+                    pack_writer=writer,
+                )
+                actual = len(service.calls[0]) if service.calls else 0
+
+                self.assertEqual(estimated, expected_count)
+                self.assertEqual(actual, expected_count)
+                self.assertIn(target_path, writer.files)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_markdown_structural_pipeline.py
+++ b/tests/test_markdown_structural_pipeline.py
@@ -1,0 +1,115 @@
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from mineai.engines.base import EngineCallbacks
+from mineai.processors.jar import JarProcessor
+from mineai.runtime.state import JobState
+from mineai.text_processing import mask_protected_fragments, unmask_translation
+
+
+TARGET_LANG = {
+    "file": "ru_ru",
+    "api": "ru",
+    "name": "Russian",
+    "regex": r"[А-Яа-яЁё]",
+}
+
+
+class _Config:
+    def getboolean(self, _section: str, _key: str) -> bool:
+        return False
+
+
+class _PayloadOnlyService:
+    def __init__(self) -> None:
+        self.config = _Config()
+        self.calls: list[dict[str, str]] = []
+
+    def translate_dict(self, strings, _target_lang, _callbacks, **_kwargs):
+        self.calls.append(dict(strings))
+        result: dict[str, str] = {}
+        for key, source in strings.items():
+            masked, mapping = mask_protected_fragments(source)
+            translated = masked.replace(
+                "ME Extended Interface is a",
+                "МЕ Расширенный интерфейс — это",
+            ).replace(
+                "with a larger configuration inventory.",
+                "с более обширным списком конфигураций.",
+            )
+            result[key] = unmask_translation(translated, mapping)
+        return result
+
+
+class _Writer:
+    def __init__(self) -> None:
+        self.files: dict[str, bytes] = {}
+
+    def write(self, path: str, payload: bytes) -> None:
+        self.files[path] = payload
+
+
+def _callbacks() -> EngineCallbacks:
+    return EngineCallbacks(
+        should_run=lambda: True,
+        wait_if_paused=lambda: None,
+        on_log=lambda *_args: None,
+        on_status=lambda *_args: None,
+        on_progress=lambda *_args: None,
+    )
+
+
+class MarkdownStructuralPipelineTests(unittest.TestCase):
+    def test_processor_never_sends_block_structure_to_translation_service(self) -> None:
+        source_path = "assets/ae2/ae2guide/structure-test.md"
+        target_path = "assets/ae2/ae2guide/_ru_ru/structure-test.md"
+        source_line = (
+            '*   ME Extended Interface is a <ItemLink id="ae2:interface" /> '
+            "with a larger configuration inventory.  "
+        )
+        expected_payload = (
+            'ME Extended Interface is a <ItemLink id="ae2:interface" /> '
+            "with a larger configuration inventory."
+        )
+        expected_output = (
+            '*   МЕ Расширенный интерфейс — это <ItemLink id="ae2:interface" /> '
+            "с более обширным списком конфигураций.  "
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            jar_path = Path(temp_dir) / "ae2.jar"
+            with zipfile.ZipFile(jar_path, "w") as archive:
+                archive.writestr(source_path, source_line.encode("utf-8"))
+            original_jar = jar_path.read_bytes()
+
+            state = JobState()
+            state.start()
+            service = _PayloadOnlyService()
+            writer = _Writer()
+
+            JarProcessor(service, state, _callbacks()).process(
+                str(jar_path),
+                target_lang=TARGET_LANG,
+                mode="force",
+                output_mode="resourcepack",
+                translate_mods=False,
+                translate_books=True,
+                pack_writer=writer,
+            )
+
+            self.assertEqual(service.calls, [{"0": expected_payload}])
+            self.assertNotIn("*   ", service.calls[0]["0"])
+            self.assertIn('<ItemLink id="ae2:interface" />', service.calls[0]["0"])
+            self.assertIn(target_path, writer.files)
+            self.assertNotIn(source_path, writer.files)
+            self.assertEqual(
+                writer.files[target_path].decode("utf-8"),
+                expected_output,
+            )
+            self.assertEqual(jar_path.read_bytes(), original_jar)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_markdown_structure_integrity.py
+++ b/tests/test_markdown_structure_integrity.py
@@ -1,0 +1,201 @@
+import unittest
+
+from mineai.processors.selection import (
+    collect_book_markdown_selection,
+    split_markdown_block_structure,
+)
+from mineai.text_processing import mask_protected_fragments, unmask_translation
+
+
+class MarkdownDocumentStructureTests(unittest.TestCase):
+    def test_smart_glue_does_not_collapse_markdown_blocks(self) -> None:
+        source = "\n".join(
+            [
+                "---",
+                "navigation:",
+                "  title: Structure Test",
+                "---",
+                "![Logo](assets/logo.png)",
+                "",
+                "## Heading",
+                "Paragraph after heading.",
+                "",
+                "| Bytes | Types |",
+                "| --- | --- |",
+                "| One | Two |",
+                "",
+                "1. First item",
+                "2. Second item",
+            ]
+        )
+
+        selection = collect_book_markdown_selection(
+            source,
+            "",
+            "force",
+            smart_glue=True,
+        )
+
+        self.assertEqual(selection.source_text, source)
+        self.assertEqual(len(selection.lines_out), len(source.split("\n")))
+        self.assertEqual(selection.lines_out[3], "---")
+        self.assertEqual(selection.lines_out[4], "![Logo](assets/logo.png)")
+        self.assertEqual(selection.lines_out[6], "## Heading")
+        self.assertEqual(selection.lines_out[9], "| Bytes | Types |")
+        self.assertEqual(selection.lines_out[10], "| --- | --- |")
+        self.assertEqual(selection.lines_out[13], "1. First item")
+        self.assertEqual(selection.lines_out[14], "2. Second item")
+
+    def test_block_structure_is_split_byte_for_byte_from_payload(self) -> None:
+        cases = {
+            "*   Bullet item": ("*   ", "Bullet item", ""),
+            "  *   Nested bullet": ("  *   ", "Nested bullet", ""),
+            "1.  Ordered item": ("1.  ", "Ordered item", ""),
+            "   2)    Ordered item": ("   2)    ", "Ordered item", ""),
+            "##   Heading": ("##   ", "Heading", ""),
+            "##   Heading   ##": ("##   ", "Heading", "   ##"),
+            ">   Quoted text": (">   ", "Quoted text", ""),
+            "> *   Nested quote item": ("> *   ", "Nested quote item", ""),
+            "  Continuation text": ("  ", "Continuation text", ""),
+            "- [ ]   Task item": ("- [ ]   ", "Task item", ""),
+            "- [x] Done item": ("- [x] ", "Done item", ""),
+            "Plain paragraph": ("", "Plain paragraph", ""),
+            "Text with hard break  ": ("", "Text with hard break", "  "),
+        }
+        for source, expected in cases.items():
+            with self.subTest(source=source):
+                self.assertEqual(split_markdown_block_structure(source), expected)
+
+    def test_selection_sends_only_bullet_payload_to_translation_service(self) -> None:
+        source = '*   ME Extended Interface is a <ItemLink id="ae2:interface" /> with a larger configuration inventory.'
+        selection = collect_book_markdown_selection(
+            source,
+            "",
+            "force",
+            smart_glue=True,
+        )
+
+        key = "0"
+        self.assertEqual(
+            selection.pending[key],
+            'ME Extended Interface is a <ItemLink id="ae2:interface" /> with a larger configuration inventory.',
+        )
+        self.assertEqual(selection.title_meta[key], ("*   ", ""))
+
+        masked, mapping = mask_protected_fragments(selection.pending[key])
+        self.assertNotIn("*   ", masked)
+        self.assertNotIn('id="ae2:interface"', masked)
+        self.assertIn('<ItemLink id="ae2:interface" />', mapping.values())
+
+        translated_payload = masked.replace(
+            "ME Extended Interface is a",
+            "МЕ Расширенный интерфейс — это",
+        ).replace(
+            "with a larger configuration inventory.",
+            "с более обширным списком конфигураций.",
+        )
+        restored_payload = unmask_translation(translated_payload, mapping)
+        prefix, suffix = selection.title_meta[key]
+        final = prefix + restored_payload + suffix
+
+        self.assertEqual(
+            final,
+            '*   МЕ Расширенный интерфейс — это <ItemLink id="ae2:interface" /> с более обширным списком конфигураций.',
+        )
+
+    def test_selection_preserves_indent_and_hard_break_outside_payload(self) -> None:
+        source = "  Continuation text with hard break  "
+        selection = collect_book_markdown_selection(
+            source,
+            "",
+            "force",
+            smart_glue=False,
+        )
+
+        self.assertEqual(selection.pending, {"0": "Continuation text with hard break"})
+        self.assertEqual(selection.title_meta["0"], ("  ", "  "))
+
+    def test_fenced_code_block_is_not_selected_for_translation(self) -> None:
+        source = "\n".join(
+            [
+                "```json",
+                '{"text": "Do not translate this example"}',
+                "```",
+                "Translate this paragraph.",
+            ]
+        )
+        selection = collect_book_markdown_selection(
+            source,
+            "",
+            "force",
+            smart_glue=False,
+        )
+
+        self.assertNotIn("0", selection.pending)
+        self.assertNotIn("1", selection.pending)
+        self.assertNotIn("2", selection.pending)
+        self.assertEqual(selection.pending["3"], "Translate this paragraph.")
+
+
+class MarkdownInlineShieldTests(unittest.TestCase):
+    def test_block_markers_are_not_placeholder_fragments(self) -> None:
+        masked, mapping = mask_protected_fragments("## Heading")
+        self.assertNotIn("## ", mapping.values())
+        self.assertEqual(masked, "## Heading")
+
+        _masked, mapping = mask_protected_fragments("*   Bullet")
+        self.assertNotIn("*   ", mapping.values())
+
+    def test_inline_itemlink_round_trips_exactly(self) -> None:
+        source = 'ME Interface is a <ItemLink id="ae2:interface" /> component.'
+        masked, mapping = mask_protected_fragments(source)
+
+        self.assertNotIn('id="ae2:interface"', masked)
+        self.assertIn('<ItemLink id="ae2:interface" />', mapping.values())
+        translated = masked.replace("ME Interface is a", "Интерфейс ME — это").replace(
+            "component.",
+            "компонент.",
+        )
+        self.assertEqual(
+            unmask_translation(translated, mapping),
+            'Интерфейс ME — это <ItemLink id="ae2:interface" /> компонент.',
+        )
+
+    def test_table_delimiters_round_trip_exactly(self) -> None:
+        source = "| Bytes | Types |"
+        masked, mapping = mask_protected_fragments(source)
+
+        self.assertEqual(sum(value == "|" for value in mapping.values()), 3)
+        translated = masked.replace("Bytes", "Байты").replace("Types", "Типы")
+        restored = unmask_translation(translated, mapping)
+
+        self.assertEqual(restored, "| Байты | Типы |")
+        self.assertEqual(restored.count("|"), source.count("|"))
+
+    def test_markdown_link_brackets_and_destination_round_trip(self) -> None:
+        source = "[Facades](../items/facades.md) will be hidden."
+        masked, mapping = mask_protected_fragments(source)
+
+        self.assertNotIn("../items/facades.md", masked)
+        self.assertIn("[", mapping.values())
+        self.assertIn("](../items/facades.md)", mapping.values())
+
+        translated = masked.replace("Facades", "Фасады").replace(
+            "will be hidden.",
+            "будут скрыты.",
+        )
+        self.assertEqual(
+            unmask_translation(translated, mapping),
+            "[Фасады](../items/facades.md) будут скрыты.",
+        )
+
+    def test_image_markup_still_round_trips_without_translation(self) -> None:
+        source = "![image](foo.png)"
+        masked, mapping = mask_protected_fragments(source)
+
+        self.assertNotIn("foo.png", masked)
+        self.assertEqual(unmask_translation(masked, mapping), source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Описание PR

## Summary

Исправляет обработку Markdown\-гайдбуков AE2/GuideME, из\-за которой MineAI мог:

- пропускать переводимый текст рядом с технической разметкой;
- не находить AE2 Guide без `/en_us/`;
- повреждать Markdown\-структуру при переводе;
- изменять пробелы у списков, заголовков и других block\-level элементов\.

Основное изменение — Markdown\-структура теперь отделяется от переводимого текста до отправки строки в `TranslationService`\.

---

## Problem

Ранее Markdown обрабатывался слишком близко к обычной текстовой строке\.

Например:

```md
*   ME Extended Interface is a <ItemLink id="ae2:interface" /> with a larger configuration inventory.
```

В этой строке есть два разных типа данных:

```text
Markdown structure:
"*   "

Human-readable payload:
ME Extended Interface is a <ItemLink id="ae2:interface" /> with a larger configuration inventory.
```

При обработке всей строки общим механизмом masking/normalization Markdown\-структура могла попасть в translation pipeline\.

Это создавало несколько проблем:

- `*   ` мог превратиться в `* `;
- заголовок мог отделиться от текста;
- строки таблицы могли схлопнуться;
- элементы списков могли объединяться;
- YAML `---` мог склеиваться со следующим блоком;
- mixed markup lines могли полностью пропускаться\.

---

## Fix

### 1\. Markdown structure отделена от translatable payload

Для переводимой Markdown\-строки теперь выделяются:

```text
prefix + payload + suffix
```

Например:

```md
*   Some text here.  
```

разбирается как:

```text
prefix:
"*   "

payload:
"Some text here."

suffix:
"  "
```

`prefix` и `suffix` не отправляются в TranslationService и сохраняются без изменения\.

Это важно для:

- indentation;
- `*`, `-`, `+`;
- numbered lists;
- headings;
- blockquotes;
- task\-list markers;
- Markdown hard breaks из двух trailing spaces\.

После перевода исходная структура приклеивается обратно\.

---

### 2\. Inline markup остаётся внутри предложения через placeholders

Inline\-технические элементы не удаляются из смыслового контекста\.

Например:

```md
ME Extended Interface is a <ItemLink id="ae2:interface" /> with a larger configuration inventory.
```

проходит через существующий Titanium Shield примерно так:

```text
SOURCE:

ME Extended Interface is a <ItemLink id="ae2:interface" /> with a larger configuration inventory.

MASKED:

ME Extended Interface is a [#0#] with a larger configuration inventory.

MAPPING:

[#0#] = <ItemLink id="ae2:interface" />
```

LLM получает предложение целиком вместе с временным placeholder:

```text
ME Extended Interface is a [#0#] with a larger configuration inventory.
```

После перевода:

```text
МЕ Расширенный интерфейс — это [#0#] с более обширным списком конфигураций.
```

placeholder заменяется обратно на оригинальный фрагмент:

```text
МЕ Расширенный интерфейс — это <ItemLink id="ae2:interface" /> с более обширным списком конфигураций.
```

Таким образом модель сохраняет смысл предложения, но не получает возможность изменить технический ID или синтаксис компонента\.

Существующая проверка placeholders также сохраняется: потерянные, добавленные или продублированные `[#N#]` не принимаются как корректный результат\.

---

### 3\. Mixed markup \+ prose больше не пропускается

Ранее строка:

```md
<ItemLink id="meteorite_compass" /> will point toward a meteorite.
```

могла быть пропущена целиком только потому, что начиналась с `<`\.

Теперь различаются:

```md
<ItemLink id="foo" />
```

техническая строка без prose — перевод не нужен;

и:

```md
<ItemLink id="foo" /> is used to store items.
```

markup \+ human\-readable prose — строка должна переводиться\.

Исправление не привязано только к `ItemLink` и работает также с HTML/GuideME\-like inline markup\.

---

### 4\. AE2 Guide без `/en_us/`

Поддерживаются direct GuideME source paths вида:

```text
assets/ae2/ae2guide/getting-started.md
```

Ранее обязательная проверка `/en_us/` могла исключить такие страницы из обработки\.

Классификация Markdown guide и target path теперь вынесена в общий helper, используемый Analyzer, Estimator и Processor\.

Для direct AE2 Guide локализованный путь формируется отдельно от source:

```text
assets/ae2/ae2guide/getting-started.md
→
assets/ae2/ae2guide/_ru_ru/getting-started.md
```

Оригинальный source\-файл не используется как target в resource\-pack mode\.

Обычная поддержка `/en_us/` сохраняется\.

Произвольные `.md` файлы не начинают переводиться\.

---

## Markdown structural safety

`smart_glue` больше не применяется ко всему Markdown\-документу до структурного разбора\.

Это предотвращает случаи вроде:

```md
---
![Logo](assets/logo.png)
```

превращающиеся в:

```md
--- ![Logo](assets/logo.png)
```

и аналогичные повреждения:

- heading \+ paragraph;
- table row \+ next table row;
- list item \+ next list item\.

Fenced code blocks также не отправляются как обычный переводимый текст\.

---

## Processing pipeline

Новый Markdown pipeline концептуально выглядит так:

```text
Markdown source
        ↓
Structural split
(prefix / payload / suffix)
        ↓
TranslationService получает только payload
        ↓
Inline Titanium Shield
        ↓
[#N#] placeholders
        ↓
Translator / LLM
        ↓
Placeholder validation
        ↓
Inline unmask
        ↓
Original prefix + translated payload + original suffix
        ↓
Markdown output
```

Block\-level Markdown structure и inline protected fragments теперь имеют разные обязанности\.

---

## Before / After

### Before

```md
*   <ItemLink id="meteorite_compass" /> will point toward a meteorite.
```

могло:

```text
→ потерять точные пробелы списка
→ быть пропущено из-за начального markup
→ или получить повреждённую Markdown-структуру
```

### After

```text
"*   "
хранится как Markdown structure

<ItemLink ... />
заменяется на [#N#]

prose переводится

[#N#]
восстанавливается

"*   "
приклеивается обратно без изменения
```

Результат:

```md
*   <ItemLink id="meteorite_compass" /> укажет направление к метеориту.
```

---

## Tests

Добавлены regression tests для:

- markup\-only lines;
- ItemLink \+ prose;
- HTML\-like markup \+ prose;
- normal Markdown;
- image\-only и image \+ caption;
- Markdown links;
- table delimiters;
- headings;
- ordered/unordered lists;
- точного сохранения bullet spacing;
- indentation;
- trailing Markdown hard\-break spaces;
- YAML/front matter;
- fenced code blocks;
- direct `ae2guide/...` без `/en_us/`;
- существующих `/en_us/` guide paths;
- GuideME target locale path;
- Analyzer / Estimator / Processor consistency;
- resource\-pack source preservation;
- append / skip / force parity;
- end\-to\-end `JarProcessor` structural reconstruction\.

Финальный CI:

```text
Windows unit tests: PASS
Ubuntu unit tests: PASS

186 tests: OK

compileall: PASS

Qt production smoke:
Windows: PASS
Ubuntu: PASS

Windows PyInstaller build: PASS
Packaged EXE verification: PASS
```

---

## Scope

PR намеренно ограничен Markdown/GuideME processing\.

Он не меняет:

- translation prompts;
- качество LLM\-перевода;
- Google / DeepL / OpenRouter / Local AI;
- cache semantics;
- GUI;
- BetterQuesting;
- SNBT;
- JSON lang processing;
- progress / ETA\.

JSON и SNBT не включены в этот refactoring, поскольку их структура уже отделяется от переводимых string values значительно раньше в pipeline\.

Цель этого PR — безопасно разделить Markdown structure и translatable payload, сохранив существующий Titanium Shield для inline\-технических фрагментов\.