### PR TITLE
fix(windows): make batch scripts archive-safe

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Keep Windows batch scripts byte-stable in GitHub source archives.
+# Batch files are stored with CRLF in the repository; do not normalize them.
+*.bat -text

--- a/build.bat
+++ b/build.bat
@@ -1,54 +1,53 @@
 @echo off
 setlocal
-chcp 65001 >nul
 cd /d "%~dp0"
 
 echo =========================================
-echo  MineAI Translator — сборка EXE
+echo  MineAI Translator - EXE build
 echo =========================================
 echo.
 
-echo [1/4] Зависимости...
+echo [1/4] Installing dependencies...
 python -m pip install -r requirements.txt pyinstaller -q
-if errorlevel 1 (
-    echo Ошибка: не удалось установить пакеты. Проверьте Python 3.10+
-    if not defined CI pause
-    exit /b 1
-)
+if errorlevel 1 goto :deps_error
 
-echo [2/4] Проверка синтаксиса всех файлов...
+echo [2/4] Checking Python syntax...
 python -m compileall mineai/ translator.py -q
-if errorlevel 1 (
-    echo.
-    echo =============================================
-    echo  ОШИБКА СИНТАКСИСА! Сборка остановлена.
-    echo  Исправьте файлы, указанные выше.
-    echo =============================================
-    if not defined CI pause
-    exit /b 1
-)
-echo    Все файлы корректны.
+if errorlevel 1 goto :syntax_error
+echo    Python sources are valid.
 
-echo [3/4] PyInstaller...
+echo [3/4] Running PyInstaller...
 python -m PyInstaller --noconfirm --clean --onefile --noconsole --icon="icon.ico" --add-data "icon.ico;." --name "MineAI_Translator" mineai\__main__.py
-if errorlevel 1 (
-    echo Ошибка сборки.
-    if not defined CI pause
-    exit /b 1
-)
+if errorlevel 1 goto :build_error
 
-if not exist "dist\MineAI_Translator.exe" (
-    echo Ошибка: dist\MineAI_Translator.exe не создан.
-    if not defined CI pause
-    exit /b 1
-)
+if not exist "dist\MineAI_Translator.exe" goto :missing_exe
 
 echo.
-echo [4/4] Готово!
+echo [4/4] Done!
 echo    EXE: dist\MineAI_Translator.exe
 echo.
-echo Рядом с EXE положите при необходимости:
+echo Optional files next to the EXE:
 echo    settings.ini, dictionary.json, cache.json
 echo.
 if not defined CI pause
 exit /b 0
+
+:deps_error
+echo ERROR: Failed to install dependencies. Check Python 3.10+.
+if not defined CI pause
+exit /b 1
+
+:syntax_error
+echo ERROR: Python syntax check failed. Build stopped.
+if not defined CI pause
+exit /b 1
+
+:build_error
+echo ERROR: PyInstaller build failed.
+if not defined CI pause
+exit /b 1
+
+:missing_exe
+echo ERROR: dist\MineAI_Translator.exe was not created.
+if not defined CI pause
+exit /b 1

--- a/start.bat
+++ b/start.bat
@@ -1,20 +1,25 @@
 @echo off
 setlocal
-chcp 65001 >nul
+cd /d "%~dp0"
+
 echo Installing dependencies...
 python -m pip install -r requirements.txt -q
-if errorlevel 1 (
-    echo Failed to install dependencies.
-    if not defined CI pause
-    exit /b 1
-)
+if errorlevel 1 goto :deps_error
+
 echo =========================================
 echo Starting MineAI Translator...
 python -m mineai
-if errorlevel 1 (
-    echo MineAI Translator exited with an error.
-    if not defined CI pause
-    exit /b 1
-)
+if errorlevel 1 goto :run_error
+
 if not defined CI pause
 exit /b 0
+
+:deps_error
+echo ERROR: Failed to install dependencies.
+if not defined CI pause
+exit /b 1
+
+:run_error
+echo ERROR: MineAI Translator exited with an error.
+if not defined CI pause
+exit /b 1

--- a/tests/test_windows_batch_archive_safety.py
+++ b/tests/test_windows_batch_archive_safety.py
@@ -1,0 +1,20 @@
+import unittest
+from pathlib import Path
+
+
+class WindowsBatchArchiveSafetyTests(unittest.TestCase):
+    def test_batch_files_are_ascii_and_crlf(self) -> None:
+        for filename in ("build.bat", "start.bat"):
+            with self.subTest(filename=filename):
+                data = Path(filename).read_bytes()
+                self.assertTrue(data.endswith(b"\r\n"))
+                self.assertNotIn(b"\n", data.replace(b"\r\n", b""))
+                data.decode("ascii")
+
+    def test_gitattributes_preserves_batch_blob_bytes(self) -> None:
+        attributes = Path(".gitattributes").read_text(encoding="utf-8")
+        self.assertIn("*.bat -text", attributes)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Исправляет ошибку запуска `build.bat` и `start.bat` на Windows, которая могла появляться при скачивании проекта через GitHub ZIP.

Причина была в формате batch-файлов: Windows `cmd.exe` мог неправильно разбирать LF-only/UTF-8 содержимое, из-за чего части строк воспринимались как отдельные команды, а PyInstaller запускался без нужных аргументов.

## Что исправлено

- `build.bat` и `start.bat` переведены в безопасный для Windows формат CRLF;
- batch-файлы сделаны ASCII-only;
- добавлен `.gitattributes`, чтобы Git не менял окончания строк `.bat`;
- упрощена обработка ошибок через `goto`;
- `start.bat` теперь запускается из своей папки;
- добавлены тесты на CRLF и корректность batch-файлов.

## Проверка

Windows и Ubuntu тесты проходят.

`build.bat` успешно запускается через `cmd.exe`, PyInstaller собирает рабочий:

```text
dist\MineAI_Translator.exe