### PR TITLE
feat(formatkit): integrate structure-safe locale and book pipeline

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Keep Windows batch scripts byte-stable in GitHub source archives.
+# Batch files are stored with CRLF in the repository; do not normalize them.
+*.bat -text

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,3 +62,10 @@ jobs:
             throw "Packaged EXE is unexpectedly small: $size bytes"
           }
           Write-Host "Packaged EXE size $size bytes"
+      - name: Upload BETAv17 Windows build
+        uses: actions/upload-artifact@v4
+        with:
+          name: MineAI-Translator-BETAv17-Windows
+          path: dist/MineAI_Translator.exe
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libegl1 libgl1
       - name: Compile sources
-        run: python -m compileall -q mineai tests translator.py
+        run: python -m compileall -q mineai mineai_formatkit tests translator.py
       - name: Run unit tests
         run: python -m unittest discover -s tests -v
       - name: Qt production smoke

--- a/build.bat
+++ b/build.bat
@@ -1,54 +1,53 @@
 @echo off
 setlocal
-chcp 65001 >nul
 cd /d "%~dp0"
 
 echo =========================================
-echo  MineAI Translator — сборка EXE
+echo  MineAI Translator - EXE build
 echo =========================================
 echo.
 
-echo [1/4] Зависимости...
+echo [1/4] Installing dependencies...
 python -m pip install -r requirements.txt pyinstaller -q
-if errorlevel 1 (
-    echo Ошибка: не удалось установить пакеты. Проверьте Python 3.10+
-    if not defined CI pause
-    exit /b 1
-)
+if errorlevel 1 goto :deps_error
 
-echo [2/4] Проверка синтаксиса всех файлов...
+echo [2/4] Checking Python syntax...
 python -m compileall mineai/ translator.py -q
-if errorlevel 1 (
-    echo.
-    echo =============================================
-    echo  ОШИБКА СИНТАКСИСА! Сборка остановлена.
-    echo  Исправьте файлы, указанные выше.
-    echo =============================================
-    if not defined CI pause
-    exit /b 1
-)
-echo    Все файлы корректны.
+if errorlevel 1 goto :syntax_error
+echo    Python sources are valid.
 
-echo [3/4] PyInstaller...
+echo [3/4] Running PyInstaller...
 python -m PyInstaller --noconfirm --clean --onefile --noconsole --icon="icon.ico" --add-data "icon.ico;." --name "MineAI_Translator" mineai\__main__.py
-if errorlevel 1 (
-    echo Ошибка сборки.
-    if not defined CI pause
-    exit /b 1
-)
+if errorlevel 1 goto :build_error
 
-if not exist "dist\MineAI_Translator.exe" (
-    echo Ошибка: dist\MineAI_Translator.exe не создан.
-    if not defined CI pause
-    exit /b 1
-)
+if not exist "dist\MineAI_Translator.exe" goto :missing_exe
 
 echo.
-echo [4/4] Готово!
+echo [4/4] Done!
 echo    EXE: dist\MineAI_Translator.exe
 echo.
-echo Рядом с EXE положите при необходимости:
+echo Optional files next to the EXE:
 echo    settings.ini, dictionary.json, cache.json
 echo.
 if not defined CI pause
 exit /b 0
+
+:deps_error
+echo ERROR: Failed to install dependencies. Check Python 3.10+.
+if not defined CI pause
+exit /b 1
+
+:syntax_error
+echo ERROR: Python syntax check failed. Build stopped.
+if not defined CI pause
+exit /b 1
+
+:build_error
+echo ERROR: PyInstaller build failed.
+if not defined CI pause
+exit /b 1
+
+:missing_exe
+echo ERROR: dist\MineAI_Translator.exe was not created.
+if not defined CI pause
+exit /b 1

--- a/mineai/__init__.py
+++ b/mineai/__init__.py
@@ -1,3 +1,7 @@
 """MineAI Modpack Translator — modular localization tool for Minecraft."""
 
 __version__ = "10.0.0 - BETAv16"
+
+from mineai.pilot_v2_bootstrap import install_pilot_v2
+
+install_pilot_v2()

--- a/mineai/__init__.py
+++ b/mineai/__init__.py
@@ -1,6 +1,6 @@
 """MineAI Modpack Translator — modular localization tool for Minecraft."""
 
-__version__ = "10.0.0 - BETAv16"
+__version__ = "10.0.0 - BETAv17"
 
 from mineai.pilot_v2_bootstrap import install_pilot_v2
 

--- a/mineai/engines/kobold.py
+++ b/mineai/engines/kobold.py
@@ -2,7 +2,7 @@ import requests
 
 from mineai.constants import KOBOLD_API
 from mineai.engines.http_retry import RequestCancelled, request_with_retry
-from mineai.engines.llm_common import BatchLlmEngine
+from mineai.engines.llm_v2 import BatchLlmEngine
 
 
 class KoboldEngine(BatchLlmEngine):

--- a/mineai/engines/llm_v2.py
+++ b/mineai/engines/llm_v2.py
@@ -1,0 +1,258 @@
+"""Pilot-v2 LLM safety layer driven by the first FTB Evolution runtime log.
+
+The legacy batch engine remains intact. Importing this module tightens its
+marker helpers, while the subclass below only changes batching for marker-heavy
+strings. This keeps the pilot easy to remove or compare against v1.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter
+from typing import Callable
+
+import requests
+
+from mineai.engines import llm_common as _base
+from mineai.text_processing import PLACEHOLDER_PATTERN
+
+
+SINGLE_ITEM_MARKER_THRESHOLD = 8
+_BARE_MARKER_PATTERN = re.compile(
+    r"#\s*(\d+)\s*#|\[\s*#\s*(\d+)\s*\]|\[\s*(\d+)\s*#\s*\]"
+)
+
+_ORIGINAL_BUILD_TRANSLATION_PROMPT = _base.build_translation_prompt
+_ORIGINAL_GET_DEFAULT_PROMPTS = _base.get_default_prompts
+
+
+def _placeholder_sequence(text: str) -> tuple[str, ...]:
+    return tuple(PLACEHOLDER_PATTERN.findall(text))
+
+
+def _bare_marker_sequence(text: str) -> tuple[str, ...]:
+    stripped = PLACEHOLDER_PATTERN.sub("", text)
+    result: list[str] = []
+    for match in _BARE_MARKER_PATTERN.finditer(stripped):
+        result.append(next(group for group in match.groups() if group is not None))
+    return tuple(result)
+
+
+def marker_validation_error(text: str, expected_text: str) -> str | None:
+    """Reject lost, added, reordered, or hallucinated numbered markers."""
+    expected = _placeholder_sequence(expected_text)
+    actual = _placeholder_sequence(text)
+    if Counter(actual) != Counter(expected):
+        return "Потеряны/добавлены маркеры [#N#]"
+    if actual != expected:
+        return "Изменён порядок маркеров [#N#]"
+    if _bare_marker_sequence(text) != _bare_marker_sequence(expected_text):
+        return "Добавлены/изменены ложные маркеры #N#"
+    return None
+
+
+def placeholders_match(text: str, expected_text: str) -> bool:
+    return marker_validation_error(text, expected_text) is None
+
+
+def build_marker_manifest(payload: dict[str, str]) -> str:
+    """Show the exact source marker sequence instead of sorting marker ids."""
+    lines: list[str] = []
+    for key, value in payload.items():
+        sequence = PLACEHOLDER_PATTERN.findall(value)
+        if not sequence:
+            lines.append(f'"{key}": (plain text, no placeholders)')
+            continue
+        listing = " ".join(f"[#{marker_id}#]" for marker_id in sequence)
+        lines.append(f'"{key}": {listing}')
+    return (
+        "MARKER WHITELIST / SOURCE ORDER (copy exactly per key):\n"
+        + "\n".join(lines)
+        + "\nRULE: the translation of each key must contain exactly this marker "
+        "sequence — no skips, no renumbering, no repeats, no reordering, "
+        "and no extra markers."
+    )
+
+
+def get_default_prompts() -> dict[str, str]:
+    prompts = dict(_ORIGINAL_GET_DEFAULT_PROMPTS())
+    prompts["technical"] = (
+        "STRICT RULES:\n"
+        "1. Copy every JSON key exactly; translate only human-readable string values.\n"
+        "2. Preserve ALL [#N#] placeholders exactly and keep the exact SOURCE ORDER. "
+        "Never add, remove, rename, duplicate, or move markers.\n"
+        "3. Never invent placeholder-like tokens or formatting markers absent from the source.\n"
+        "4. MUST escape all newlines as \\n. DO NOT output raw/literal newlines inside JSON strings.\n"
+        "5. Output ONLY one raw valid JSON object. No markdown, code fences, comments, "
+        "explanations, or intro text."
+    )
+    return prompts
+
+
+def _renumber_rules(text: str) -> str:
+    out: list[str] = []
+    number = 1
+    for line in text.splitlines():
+        if re.match(r"^\s*\d+\.\s+", line):
+            line = re.sub(r"^\s*\d+\.\s+", f"{number}. ", line, count=1)
+            number += 1
+        out.append(line)
+    return "\n".join(out)
+
+
+def build_translation_prompt(
+    payload: dict[str, str],
+    lang_name: str,
+    *,
+    mode: str,
+    context: str,
+    prompt_type: str = "mods",
+) -> str:
+    prompt = _ORIGINAL_BUILD_TRANSLATION_PROMPT(
+        payload,
+        lang_name,
+        mode=mode,
+        context=context,
+        prompt_type=prompt_type,
+    )
+    separator = "\n\nDATA:\n"
+    if separator not in prompt:
+        return prompt
+    head, data = prompt.split(separator, 1)
+    head = _renumber_rules(head)
+    has_markers = any(PLACEHOLDER_PATTERN.search(value) for value in payload.values())
+    if has_markers:
+        safety = (
+            "STRUCTURAL SAFETY (runtime-enforced): preserve the exact [#N#] "
+            "sequence in SOURCE ORDER for every key. Never move, add, or duplicate "
+            "markers, and never invent marker-like tokens."
+        )
+    else:
+        safety = (
+            "STRUCTURAL SAFETY: Copy JSON keys exactly. Do not invent placeholders "
+            "or formatting markers. Return raw JSON only."
+        )
+    return f"{head}\n\n{safety}{separator}{data}"
+
+
+def repair_markers(
+    call_api: Callable[[str, int], str | None],
+    masked_source: str,
+    broken_translation: str,
+    max_tokens: int,
+) -> str | None:
+    prompt = (
+        "The translation below lost, moved, or corrupted numbered markers.\n"
+        "Restore EXACTLY the source marker sequence: same ids, same counts, same SOURCE ORDER.\n"
+        "Remove marker-like tokens absent from the source. Do not retranslate.\n"
+        "Output ONLY the corrected text, no explanations.\n\n"
+        f"SOURCE:\n{masked_source}\n\n"
+        f"BROKEN TRANSLATION:\n{broken_translation}\n"
+    )
+    content = call_api(prompt, max_tokens)
+    if not content:
+        return None
+    raw = re.sub(
+        r"^```[a-z]*\s*|\s*```$",
+        "",
+        content.strip(),
+        flags=re.IGNORECASE | re.MULTILINE,
+    ).strip()
+    if raw.startswith("{") and raw.endswith("}"):
+        try:
+            json.loads(raw)
+            return None
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return raw if raw and marker_validation_error(raw, masked_source) is None else None
+
+
+# The inherited _translate_chunk() resolves these helpers through llm_common's
+# module globals at runtime, so patching them here upgrades validation without
+# copying the large legacy implementation.
+_base.get_default_prompts = get_default_prompts
+_base.build_marker_manifest = build_marker_manifest
+_base.build_translation_prompt = build_translation_prompt
+_base.placeholders_match = placeholders_match
+_base.repair_markers = repair_markers
+
+
+class BatchLlmEngine(_base.BatchLlmEngine):
+    """V2 batch policy: isolate marker-heavy strings before the legacy retry path."""
+
+    def translate_batch(self, items, target_lang, callbacks):
+        result: dict[str, str] = {}
+        keys = list(items.keys())
+        index = 0
+        while index < len(keys) and callbacks.should_run():
+            callbacks.wait_if_paused()
+            if not callbacks.should_run():
+                break
+
+            first_markers = len(PLACEHOLDER_PATTERN.findall(items[keys[index]].masked))
+            if first_markers >= SINGLE_ITEM_MARKER_THRESHOLD:
+                chunk = [keys[index]]
+            else:
+                end = index
+                while end < len(keys) and end - index < self.batch_size:
+                    marker_count = len(PLACEHOLDER_PATTERN.findall(items[keys[end]].masked))
+                    if marker_count >= SINGLE_ITEM_MARKER_THRESHOLD:
+                        break
+                    end += 1
+                chunk = keys[index:end]
+
+            failed = self._translate_chunk(chunk, items, target_lang, result, callbacks)
+
+            hopeless = [
+                key for key in failed
+                if len(PLACEHOLDER_PATTERN.findall(items[key].masked)) > 20
+            ]
+            if hopeless:
+                callbacks.on_log(
+                    f"⚠️ {self.label}: {len(hopeless)} строк с >20 маркерами — повторы отключены",
+                    "yellow",
+                )
+                failed = [key for key in failed if key not in hopeless]
+
+            active_retries = _base.RETRY_BATCH_SIZES[: self.retries]
+            for retry_number, retry_batch_size in enumerate(active_retries, start=1):
+                if not failed or not callbacks.should_run():
+                    break
+                callbacks.on_log(
+                    f"🔁 {self.label}: повтор {retry_number}/{len(_base.RETRY_BATCH_SIZES)} — "
+                    f"{len(failed)} строк",
+                    "orange",
+                )
+                retry_failed: list[str] = []
+                for retry_index in range(0, len(failed), retry_batch_size):
+                    if not callbacks.should_run():
+                        break
+                    callbacks.wait_if_paused()
+                    if not callbacks.should_run():
+                        break
+                    subset = failed[retry_index : retry_index + retry_batch_size]
+                    retry_failed.extend(
+                        self._translate_chunk(subset, items, target_lang, result, callbacks)
+                    )
+                failed = retry_failed
+
+            if failed and callbacks.should_run():
+                callbacks.on_log(
+                    f"⚠️ {self.label}: не удалось перевести после повторов — "
+                    f"{len(failed)} строк; сохранён исходный текст",
+                    "yellow",
+                )
+
+            index += len(chunk)
+        return result
+
+
+__all__ = [
+    "BatchLlmEngine",
+    "SINGLE_ITEM_MARKER_THRESHOLD",
+    "build_marker_manifest",
+    "build_translation_prompt",
+    "marker_validation_error",
+    "placeholders_match",
+]

--- a/mineai/engines/openrouter.py
+++ b/mineai/engines/openrouter.py
@@ -2,7 +2,7 @@ import logging
 import requests
 from mineai.constants import OPENROUTER_API
 from mineai.engines.http_retry import RequestCancelled, request_with_retry
-from mineai.engines.llm_common import BatchLlmEngine
+from mineai.engines.llm_v2 import BatchLlmEngine
 
 logger = logging.getLogger(__name__)
 

--- a/mineai/engines/service.py
+++ b/mineai/engines/service.py
@@ -1,5 +1,6 @@
 from collections import Counter
 import re
+from typing import Callable
 from mineai.cache import TranslationCache
 from mineai.config import ConfigManager
 from mineai.constants import DEFAULT_OPENROUTER_MODEL
@@ -169,11 +170,17 @@ class TranslationService:
         *,
         context: str = "",
         prompt_type: str = "mods",
+        candidate_validator: Callable[[str, str], tuple[bool, str | None]] | None = None,
+        preserve_source_structure: bool = False,
     ) -> dict[str, str]:
         if not strings:
             return {}
 
-        smart_glue = self.config.getboolean("GENERAL", "smart_glue")
+        smart_glue = (
+            False
+            if preserve_source_structure
+            else self.config.getboolean("GENERAL", "smart_glue")
+        )
         result: dict[str, str] = {}
         pending: dict[str, EngineItem] = {}
         source_owner: dict[str, str] = {}
@@ -192,9 +199,38 @@ class TranslationService:
             if callbacks.on_metric:
                 callbacks.on_metric(name, n)
 
+        def validate_candidate(
+            owner_key: str,
+            item: EngineItem,
+            text: object,
+            *,
+            validation_keys: tuple[str, ...] | None = None,
+        ):
+            ok, reason, identity = _validate_candidate(item, text, target_lang)
+            if not ok:
+                return False, reason, identity
+            assert isinstance(text, str)
+            if candidate_validator is not None:
+                keys = validation_keys or (owner_key,)
+                for validation_key in keys:
+                    format_ok, format_reason = candidate_validator(validation_key, text)
+                    if not format_ok:
+                        return (
+                            False,
+                            format_reason or "нарушена структура формата",
+                            False,
+                        )
+            return True, None, identity
+
         def commit(owner_key: str, text: object, source_label: str) -> bool:
             item = pending[owner_key]
-            ok, reason, identity = _validate_candidate(item, text, target_lang)
+            output_keys = tuple(aliases[owner_key])
+            ok, reason, identity = validate_candidate(
+                owner_key,
+                item,
+                text,
+                validation_keys=output_keys,
+            )
             if not ok:
                 failure_reasons[owner_key] = f"{source_label}: {reason}"
                 preview = repr(text)[:120] if text is not None else "None"
@@ -204,7 +240,6 @@ class TranslationService:
                 )
                 return False
             assert isinstance(text, str)
-            output_keys = aliases[owner_key]
             for key in output_keys:
                 result[key] = text
             accepted.add(owner_key)
@@ -245,7 +280,7 @@ class TranslationService:
 
             hit, is_imported = self.cache.get(target_lang["api"], text)
             if hit is not None:
-                valid, reason, _id = _validate_candidate(item, hit, target_lang)
+                valid, reason, _id = validate_candidate(key, item, hit)
                 if valid:
                     result[key] = hit
                     if is_imported:

--- a/mineai/formatkit_books_bridge.py
+++ b/mineai/formatkit_books_bridge.py
@@ -1,0 +1,522 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Mapping
+
+from mineai.text_processing import already_translated, is_technical_term, looks_like_source_language
+from mineai.formatkit_profile import (
+    MineAiModonomiconBookJsonAdapter,
+    MineAiPatchouliBookJsonAdapter,
+)
+from mineai_formatkit import (
+    FORMATKIT_PILOT_HARDENING,
+    FORMATKIT_SOURCE_SHA,
+    ImmersiveEngineeringManualAdapter,
+    TranslationPlan,
+    TranslationUnit,
+    ValidationError,
+)
+
+
+_PLACEHOLDER_RE = re.compile(r"\[#\d+#\]")
+_WORD_RE = re.compile(r"[^\W_]+(?:[’'][^\W_]+)?", re.UNICODE)
+
+
+def _semantic_anchor_rows(plan: TranslationPlan, parent_id: str):
+    anchors = plan.metadata.get("semantic_anchors")
+    if not isinstance(anchors, dict):
+        return ()
+    rows = anchors.get(parent_id, ())
+    return rows if isinstance(rows, tuple) else tuple(rows) if isinstance(rows, list) else ()
+
+
+def _semantic_child_ids(plan: TranslationPlan) -> set[str]:
+    anchors = plan.metadata.get("semantic_anchors")
+    if not isinstance(anchors, dict):
+        return set()
+    out: set[str] = set()
+    for rows in anchors.values():
+        if not isinstance(rows, (tuple, list)):
+            continue
+        for anchor in rows:
+            child_id = getattr(anchor, "child_id", None)
+            if isinstance(child_id, str):
+                out.add(child_id)
+    return out
+
+
+def split_semantic_book_pending(
+    work: "FormatKitBookWork",
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Translate semantic children before parents that depend on them.
+
+    Non-semantic documents keep the original single-stage behavior. The split is
+    host scheduling only; FormatKit remains the parser/reconstruction authority.
+    """
+
+    child_ids = _semantic_child_ids(work.source_plan)
+    if not child_ids:
+        return {}, dict(work.pending)
+    children = {key: value for key, value in work.pending.items() if key in child_ids}
+    remaining = {key: value for key, value in work.pending.items() if key not in child_ids}
+    return children, remaining
+
+
+def semantic_resolved_values(
+    work: "FormatKitBookWork", translated: Mapping[str, str]
+) -> dict[str, str]:
+    """Return the effective child payloads available to parent validation."""
+
+    out: dict[str, str] = {}
+    for child_id in _semantic_child_ids(work.source_plan):
+        unit = work.units_by_id.get(child_id)
+        if unit is None:
+            continue
+        out[child_id] = translated.get(
+            child_id,
+            work.preserved.get(child_id, work.passthrough.get(child_id, unit.text)),
+        )
+    return out
+
+
+def _lexical_words(text: str) -> tuple[str, ...]:
+    visible = _PLACEHOLDER_RE.sub(" ", text)
+    return tuple(match.group(0).casefold() for match in _WORD_RE.finditer(visible))
+
+
+def _duplicate_sides_next_to_anchor(
+    parent_text: str, placeholder: str, child_text: str
+) -> frozenset[str]:
+    if parent_text.count(placeholder) != 1:
+        return frozenset()
+    child_words = _lexical_words(child_text)
+    if not child_words or sum(len(word) for word in child_words) < 3:
+        return frozenset()
+    left, right = parent_text.split(placeholder, 1)
+    left_words = _lexical_words(left)
+    right_words = _lexical_words(right)
+    size = len(child_words)
+    sides: set[str] = set()
+    if len(left_words) >= size and left_words[-size:] == child_words:
+        sides.add("left")
+    if len(right_words) >= size and right_words[:size] == child_words:
+        sides.add("right")
+    return frozenset(sides)
+
+
+_ANCHOR_PREFIX_FUNCTION_WORDS = frozenset(
+    {
+        # Articles/determiners used by the currently supported target languages.
+        "a", "an", "the",
+        "un", "una", "uno", "el", "la", "los", "las",
+        "ein", "eine", "einer", "einem", "einen", "eines",
+        "der", "die", "das", "den", "dem", "des",
+        "le", "les", "une",
+        "o", "os", "as", "um", "uma", "uns", "umas",
+        "il", "lo", "gli", "i",
+        "это", "этот", "эта", "эти",
+        "данный", "данная", "данное", "данные",
+    }
+)
+
+
+def _clause_words_before_anchor(text: str) -> tuple[str, ...]:
+    """Return lexical words in the local clause immediately before an anchor."""
+
+    starts = [0]
+    for match in _PLACEHOLDER_RE.finditer(text):
+        starts.append(match.end())
+    for match in re.finditer(r"[.!?]\s+", text):
+        starts.append(match.end())
+    return _lexical_words(text[max(starts) :])
+
+
+def _introduces_label_before_bare_anchor(
+    source_parent: str, candidate: str, placeholder: str
+) -> bool:
+    """Detect an invented label before an article-led semantic anchor.
+
+    A real runtime failure translated ``An [#0#] is ...`` as
+    ``Аффикс [#0#] — ...`` while the semantic child itself was translated to a
+    different synonym. Exact child-text comparison cannot catch that case.
+    Only the narrow article-at-clause-start + copula shape is guarded here so
+    ordinary reordering around anchors elsewhere in a sentence remains valid.
+    """
+
+    if source_parent.count(placeholder) != 1 or candidate.count(placeholder) != 1:
+        return False
+
+    source_left, source_right = source_parent.split(placeholder, 1)
+    if _clause_words_before_anchor(source_left) not in {
+        ("a",),
+        ("an",),
+        ("the",),
+    }:
+        return False
+    if re.match(r"\s*(?:is|are|was|were)\b", source_right, re.IGNORECASE) is None:
+        return False
+
+    candidate_left, _ = candidate.split(placeholder, 1)
+    candidate_words = _clause_words_before_anchor(candidate_left)
+    if not candidate_words:
+        return False
+    last_word = candidate_words[-1]
+    return len(last_word) > 2 and last_word not in _ANCHOR_PREFIX_FUNCTION_WORDS
+
+
+def _semantic_duplication_reason(
+    work: "FormatKitBookWork",
+    parent_id: str,
+    candidate: str,
+    resolved_semantic: Mapping[str, str],
+) -> str | None:
+    parent = work.units_by_id.get(parent_id)
+    if parent is None:
+        return None
+    for anchor in _semantic_anchor_rows(work.source_plan, parent_id):
+        placeholder = getattr(anchor, "placeholder", None)
+        child_id = getattr(anchor, "child_id", None)
+        if not isinstance(placeholder, str) or not isinstance(child_id, str):
+            continue
+        child = work.units_by_id.get(child_id)
+        child_candidate = resolved_semantic.get(child_id)
+        if child is None or not isinstance(child_candidate, str):
+            continue
+
+        # Repetition already present in canonical source is author-owned and must
+        # never be "fixed" by MineAI. Reject only a newly introduced adjacency.
+        source_sides = _duplicate_sides_next_to_anchor(
+            parent.text, placeholder, child.text
+        )
+        candidate_sides = _duplicate_sides_next_to_anchor(
+            candidate, placeholder, child_candidate
+        )
+        introduced_sides = candidate_sides - source_sides
+        if introduced_sides:
+            side_label = ",".join(sorted(introduced_sides))
+            return (
+                f"semantic anchor {placeholder} duplicates translated child "
+                f"{child_id} outside its source-owned wrapper ({side_label})"
+            )
+        if _introduces_label_before_bare_anchor(parent.text, candidate, placeholder):
+            return (
+                f"semantic anchor {placeholder} introduces an extra label before "
+                f"translated child {child_id}"
+            )
+    return None
+
+
+@dataclass(frozen=True)
+class FormatKitBookWork:
+    adapter_name: str
+    adapter: object
+    source_plan: TranslationPlan
+    units_by_id: Mapping[str, TranslationUnit]
+    pending: Mapping[str, str]
+    preserved: Mapping[str, str]
+    passthrough: Mapping[str, str]
+    total_translatable: int
+    target_path: str
+    target_parse_error: str | None
+    emit_structural_copy: bool = False
+    target_reuse_disabled: bool = False
+
+
+# Only formats already exercised by the MineAI pilots are enabled here. The
+# current SDK registry supports more formats, but v3.4 is a synchronization and
+# cleanup step, not a feature-expansion release.
+_BOOK_ADAPTERS = (
+    MineAiModonomiconBookJsonAdapter(),
+    MineAiPatchouliBookJsonAdapter(),
+    ImmersiveEngineeringManualAdapter(),
+)
+
+
+def book_adapter_for(path: str):
+    normalized = path.replace("\\", "/")
+    for adapter in _BOOK_ADAPTERS:
+        if adapter.matches(normalized):
+            return adapter
+    return None
+
+
+def is_formatkit_book_path(path: str) -> bool:
+    return book_adapter_for(path) is not None
+
+
+def _is_modonomicon_data(adapter) -> bool:
+    return getattr(adapter, "name", "") == "modonomicon-book-json"
+
+
+def target_path_for_book(path: str, target_code: str) -> str | None:
+    """Return MineAI's output path for an SDK-owned book source.
+
+    Modonomicon book JSON is locale-neutral datapack data. The SDK deliberately
+    refuses to invent a locale target path for it; MineAI, as the output-policy
+    owner, overlays the translated document at the same ``data/...`` path.
+    """
+
+    adapter = book_adapter_for(path)
+    if adapter is None:
+        return None
+    normalized = path.replace("\\", "/")
+    if _is_modonomicon_data(adapter):
+        return normalized
+    return adapter.target_path(normalized, target_code)
+
+
+def _raw_source_value(plan: TranslationPlan, unit: TranslationUnit) -> str:
+    # Prefer SDK-owned semantic payload metadata where available. This keeps
+    # host filtering independent from parser internals while correctly handling
+    # semantic child units whose source offsets intentionally cover an outer
+    # field/line.
+    for key in ("originals", "semantic_payloads", "original_values"):
+        values = plan.metadata.get(key)
+        if isinstance(values, dict):
+            value = values.get(unit.id)
+            if isinstance(value, str):
+                return value
+    return unit.text
+
+
+def _protected_values(unit: TranslationUnit) -> tuple[str, ...]:
+    return tuple(fragment.value for fragment in unit.protected)
+
+
+def _has_semantic_anchors(plan: TranslationPlan) -> bool:
+    anchors = plan.metadata.get("semantic_anchors")
+    return isinstance(anchors, dict) and bool(anchors)
+
+
+def _display_adapter_name(adapter, plan: TranslationPlan) -> str:
+    # The current SDK intentionally folds Patchouli templates into the normal
+    # Patchouli adapter and exposes zero translation units. Keep the historical
+    # MineAI label only for UI/logging and structural-copy policy; there is no
+    # second template parser anymore.
+    if plan.metadata.get("patchouli_template_immutable") is True:
+        return "patchouli-template-json"
+    return getattr(adapter, "name", type(adapter).__name__)
+
+
+def _validate_candidate(
+    adapter,
+    plan: TranslationPlan,
+    units_by_id: Mapping[str, TranslationUnit],
+    unit_id: str,
+    candidate: str,
+) -> tuple[bool, str | None]:
+    """Validate one candidate through the unmodified SDK adapter.
+
+    v3.2's per-unit fallback remains a MineAI transport policy. The former
+    vendored SDK helper has been removed: reconstructing one candidate against
+    the canonical plan invokes the adapter's own local and whole-document
+    invariants and is therefore the authoritative fail-closed check.
+    """
+
+    if unit_id not in units_by_id:
+        return False, f"unknown translation unit {unit_id}"
+    try:
+        adapter.apply(plan, {unit_id: candidate})
+    except (ValidationError, ValueError) as exc:
+        return False, str(exc)
+    return True, None
+
+
+def _existing_target_candidates(
+    adapter,
+    source_plan: TranslationPlan,
+    target_text: str,
+):
+    """Yield public-SDK target candidates in source unit order.
+
+    No private ``_parse``/``_protect``/JSON-pointer access is used. Re-planning
+    the target through the same public adapter lets us compare unit topology and
+    exact protected runtime fragments before considering reuse.
+    """
+
+    target_plan = adapter.prepare(source_plan.path, target_text)
+    if len(source_plan.units) != len(target_plan.units):
+        raise ValidationError("existing target translation unit topology changed")
+
+    for source_unit, target_unit in zip(source_plan.units, target_plan.units):
+        if source_unit.kind != target_unit.kind:
+            raise ValidationError("existing target translation unit kind changed")
+        if _protected_values(source_unit) != _protected_values(target_unit):
+            raise ValidationError("existing target protected runtime fragments changed")
+        yield source_unit, target_unit.text
+
+
+def plan_book_work(
+    path: str,
+    source_text: str,
+    target_code: str,
+    target_regex: str,
+    target_text: str | None,
+    mode: str,
+) -> FormatKitBookWork | None:
+    adapter = book_adapter_for(path)
+    if adapter is None:
+        return None
+
+    normalized = path.replace("\\", "/")
+    source_plan = adapter.prepare(normalized, source_text)
+    units_by_id = source_plan.by_id()
+    display_name = _display_adapter_name(adapter, source_plan)
+    emit_structural_copy = source_plan.metadata.get("patchouli_template_immutable") is True
+    target_path = target_path_for_book(normalized, target_code)
+    assert target_path is not None
+
+    eligible_ids: set[str] = set()
+    for unit in source_plan.units:
+        original = _raw_source_value(source_plan, unit)
+        if not isinstance(original, str) or not original.strip():
+            continue
+        if not looks_like_source_language(original) or is_technical_term(original):
+            continue
+        eligible_ids.add(unit.id)
+
+    preserved: dict[str, str] = {}
+    target_parse_error: str | None = None
+
+    # A v3.3 target can preserve every flat marker yet attach a style/link to the
+    # wrong words. Once the SDK reports semantic anchors, do not mine wording
+    # from that old target. Rebuild from canonical English + newly validated
+    # semantic units instead. This is intentionally conservative for the first
+    # SDK-sync pilot and prevents a previously accepted bad pack from reviving
+    # through Append mode.
+    target_reuse_disabled = _has_semantic_anchors(source_plan)
+
+    if (
+        mode != "force"
+        and target_text
+        and not emit_structural_copy
+        and not _is_modonomicon_data(adapter)
+        and not target_reuse_disabled
+    ):
+        try:
+            for source_unit, candidate in _existing_target_candidates(
+                adapter, source_plan, target_text
+            ):
+                if source_unit.id not in eligible_ids:
+                    continue
+                if candidate == source_unit.text:
+                    continue
+                if not already_translated(candidate, target_regex):
+                    continue
+                ok, reason = _validate_candidate(
+                    adapter, source_plan, units_by_id, source_unit.id, candidate
+                )
+                if not ok:
+                    raise ValidationError(reason or "existing target candidate rejected")
+                preserved[source_unit.id] = candidate
+        except (ValidationError, ValueError, KeyError, IndexError, TypeError) as exc:
+            target_parse_error = str(exc)
+            preserved.clear()
+
+    pending = {
+        unit.id: unit.text
+        for unit in source_plan.units
+        if unit.id in eligible_ids and unit.id not in preserved
+    }
+    passthrough = {
+        unit.id: unit.text
+        for unit in source_plan.units
+        if unit.id not in eligible_ids
+    }
+
+    return FormatKitBookWork(
+        adapter_name=display_name,
+        adapter=adapter,
+        source_plan=source_plan,
+        units_by_id=units_by_id,
+        pending=pending,
+        preserved=preserved,
+        passthrough=passthrough,
+        total_translatable=len(eligible_ids),
+        target_path=target_path,
+        target_parse_error=target_parse_error,
+        emit_structural_copy=emit_structural_copy,
+        target_reuse_disabled=target_reuse_disabled,
+    )
+
+
+def validate_book_candidate(
+    work: FormatKitBookWork,
+    unit_id: str,
+    candidate: str,
+    *,
+    resolved_semantic: Mapping[str, str] | None = None,
+) -> tuple[bool, str | None]:
+    ok, reason = _validate_candidate(
+        work.adapter,
+        work.source_plan,
+        work.units_by_id,
+        unit_id,
+        candidate,
+    )
+    if not ok:
+        return False, f"FormatKit: {reason}"
+    if resolved_semantic is not None:
+        duplicate_reason = _semantic_duplication_reason(
+            work, unit_id, candidate, resolved_semantic
+        )
+        if duplicate_reason is not None:
+            return False, f"FormatKit: {duplicate_reason}"
+    return True, None
+
+
+def build_book_output(work: FormatKitBookWork, translated: Mapping[str, str]) -> str:
+    values = dict(work.passthrough)
+    values.update(work.preserved)
+    for unit_id in work.pending:
+        values[unit_id] = translated.get(unit_id, work.units_by_id[unit_id].text)
+
+    # Semantic child units are reconstructed inside their parent prose. If a
+    # parent translation was rejected and therefore falls back to canonical
+    # source text, applying a translated child would create a mixed-language
+    # fragment (for example ``An $(6)Прикрепление$() is ...``). Keep the whole
+    # source-owned semantic fragment atomic on fallback: a child is reverted
+    # only when every parent that owns it is also falling back.
+    child_parents: dict[str, set[str]] = {}
+    anchors = work.source_plan.metadata.get("semantic_anchors")
+    if isinstance(anchors, dict):
+        for parent_id, rows in anchors.items():
+            if not isinstance(parent_id, str) or not isinstance(rows, (tuple, list)):
+                continue
+            for anchor in rows:
+                child_id = getattr(anchor, "child_id", None)
+                if isinstance(child_id, str):
+                    child_parents.setdefault(child_id, set()).add(parent_id)
+
+    for child_id, parent_ids in child_parents.items():
+        if child_id not in values:
+            continue
+        if parent_ids and all(
+            parent_id in work.pending
+            and (
+                parent_id not in translated
+                or translated.get(parent_id) == work.units_by_id[parent_id].text
+            )
+            for parent_id in parent_ids
+        ):
+            child = work.units_by_id.get(child_id)
+            if child is not None:
+                values[child_id] = child.text
+
+    return work.adapter.apply(work.source_plan, values)
+
+
+__all__ = [
+    "FORMATKIT_PILOT_HARDENING",
+    "FORMATKIT_SOURCE_SHA",
+    "FormatKitBookWork",
+    "book_adapter_for",
+    "build_book_output",
+    "is_formatkit_book_path",
+    "plan_book_work",
+    "semantic_resolved_values",
+    "split_semantic_book_pending",
+    "target_path_for_book",
+    "validate_book_candidate",
+]

--- a/mineai/formatkit_bridge.py
+++ b/mineai/formatkit_bridge.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Callable, Mapping
+
+from mineai.text_processing import is_technical_term, looks_like_source_language
+from mineai.formatkit_profile import MineAiLocaleMergePlanner, MineAiMinecraftLangJsonAdapter
+from mineai_formatkit import (
+    FORMATKIT_SOURCE_SHA,
+    CollapsibleGroupsConfigLangJsonAdapter,
+    JaopcaConfigLangJsonAdapter,
+    LocaleMergePlan,
+    TranslationUnit,
+    ValidationError,
+)
+
+
+@dataclass(frozen=True)
+class FormatKitLocaleWork:
+    """One MineAI locale job planned by the pinned FormatKit SDK slice."""
+
+    adapter_name: str
+    planner: MineAiLocaleMergePlanner
+    plan: LocaleMergePlan
+    units_by_id: Mapping[str, TranslationUnit]
+    pending: Mapping[str, str]
+    passthrough: Mapping[str, str]
+    total_translatable: int
+    target_path: str
+    target_parse_error: str | None
+    target_text: str | None
+
+
+_LOCALE_ADAPTERS = (
+    CollapsibleGroupsConfigLangJsonAdapter(),
+    JaopcaConfigLangJsonAdapter(),
+    MineAiMinecraftLangJsonAdapter(),
+)
+
+
+def locale_adapter_for(path: str):
+    """Return the first SDK locale adapter enabled by the MineAI pilot."""
+
+    normalized = path.replace("\\", "/")
+    for adapter in _LOCALE_ADAPTERS:
+        if adapter.matches(normalized):
+            return adapter
+    return None
+
+
+def modonomicon_locale_adapter():
+    """Compatibility accessor for the books-only Modonomicon path.
+
+    The current SDK profile's public Minecraft locale adapter is already
+    Modonomicon-aware, so there is no longer a second patched adapter or
+    archive-dependent behavior.
+    """
+
+    return _LOCALE_ADAPTERS[-1]
+
+
+def is_formatkit_locale_path(path: str) -> bool:
+    return locale_adapter_for(path) is not None
+
+
+def target_path_for_locale(path: str, target_code: str) -> str | None:
+    adapter = locale_adapter_for(path)
+    if adapter is None:
+        return None
+    return adapter.target_path(path.replace("\\", "/"), target_code)
+
+
+def plan_locale_work(
+    path: str,
+    source_text: str,
+    target_code: str,
+    target_text: str | None,
+    mode: str,
+    *,
+    adapter=None,
+    key_filter: Callable[[str], bool] | None = None,
+) -> FormatKitLocaleWork | None:
+    """Plan a locale while MineAI keeps product-level translation filtering.
+
+    FormatKit owns parsing, protected syntax, target reuse and reconstruction.
+    MineAI still decides which structurally-safe units are useful to translate.
+
+    ``adapter`` remains only as a compatibility argument for the v3.3 books-only
+    call site. The compatibility accessor now returns the same official SDK
+    Minecraft locale adapter used by the normal path.
+    """
+
+    adapter = adapter or locale_adapter_for(path)
+    if adapter is None:
+        return None
+
+    planner = MineAiLocaleMergePlanner(adapter=adapter)
+    planner_mode = "append" if mode == "skip" else mode
+    merge_plan = planner.plan(
+        path.replace("\\", "/"),
+        source_text,
+        target_code,
+        target_text=target_text,
+        mode=planner_mode,
+    )
+
+    units = merge_plan.source_plan.by_id()
+    originals = merge_plan.source_plan.metadata.get("original_values", {})
+    eligible_ids: set[str] = set()
+    for unit_id, unit in units.items():
+        original = originals.get(unit_id, unit.text) if isinstance(originals, dict) else unit.text
+        if not isinstance(original, str) or not original.strip():
+            continue
+        if not looks_like_source_language(original) or is_technical_term(original):
+            continue
+        if key_filter is not None and not key_filter(unit.context):
+            continue
+        eligible_ids.add(unit_id)
+
+    pending_ids = set(merge_plan.pending_ids)
+    pending = {
+        unit_id: units[unit_id].text
+        for unit_id in merge_plan.pending_ids
+        if unit_id in eligible_ids
+    }
+    passthrough = {
+        unit_id: units[unit_id].text
+        for unit_id in merge_plan.pending_ids
+        if unit_id not in eligible_ids
+    }
+    if set(pending) | set(passthrough) != pending_ids:
+        raise ValueError("FormatKit locale bridge failed to classify pending units")
+
+    return FormatKitLocaleWork(
+        adapter_name=adapter.name,
+        planner=planner,
+        plan=merge_plan,
+        units_by_id=units,
+        pending=pending,
+        passthrough=passthrough,
+        total_translatable=len(eligible_ids),
+        target_path=merge_plan.target_path,
+        target_parse_error=merge_plan.target_parse_error,
+        target_text=target_text,
+    )
+
+
+def validate_locale_candidate(
+    work: FormatKitLocaleWork,
+    unit_id: str,
+    candidate: str,
+) -> tuple[bool, str | None]:
+    """Validate one candidate through the unmodified SDK adapter.
+
+    Pilot v3.3 carried a custom validation helper inside the vendored SDK. v3.4
+    removes that fork: MineAI asks the owning adapter to reconstruct one changed
+    unit against the canonical source plan. Adapter validation remains the only
+    authority and rejected candidates never reach cache/write.
+    """
+
+    if unit_id not in work.units_by_id:
+        return False, f"FormatKit: unknown translation unit {unit_id}"
+    try:
+        work.planner.adapter.apply(work.plan.source_plan, {unit_id: candidate})
+    except (ValidationError, ValueError) as exc:
+        return False, f"FormatKit: {exc}"
+    return True, None
+
+
+def build_locale_output(
+    work: FormatKitLocaleWork,
+    translated: Mapping[str, str],
+) -> str:
+    """Build a complete validated locale, retaining source for rejected items.
+
+    The SDK merge planner deliberately performs cheap target-reuse checks while
+    planning and the owning adapter performs the full semantic validation when
+    reconstructing.  A real Modonomicon RU locale can therefore contain one
+    legacy value whose markup is no longer safe to reuse even though the rest of
+    the target file is valid.  Never let that single reused value drop the whole
+    generated locale: retry once with every existing target value converted to a
+    public ``prepare()`` candidate.  Values that still violate the canonical
+    source contract fall back to the source unit only; safe translated prose is
+    retained and source-owned runtime syntax is restored by the SDK adapter.
+    """
+
+    values = dict(work.passthrough)
+    for unit_id in work.pending:
+        values[unit_id] = translated.get(unit_id, work.units_by_id[unit_id].text)
+    try:
+        return work.planner.build(work.plan, values)
+    except (ValidationError, ValueError):
+        if work.target_text is None or not work.plan.existing_values:
+            raise
+
+    adapter = work.planner.adapter
+    try:
+        target_plan = adapter.prepare(work.plan.source_plan.path, work.target_text)
+        target_units = target_plan.by_id()
+    except (ValidationError, ValueError):
+        target_units = {}
+
+    recovery_ids = set(work.plan.pending_ids) | set(work.plan.existing_values)
+    recovery_values = dict(values)
+    for unit_id in work.plan.existing_values:
+        source_unit = work.units_by_id.get(unit_id)
+        if source_unit is None:
+            continue
+        target_unit = target_units.get(unit_id)
+        candidate = target_unit.text if target_unit is not None else source_unit.text
+        try:
+            adapter.apply(work.plan.source_plan, {unit_id: candidate})
+        except (ValidationError, ValueError):
+            candidate = source_unit.text
+        recovery_values[unit_id] = candidate
+
+    ordered_recovery_ids = tuple(
+        unit.id for unit in work.plan.source_plan.units if unit.id in recovery_ids
+    )
+    recovery_plan = replace(
+        work.plan,
+        pending_ids=ordered_recovery_ids,
+        existing_values={},
+    )
+    return work.planner.build(recovery_plan, recovery_values)
+
+
+__all__ = [
+    "FORMATKIT_SOURCE_SHA",
+    "FormatKitLocaleWork",
+    "build_locale_output",
+    "is_formatkit_locale_path",
+    "locale_adapter_for",
+    "modonomicon_locale_adapter",
+    "plan_locale_work",
+    "validate_locale_candidate",
+    "target_path_for_locale",
+]

--- a/mineai/formatkit_profile.py
+++ b/mineai/formatkit_profile.py
@@ -1,0 +1,149 @@
+"""MineAI host safety profile layered on the pinned public FormatKit SDK.
+
+The vendored ``mineai_formatkit`` parser/reconstruction modules stay byte-for-byte
+copies of the pinned upstream SDK.  MineAI-specific runtime policy lives here:
+exact protected-marker order, per-unit candidate hooks, and the two corpus-proven
+Patchouli guards retained from the v3.4 acceptance line.
+"""
+
+from __future__ import annotations
+
+import re
+
+from mineai_formatkit.core import ProtectedFragment, TranslationPlan, TranslationUnit, ValidationError
+from mineai_formatkit.minecraft_lang import _PLACEHOLDER_RE
+from mineai_formatkit.modonomicon import (
+    ModonomiconAwareLocaleMergePlanner,
+    ModonomiconAwareMinecraftLangJsonAdapter,
+    ModonomiconBookJsonAdapter as _ModonomiconBookJsonAdapter,
+)
+from mineai_formatkit.patchouli_base import PatchouliFingerprint
+from mineai_formatkit.patchouli_safe import PatchouliBookJsonAdapter as _PatchouliBookJsonAdapter
+
+
+class MineAiMinecraftLangJsonAdapter(ModonomiconAwareMinecraftLangJsonAdapter):
+    """Public locale stack plus the exact marker-order invariant proven by MineAI."""
+
+    name = "minecraft-lang-json"
+
+    def _protect(self, text: str) -> tuple[str, tuple[ProtectedFragment, ...]]:
+        masked, protected = super()._protect(text)
+        occurrence = {
+            match.group(0): index
+            for index, match in enumerate(_PLACEHOLDER_RE.finditer(masked))
+        }
+        return masked, tuple(
+            sorted(
+                protected,
+                key=lambda fragment: occurrence.get(fragment.placeholder, 10**9),
+            )
+        )
+
+    @staticmethod
+    def _restore_protected(unit: TranslationUnit, translated: str) -> str:
+        expected = [fragment.placeholder for fragment in unit.protected]
+        actual = [match.group(0) for match in _PLACEHOLDER_RE.finditer(translated)]
+        if actual != expected:
+            raise ValidationError(
+                f"Unit {unit.id} changed protected placeholder order: "
+                f"expected {expected}, got {actual}"
+            )
+        restored = translated
+        for fragment in unit.protected:
+            restored = restored.replace(fragment.placeholder, fragment.value)
+        return restored
+
+    def validate_candidate(
+        self, plan: TranslationPlan, unit_id: str, candidate: str
+    ) -> None:
+        if unit_id not in plan.by_id():
+            raise ValidationError(f"Unknown translation unit id: {unit_id}")
+        self.apply(plan, {unit_id: candidate})
+
+
+class MineAiLocaleMergePlanner(ModonomiconAwareLocaleMergePlanner):
+    """Public FormatKit merge planner using MineAI's exact-order locale adapter."""
+
+    def __init__(self, adapter: MineAiMinecraftLangJsonAdapter | None = None) -> None:
+        super().__init__(adapter or MineAiMinecraftLangJsonAdapter())
+
+
+class MineAiModonomiconBookJsonAdapter(_ModonomiconBookJsonAdapter):
+    """Public Modonomicon adapter plus a real-corpus DescriptionId boundary.
+
+    Genetics Resequenced 1.21.1 uses translation DescriptionIds containing a
+    slash inside a technical path segment, e.g. ``book.demo.guide.demo/entry.text``.
+    Current FormatKit main recognises dotted DescriptionIds but not this proven
+    slash form, so without this host compatibility guard the identifier itself
+    can be exposed to the LLM. Keep the grammar deliberately narrow and
+    whitespace-free; literal prose still falls through to the SDK classifier.
+    """
+
+    _DESCRIPTION_ID_WITH_PATH_RE = re.compile(
+        r"^[A-Za-z0-9_-]+(?:[./][A-Za-z0-9_-]+){2,}$"
+    )
+
+    @staticmethod
+    def _is_inline_prose(value: str) -> bool:
+        if MineAiModonomiconBookJsonAdapter._DESCRIPTION_ID_WITH_PATH_RE.fullmatch(value):
+            return False
+        return _ModonomiconBookJsonAdapter._is_inline_prose(value)
+
+    def validate_candidate(
+        self, plan: TranslationPlan, unit_id: str, candidate: str
+    ) -> None:
+        if unit_id not in plan.by_id():
+            raise ValidationError(f"Unknown translation unit id: {unit_id}")
+        self.apply(plan, {unit_id: candidate})
+
+
+class MineAiPatchouliBookJsonAdapter(_PatchouliBookJsonAdapter):
+    """Public semantic-anchor adapter plus two previously proven MineAI invariants."""
+
+    name = "patchouli-book-json"
+
+    def fingerprint(self, text: str) -> PatchouliFingerprint:
+        root = self._parse(text)
+        targets = []
+        self._collect(root, "", targets)
+        selected = [(locator, node) for locator, node, _value in targets]
+        out: list[str] = []
+        cursor = 0
+        for locator, node in sorted(selected, key=lambda item: item[1].start):
+            out.append(text[cursor:node.start])
+            out.append('"<mineai-patchouli-text>"')
+            cursor = node.end
+        out.append(text[cursor:])
+        return PatchouliFingerprint(
+            locators=tuple(locator for locator, _node in selected),
+            skeleton="".join(out),
+        )
+
+    def validate(self, source_text: str, output_text: str) -> None:
+        if self.fingerprint(source_text) != self.fingerprint(output_text):
+            raise ValidationError("Patchouli JSON structure changed during reconstruction")
+
+        before = self._values_by_locator(source_text)
+        after = self._values_by_locator(output_text)
+        if before.keys() != after.keys():
+            raise ValidationError("Patchouli translatable field locations changed")
+        for locator, original in before.items():
+            translated = after[locator]
+            if translated.count("\\") != original.count("\\"):
+                raise ValidationError(
+                    f"Patchouli field {locator} changed literal backslash structure"
+                )
+
+    def _values_by_locator(self, text: str) -> dict[str, str]:
+        root = self._parse(text)
+        targets = []
+        self._collect(root, "", targets)
+        return {locator: value for locator, _node, value in targets}
+
+
+__all__ = [
+    "MineAiLocaleMergePlanner",
+    "MineAiMinecraftLangJsonAdapter",
+    "MineAiModonomiconBookJsonAdapter",
+    "MineAiPatchouliBookJsonAdapter",
+]

--- a/mineai/pilot_v2_bootstrap.py
+++ b/mineai/pilot_v2_bootstrap.py
@@ -1,0 +1,92 @@
+"""Install pilot-v2 host safety without changing the certified FormatKit snapshot."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import re
+
+from mineai import formatkit_bridge as _bridge
+from mineai.text_processing import (
+    PLACEHOLDER_PATTERN,
+    is_technical_term,
+    looks_like_source_language,
+)
+
+
+_PILOT_KEY_LABELS = frozenset(
+    {"[shift]", "[ctrl]", "[alt]", "[tab]", "[enter]", "[esc]", "[escape]"}
+)
+_COORDINATE_PAIR_RE = re.compile(
+    r"^[+-]?\d+(?:\.\d+)?\s*[NS]\s+[+-]?\d+(?:\.\d+)?\s*[EW]$",
+    re.IGNORECASE,
+)
+_UUID_VALUE_RE = re.compile(
+    r"^UUID\s*:\s*(?:\[\s*#\s*\d+\s*#\s*\]\s*)+$",
+    re.IGNORECASE,
+)
+_PURE_PLACEHOLDER_FORMAT_RE = re.compile(r"^[\s+\-*/=():.,%$]*$")
+_ORIGINAL_PLAN_LOCALE_WORK = _bridge.plan_locale_work
+_INSTALLED = False
+
+
+def _is_obvious_runtime_technical(text: str, masked_text: str) -> bool:
+    stripped = text.strip()
+    masked = masked_text.strip()
+    if stripped in {"true", "false"}:
+        return True
+    if stripped.casefold() in _PILOT_KEY_LABELS:
+        return True
+    if _COORDINATE_PAIR_RE.fullmatch(stripped):
+        return True
+    if _UUID_VALUE_RE.fullmatch(masked):
+        return True
+    if PLACEHOLDER_PATTERN.search(masked):
+        visible = PLACEHOLDER_PATTERN.sub("", masked)
+        if _PURE_PLACEHOLDER_FORMAT_RE.fullmatch(visible):
+            return True
+    return False
+
+
+def _plan_locale_work_v2(*args, **kwargs):
+    work = _ORIGINAL_PLAN_LOCALE_WORK(*args, **kwargs)
+    if work is None:
+        return None
+
+    units = work.plan.source_plan.by_id()
+    originals = work.plan.source_plan.metadata.get("original_values", {})
+    filtered_ids: set[str] = set()
+    for unit_id, unit in units.items():
+        original = originals.get(unit_id, unit.text) if isinstance(originals, dict) else unit.text
+        if not isinstance(original, str) or not original.strip():
+            continue
+        was_eligible = looks_like_source_language(original) and not is_technical_term(original)
+        if was_eligible and _is_obvious_runtime_technical(original, unit.text):
+            filtered_ids.add(unit_id)
+
+    if not filtered_ids:
+        return work
+
+    pending = dict(work.pending)
+    passthrough = dict(work.passthrough)
+    for unit_id in filtered_ids:
+        if unit_id in pending:
+            pending.pop(unit_id)
+            passthrough[unit_id] = units[unit_id].text
+
+    return replace(
+        work,
+        pending=pending,
+        passthrough=passthrough,
+        total_translatable=max(0, work.total_translatable - len(filtered_ids)),
+    )
+
+
+def install_pilot_v2() -> None:
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    _bridge.plan_locale_work = _plan_locale_work_v2
+    _INSTALLED = True
+
+
+__all__ = ["install_pilot_v2"]

--- a/mineai/processors/analyzer.py
+++ b/mineai/processors/analyzer.py
@@ -3,9 +3,16 @@ import os
 import re
 import zipfile
 
-from mineai.constants import BOOK_PATH_MARKERS, MD_PATH_MARKERS, RESEARCH_PATH_MARKERS
+from mineai.constants import BOOK_PATH_MARKERS, RESEARCH_PATH_MARKERS
 from mineai.json_utils import iter_translatable_strings, load_lenient_json
+from mineai import formatkit_bridge as _formatkit_bridge
 from mineai.mod_names import get_mod_name
+from mineai.processors.markdown_guides import (
+    get_markdown_target_path,
+    is_source_markdown_guide,
+    is_target_markdown_locale_path,
+)
+from mineai.processors.selection import collect_book_markdown_selection
 from mineai.processors.snbt_extract import extract_snbt_strings
 from mineai.runtime.state import JobState
 from mineai.text_processing import (
@@ -71,13 +78,13 @@ class ModpackAnalyzer:
                         # Отсекаем файлы других локализаций в корне (ru_ru, es_es и т.д.)
                         if re.match(r"^[a-z]{2}_[a-z]{2}\.snbt$", nl) and nl != "en_us.snbt":
                             continue
-                        
+
                         # Отсекаем огромный резервный en_us.snbt, если рядом есть папка en_us
                         if nl == "en_us.snbt" and os.path.isdir(os.path.join(root, "en_us")):
                             continue
 
                         snbt_files.append(os.path.join(root, name))
-        
+
         # ПОИСК BQ
         bq_dir = os.path.join(mc_dir, "config", "betterquesting", "DefaultQuests")
         bq_files: list[str] = []
@@ -86,7 +93,7 @@ class ModpackAnalyzer:
                 for name in files:
                     if name.endswith(".json") and ("QuestLines" in root or "Quests" in root):
                         bq_files.append(os.path.join(root, name))
-                        
+
         for index, path in enumerate(snbt_files):
             if not self.state.should_run():
                 break
@@ -109,13 +116,15 @@ class ModpackAnalyzer:
     def _analyze_jar(self, path, target_file, target_regex, translate_mods, translate_books, on_row, mod_name):
         total_en = 0
         total_tr = 0
+        target_code = target_file.replace(".json", "")
         try:
             with zipfile.ZipFile(path, "r") as zin:
                 locale = {
                     i.filename.lower(): i
                     for i in zin.infolist()
                     if target_file in i.filename.lower()
-                    or f"/{target_file.replace('.json','')}/" in i.filename.lower()
+                    or f"/{target_code}/" in i.filename.lower()
+                    or is_target_markdown_locale_path(i.filename, target_code)
                 }
                 if translate_mods:
                     en, tr = self._analyze_mods_ui(zin, locale, target_file, mod_name, on_row)
@@ -131,11 +140,38 @@ class ModpackAnalyzer:
 
     def _analyze_mods_ui(self, zin, locale, target_file, mod_name, on_row):
         en_c = tr_c = 0
+        target_code = target_file[:-5]
         for item in zin.infolist():
             fl = item.filename.lower()
             if not fl.endswith("en_us.json") or any(x in fl for x in BOOK_PATH_MARKERS):
                 continue
             try:
+                if _formatkit_bridge.is_formatkit_locale_path(item.filename):
+                    source_text = zin.read(item).decode("utf-8-sig")
+                    preliminary = _formatkit_bridge.plan_locale_work(
+                        item.filename,
+                        source_text,
+                        target_code,
+                        None,
+                        "append",
+                    )
+                    assert preliminary is not None
+                    target_key = preliminary.target_path.lower()
+                    target_text = None
+                    if target_key in locale:
+                        target_text = zin.read(locale[target_key]).decode("utf-8-sig")
+                    work = _formatkit_bridge.plan_locale_work(
+                        item.filename,
+                        source_text,
+                        target_code,
+                        target_text,
+                        "append",
+                    )
+                    assert work is not None
+                    en_c += work.total_translatable
+                    tr_c += work.total_translatable - len(work.pending)
+                    continue
+
                 en = load_lenient_json(zin.read(item))
                 tr_key = fl.replace("en_us.json", target_file)
                 tr = load_lenient_json(zin.read(locale[tr_key])) if tr_key in locale else {}
@@ -146,7 +182,7 @@ class ModpackAnalyzer:
                     existing = str(tr.get(key, ""))
                     if existing.strip() and existing != value:
                         tr_c += 1
-            except (json.JSONDecodeError, OSError):
+            except (json.JSONDecodeError, UnicodeError, OSError, ValueError):
                 continue
         if en_c:
             on_row("📦", mod_name, "Интерфейс", tr_c, en_c, int(tr_c / en_c * 100))
@@ -154,6 +190,7 @@ class ModpackAnalyzer:
 
     def _analyze_books(self, zin, locale, target_file, target_regex, mod_name, on_row):
         b_en = b_tr = m_en = m_tr = 0
+        target_code = target_file.replace(".json", "")
         for item in zin.infolist():
             fl = item.filename.lower()
             is_jb = (
@@ -164,15 +201,11 @@ class ModpackAnalyzer:
                     or any(x in fl for x in RESEARCH_PATH_MARKERS)
                 )
             )
-            is_mb = (
-                (fl.endswith(".md") or fl.endswith(".txt"))
-                and "/en_us/" in fl
-                and any(x in fl for x in MD_PATH_MARKERS)
-            )
+            is_mb = is_source_markdown_guide(item.filename)
             if is_jb:
                 try:
                     en = load_lenient_json(zin.read(item))
-                    tr_path = fl.replace("/en_us/", f"/{target_file.replace('.json','')}/")
+                    tr_path = fl.replace("/en_us/", f"/{target_code}/")
                     tr = load_lenient_json(zin.read(locale[tr_path])) if tr_path in locale else {}
                     en_s = [s for p, s in iter_translatable_strings(en) if s.strip() and looks_like_source_language(s)]
                     tr_s = [s for p, s in iter_translatable_strings(tr)] if tr else []
@@ -185,27 +218,21 @@ class ModpackAnalyzer:
             elif is_mb:
                 try:
                     en_t = zin.read(item).decode("utf-8-sig", errors="ignore")
-                    tr_path = fl.replace("/en_us/", f"/{target_file.replace('.json','')}/") if "/en_us/" in fl else fl
-                    tr_t = zin.read(locale[tr_path]).decode("utf-8-sig", errors="ignore") if tr_path in locale else ""
-                    tr_lines = tr_t.split("\n")
-                    in_yaml = False
-                    for idx, line in enumerate(en_t.split("\n")):
-                        if line.strip() == "---":
-                            in_yaml = not in_yaml
-                            continue
-                        if in_yaml:
-                            m = re.match(r'^(\s*title\s*:\s*[\'"]?)(.*?)([\'"]?)$', line, re.IGNORECASE)
-                            if m and looks_like_source_language(m.group(2)):
-                                m_en += 1
-                                if idx < len(tr_lines) and already_translated(tr_lines[idx], target_regex):
-                                    m_tr += 1
-                            continue
-                        if line.strip().startswith("<") or line.strip().startswith("!["):
-                            continue
-                        if line.strip() and looks_like_source_language(line) and not is_technical_term(line):
-                            m_en += 1
-                            if idx < len(tr_lines) and already_translated(tr_lines[idx], target_regex):
-                                m_tr += 1
+                    tr_path = get_markdown_target_path(item.filename, target_code)
+                    tr_key = tr_path.lower()
+                    tr_t = (
+                        zin.read(locale[tr_key]).decode("utf-8-sig", errors="ignore")
+                        if tr_key in locale
+                        else ""
+                    )
+                    selection = collect_book_markdown_selection(
+                        en_t,
+                        tr_t,
+                        "append",
+                        smart_glue=False,
+                    )
+                    m_en += selection.total_translatable
+                    m_tr += selection.total_translatable - len(selection.pending)
                 except OSError:
                     pass
         if b_en:
@@ -226,8 +253,7 @@ class ModpackAnalyzer:
         if en_c:
             on_row("📜", os.path.basename(path), "Квесты", tr_c, en_c, int(tr_c / en_c * 100))
         return en_c, tr_c
-    
-    
+
     def _analyze_bq(self, path: str, target_regex: str, on_row) -> tuple[int, int]:
         try:
             with open(path, "r", encoding="utf-8") as f:
@@ -250,10 +276,10 @@ class ModpackAnalyzer:
                             en_c += 1
                             if already_translated(text, target_regex):
                                 tr_c += 1
-                                
+
         if en_c:
             folder = os.path.basename(os.path.dirname(path))
             name = f"{folder}/{os.path.basename(path)}"
             on_row("📜", name, "BetterQuesting", tr_c, en_c, int(tr_c / en_c * 100))
-            
+
         return en_c, tr_c

--- a/mineai/processors/estimator.py
+++ b/mineai/processors/estimator.py
@@ -5,7 +5,6 @@ import zipfile
 
 from mineai.constants import (
     BOOK_PATH_MARKERS,
-    MD_PATH_MARKERS,
     RESEARCH_PATH_MARKERS,
 )
 from mineai.json_utils import load_lenient_json
@@ -13,6 +12,11 @@ from mineai.processors.bq_baseline import resolve_bq_force_baseline
 from mineai.processors.locale_keys import (
     collect_lang_keys_to_translate,
     count_translatable_lang_entries,
+)
+from mineai.processors.markdown_guides import (
+    get_markdown_target_path,
+    is_source_markdown_guide,
+    is_target_markdown_locale_path,
 )
 from mineai.processors.selection import (
     collect_book_json_selection,
@@ -113,6 +117,10 @@ class StringEstimator:
                     for item in archive.infolist()
                     if target_file in item.filename.lower()
                     or f"/{target_lang['file']}/" in item.filename.lower()
+                    or is_target_markdown_locale_path(
+                        item.filename,
+                        target_lang["file"],
+                    )
                 }
                 for item in archive.infolist():
                     file_lower = item.filename.lower()
@@ -130,17 +138,7 @@ class StringEstimator:
                             )
                         )
                     )
-                    is_book_md = (
-                        (
-                            file_lower.endswith(".md")
-                            or file_lower.endswith(".txt")
-                        )
-                        and "/en_us/" in file_lower
-                        and any(
-                            marker in file_lower
-                            for marker in MD_PATH_MARKERS
-                        )
-                    )
+                    is_book_md = is_source_markdown_guide(item.filename)
                     is_lang = (
                         file_lower.endswith("en_us.json")
                         and not is_book_json
@@ -278,11 +276,9 @@ class StringEstimator:
         except OSError:
             return 0
 
-        target_path = re.sub(
-            r"/en_us/",
-            f"/{target_lang['file']}/",
+        target_path = get_markdown_target_path(
             item.filename,
-            flags=re.IGNORECASE,
+            target_lang["file"],
         )
         target_text = ""
         target_key = target_path.lower()

--- a/mineai/processors/formatkit_books_pilot.py
+++ b/mineai/processors/formatkit_books_pilot.py
@@ -1,0 +1,564 @@
+from __future__ import annotations
+
+import json
+import re
+import zipfile
+
+from mineai import formatkit_books_bridge as _books
+from mineai import formatkit_bridge as _locale_bridge
+from mineai.constants import BOOK_PATH_MARKERS, MD_PATH_MARKERS, RESEARCH_PATH_MARKERS
+from mineai.json_utils import iter_translatable_strings, load_lenient_json
+from mineai.processors.analyzer import ModpackAnalyzer as LegacyModpackAnalyzer
+from mineai.processors.formatkit_pilot import (
+    FormatKitJarProcessor,
+    FormatKitStringEstimator,
+)
+from mineai.processors.selection import skip_threshold_reached
+from mineai.text_processing import already_translated, is_technical_term, looks_like_source_language
+from mineai_formatkit import ModonomiconBookJsonAdapter
+
+
+class FormatKitBooksJarProcessor(FormatKitJarProcessor):
+    """Pilot v3.3: FormatKit-owned locale/books plus Modonomicon dual-path output."""
+
+    def process(
+        self,
+        jar_path: str,
+        *,
+        target_lang: dict,
+        mode: str,
+        output_mode: str,
+        translate_mods: bool,
+        translate_books: bool,
+        pack_writer,
+    ) -> None:
+        # Preserve the proven v3.2 path first. Modonomicon's language-neutral
+        # data JSON is an additional datapack overlay and is deliberately kept
+        # out of the legacy /en_us/ book heuristics.
+        super().process(
+            jar_path,
+            target_lang=target_lang,
+            mode=mode,
+            output_mode=output_mode,
+            translate_mods=translate_mods,
+            translate_books=translate_books,
+            pack_writer=pack_writer,
+        )
+        if (
+            not translate_books
+            or not self.state.should_run()
+            or output_mode != "resourcepack"
+            or pack_writer is None
+        ):
+            return
+
+        modono_adapter = ModonomiconBookJsonAdapter()
+        try:
+            with zipfile.ZipFile(jar_path, "r") as zin:
+                modono_items = [item for item in zin.infolist() if modono_adapter.matches(item.filename)]
+                if not modono_items:
+                    return
+                target_file = f"{target_lang['file']}.json"
+                locale_files = {
+                    item.filename.lower(): item
+                    for item in zin.infolist()
+                    if target_file in item.filename.lower()
+                    or f"/{target_lang['file']}/" in item.filename.lower()
+                }
+
+                # Books-only mode must still translate Modonomicon's book.*
+                # locale text even though normal UI translation is disabled.
+                if not translate_mods:
+                    for item in zin.infolist():
+                        if item.filename.lower().endswith("/lang/en_us.json"):
+                            self._process_modonomicon_book_locale(
+                                zin, item, locale_files, target_lang, mode, pack_writer, jar_path
+                            )
+
+                for item in modono_items:
+                    if not self.state.should_run():
+                        break
+                    self.state.wait_if_paused()
+                    self._process_formatkit_book(
+                        zin,
+                        None,
+                        item,
+                        locale_files,
+                        target_lang,
+                        mode,
+                        output_mode,
+                        pack_writer,
+                        jar_path.rsplit("/", 1)[-1].rsplit("\\", 1)[-1],
+                        set(),
+                    )
+        except (OSError, zipfile.BadZipFile) as exc:
+            self.callbacks.on_log(f"⚠ Modonomicon JAR пропущен {jar_path}: {exc}", "yellow")
+
+    def _process_modonomicon_book_locale(
+        self, zin, item, locale_files, target_lang, mode, pack_writer, mod_name
+    ) -> bool:
+        try:
+            raw = zin.read(item)
+            source_bom = raw.startswith(b"\xef\xbb\xbf")
+            source_text = raw.decode("utf-8-sig")
+            adapter = _locale_bridge.modonomicon_locale_adapter()
+            preliminary = _locale_bridge.plan_locale_work(
+                item.filename, source_text, target_lang["file"], None, mode,
+                adapter=adapter, key_filter=lambda key: key.startswith("book."),
+            )
+            assert preliminary is not None
+            target_text = None
+            target_key = preliminary.target_path.lower()
+            if mode != "force" and target_key in locale_files:
+                target_text = zin.read(locale_files[target_key]).decode("utf-8-sig")
+            work = _locale_bridge.plan_locale_work(
+                item.filename, source_text, target_lang["file"], target_text, mode,
+                adapter=adapter, key_filter=lambda key: key.startswith("book."),
+            )
+            assert work is not None
+        except (OSError, UnicodeError, ValueError) as exc:
+            self.callbacks.on_log(f"⚠ Modonomicon locale пропущена {item.filename}: {exc}", "yellow")
+            return False
+
+        if work.total_translatable == 0:
+            return False
+        if mode == "skip" and skip_threshold_reached(work.total_translatable, len(work.pending)):
+            return False
+        translated: dict[str, str] = {}
+        if work.pending:
+            self.callbacks.on_log(
+                f"⚡ Перевод {mod_name} [Modonomicon Locale/FormatKit] — {len(work.pending)} строк",
+                "magenta",
+            )
+            translated = self.service.translate_dict(
+                dict(work.pending),
+                target_lang,
+                self.callbacks,
+                context=mod_name,
+                candidate_validator=lambda unit_id, candidate: _locale_bridge.validate_locale_candidate(
+                    work, unit_id, candidate
+                ),
+                preserve_source_structure=True,
+            )
+        if not self.state.should_run():
+            return False
+        try:
+            output = _locale_bridge.build_locale_output(work, translated)
+        except ValueError as exc:
+            self.callbacks.on_log(f"❌ FormatKit отклонил Modonomicon locale {item.filename}: {exc}", "red")
+            return False
+        payload = output.encode("utf-8")
+        if source_bom:
+            payload = b"\xef\xbb\xbf" + payload
+        pack_writer.write(work.target_path, payload)
+        return True
+
+    def _process_book_json(
+        self, zin, zout, item, locale_files, target_lang, mode,
+        output_mode, pack_writer, mod_name, written_inplace,
+    ) -> bool:
+        if not _books.is_formatkit_book_path(item.filename):
+            return super()._process_book_json(
+                zin, zout, item, locale_files, target_lang, mode,
+                output_mode, pack_writer, mod_name, written_inplace,
+            )
+        return self._process_formatkit_book(
+            zin, zout, item, locale_files, target_lang, mode,
+            output_mode, pack_writer, mod_name, written_inplace,
+        )
+
+    def _process_book_md(
+        self, zin, zout, item, locale_files, target_lang, mode,
+        output_mode, pack_writer, mod_name, written_inplace,
+    ) -> bool:
+        if not _books.is_formatkit_book_path(item.filename):
+            return super()._process_book_md(
+                zin, zout, item, locale_files, target_lang, mode,
+                output_mode, pack_writer, mod_name, written_inplace,
+            )
+        return self._process_formatkit_book(
+            zin, zout, item, locale_files, target_lang, mode,
+            output_mode, pack_writer, mod_name, written_inplace,
+        )
+
+    def _process_formatkit_book(
+        self, zin, zout, item, locale_files, target_lang, mode,
+        output_mode, pack_writer, mod_name, written_inplace,
+    ) -> bool:
+        try:
+            raw_source = zin.read(item)
+            source_bom = raw_source.startswith(b"\xef\xbb\xbf")
+            source_text = raw_source.decode("utf-8-sig")
+            tr_path = _books.target_path_for_book(item.filename, target_lang["file"])
+            assert tr_path is not None
+            tr_key = tr_path.lower()
+            target_text = None
+            if mode != "force" and tr_key in locale_files:
+                try:
+                    target_text = zin.read(locale_files[tr_key]).decode("utf-8-sig")
+                except (OSError, UnicodeError):
+                    target_text = None
+            work = _books.plan_book_work(
+                item.filename,
+                source_text,
+                target_lang["file"],
+                target_lang["regex"],
+                target_text,
+                mode,
+            )
+            assert work is not None
+        except (OSError, UnicodeError, ValueError) as exc:
+            self.callbacks.on_log(f"⚠ FormatKit книга пропущена {item.filename}: {exc}", "yellow")
+            return False
+
+        if work.target_parse_error:
+            self.callbacks.on_log(
+                "⚠ FormatKit отбросил небезопасную существующую книгу "
+                f"{work.target_path}: {work.target_parse_error}",
+                "yellow",
+            )
+        emit_structural_copy = work.adapter_name == "patchouli-template-json"
+        if work.total_translatable == 0 and not emit_structural_copy:
+            return False
+
+        skip_file = mode == "skip" and work.total_translatable > 0 and skip_threshold_reached(
+            work.total_translatable, len(work.pending)
+        )
+        translated: dict[str, str] = {}
+        if work.pending and not skip_file:
+            if work.adapter_name == "patchouli-book-json":
+                label = "Patchouli/FormatKit"
+            elif work.adapter_name == "patchouli-template-json":
+                label = "Patchouli Template/FormatKit"
+            elif work.adapter_name == "modonomicon-book-json":
+                label = "Modonomicon/FormatKit"
+            else:
+                label = "IE Manual/FormatKit"
+            self.callbacks.on_log(
+                f"⚡ Перевод {mod_name} [{label}] — {len(work.pending)} строк",
+                "magenta",
+            )
+            translated = self.service.translate_dict(
+                dict(work.pending),
+                target_lang,
+                self.callbacks,
+                context=mod_name,
+                candidate_validator=lambda unit_id, candidate: _books.validate_book_candidate(
+                    work, unit_id, candidate
+                ),
+                preserve_source_structure=True,
+            )
+
+        if not self.state.should_run():
+            return False
+        try:
+            output_text = _books.build_book_output(work, translated)
+        except ValueError as exc:
+            self.callbacks.on_log(
+                f"❌ FormatKit отклонил реконструкцию книги {item.filename}: {exc}",
+                "red",
+            )
+            return False
+
+        payload = output_text.encode("utf-8")
+        if source_bom:
+            payload = b"\xef\xbb\xbf" + payload
+        if output_mode == "resourcepack" and pack_writer:
+            pack_writer.write(work.target_path, payload)
+            return True
+        if zout:
+            zout.writestr(work.target_path, payload)
+            written_inplace.add(work.target_path)
+            return True
+        return False
+
+
+class FormatKitBooksStringEstimator(FormatKitStringEstimator):
+    def _estimate_jar(
+        self, path, target_file, target_lang, mode, translate_mods, translate_books, smart_glue
+    ) -> int:
+        count = super()._estimate_jar(
+            path, target_file, target_lang, mode, translate_mods, translate_books, smart_glue
+        )
+        if not translate_books or not self.state.should_run():
+            return count
+        adapter = ModonomiconBookJsonAdapter()
+        try:
+            with zipfile.ZipFile(path, "r") as archive:
+                items = [item for item in archive.infolist() if adapter.matches(item.filename)]
+                if not items:
+                    return count
+                locale = {
+                    item.filename.lower(): item
+                    for item in archive.infolist()
+                    if target_file in item.filename.lower()
+                    or f"/{target_lang['file']}/" in item.filename.lower()
+                }
+                if not translate_mods:
+                    for item in archive.infolist():
+                        if not item.filename.lower().endswith("/lang/en_us.json"):
+                            continue
+                        try:
+                            source = archive.read(item).decode("utf-8-sig")
+                            modono_locale = _locale_bridge.modonomicon_locale_adapter()
+                            preliminary = _locale_bridge.plan_locale_work(
+                                item.filename, source, target_lang["file"], None, mode,
+                                adapter=modono_locale, key_filter=lambda key: key.startswith("book."),
+                            )
+                            assert preliminary is not None
+                            target_text = None
+                            if mode != "force" and preliminary.target_path.lower() in locale:
+                                target_text = archive.read(locale[preliminary.target_path.lower()]).decode("utf-8-sig")
+                            work = _locale_bridge.plan_locale_work(
+                                item.filename, source, target_lang["file"], target_text, mode,
+                                adapter=modono_locale, key_filter=lambda key: key.startswith("book."),
+                            )
+                            assert work is not None
+                            if not (mode == "skip" and skip_threshold_reached(work.total_translatable, len(work.pending))):
+                                count += len(work.pending)
+                        except (OSError, UnicodeError, ValueError):
+                            pass
+                for item in items:
+                    count += self._count_formatkit_book(archive, item, locale, target_lang, mode)
+        except (OSError, zipfile.BadZipFile):
+            pass
+        return count
+
+    def _count_book_json(self, archive, item, locale, target_lang, mode) -> int:
+        if not _books.is_formatkit_book_path(item.filename):
+            return super()._count_book_json(archive, item, locale, target_lang, mode)
+        return self._count_formatkit_book(archive, item, locale, target_lang, mode)
+
+    def _count_book_md(self, archive, item, locale, target_lang, mode, smart_glue) -> int:
+        if not _books.is_formatkit_book_path(item.filename):
+            return super()._count_book_md(archive, item, locale, target_lang, mode, smart_glue)
+        return self._count_formatkit_book(archive, item, locale, target_lang, mode)
+
+    def _count_formatkit_book(self, archive, item, locale, target_lang, mode) -> int:
+        try:
+            source_text = archive.read(item).decode("utf-8-sig")
+            tr_path = _books.target_path_for_book(item.filename, target_lang["file"])
+            assert tr_path is not None
+            target_text = None
+            if (
+                mode != "force"
+                and not item.filename.lower().startswith("data/")
+                and tr_path.lower() in locale
+            ):
+                try:
+                    target_text = archive.read(locale[tr_path.lower()]).decode("utf-8-sig")
+                except (OSError, UnicodeError):
+                    target_text = None
+            work = _books.plan_book_work(
+                item.filename, source_text, target_lang["file"], target_lang["regex"], target_text, mode
+            )
+            assert work is not None
+        except (OSError, UnicodeError, ValueError):
+            return 0
+        if mode == "skip" and skip_threshold_reached(work.total_translatable, len(work.pending)):
+            return 0
+        return len(work.pending)
+
+
+class FormatKitModpackAnalyzer(LegacyModpackAnalyzer):
+    """Analyzer counterpart using the same v3.3 plans as processor/estimator."""
+
+    def _analyze_mods_ui(self, zin, locale, target_file, mod_name, on_row):
+        en_c = tr_c = 0
+        target_code = target_file[:-5]
+        has_modono = any(ModonomiconBookJsonAdapter().matches(i.filename) for i in zin.infolist())
+        for item in zin.infolist():
+            fl = item.filename.lower()
+            if not fl.endswith("en_us.json") or any(x in fl for x in BOOK_PATH_MARKERS):
+                continue
+            try:
+                if _locale_bridge.is_formatkit_locale_path(item.filename):
+                    source_text = zin.read(item).decode("utf-8-sig")
+                    adapter = _locale_bridge.modonomicon_locale_adapter() if has_modono else None
+                    preliminary = _locale_bridge.plan_locale_work(
+                        item.filename, source_text, target_code, None, "append", adapter=adapter
+                    )
+                    assert preliminary is not None
+                    target_text = None
+                    if preliminary.target_path.lower() in locale:
+                        target_text = zin.read(locale[preliminary.target_path.lower()]).decode("utf-8-sig")
+                    work = _locale_bridge.plan_locale_work(
+                        item.filename, source_text, target_code, target_text, "append", adapter=adapter
+                    )
+                    assert work is not None
+                    en_c += work.total_translatable
+                    tr_c += work.total_translatable - len(work.pending)
+                    continue
+                en = load_lenient_json(zin.read(item))
+                tr_key = fl.replace("en_us.json", target_file)
+                tr = load_lenient_json(zin.read(locale[tr_key])) if tr_key in locale else {}
+                for key, value in en.items():
+                    if not isinstance(value, str) or not looks_like_source_language(value) or is_technical_term(value):
+                        continue
+                    en_c += 1
+                    existing = str(tr.get(key, ""))
+                    if existing.strip() and existing != value:
+                        tr_c += 1
+            except (json.JSONDecodeError, UnicodeError, OSError, ValueError):
+                continue
+        if en_c:
+            on_row("📦", mod_name, "Интерфейс/FormatKit", tr_c, en_c, int(tr_c / en_c * 100))
+        return en_c, tr_c
+
+    def _analyze_jar(self, path, target_file, target_regex, translate_mods, translate_books, on_row, mod_name):
+        total_en, total_tr = super()._analyze_jar(
+            path, target_file, target_regex, translate_mods, translate_books, on_row, mod_name
+        )
+        if not translate_books or translate_mods:
+            return total_en, total_tr
+        try:
+            with zipfile.ZipFile(path, "r") as zin:
+                if not any(ModonomiconBookJsonAdapter().matches(i.filename) for i in zin.infolist()):
+                    return total_en, total_tr
+                locale = {
+                    i.filename.lower(): i
+                    for i in zin.infolist()
+                    if target_file in i.filename.lower() or f"/{target_file[:-5]}/" in i.filename.lower()
+                }
+                book_en = book_tr = 0
+                for item in zin.infolist():
+                    if not item.filename.lower().endswith("/lang/en_us.json"):
+                        continue
+                    source = zin.read(item).decode("utf-8-sig")
+                    adapter = _locale_bridge.modonomicon_locale_adapter()
+                    preliminary = _locale_bridge.plan_locale_work(
+                        item.filename, source, target_file[:-5], None, "append",
+                        adapter=adapter, key_filter=lambda key: key.startswith("book."),
+                    )
+                    assert preliminary is not None
+                    target_text = None
+                    if preliminary.target_path.lower() in locale:
+                        target_text = zin.read(locale[preliminary.target_path.lower()]).decode("utf-8-sig")
+                    work = _locale_bridge.plan_locale_work(
+                        item.filename, source, target_file[:-5], target_text, "append",
+                        adapter=adapter, key_filter=lambda key: key.startswith("book."),
+                    )
+                    assert work is not None
+                    book_en += work.total_translatable
+                    book_tr += work.total_translatable - len(work.pending)
+                if book_en:
+                    on_row("📘", mod_name, "Modonomicon Locale/FormatKit", book_tr, book_en, int(book_tr / book_en * 100))
+                    total_en += book_en
+                    total_tr += book_tr
+        except (OSError, UnicodeError, zipfile.BadZipFile, ValueError):
+            pass
+        return total_en, total_tr
+
+    def _analyze_books(self, zin, locale, target_file, target_regex, mod_name, on_row):
+        b_en = b_tr = m_en = m_tr = 0
+        target_code = target_file[:-5]
+        for item in zin.infolist():
+            fl = item.filename.lower()
+            is_jb = (
+                fl.endswith(".json")
+                and "/en_us/" in fl
+                and (
+                    any(x in fl for x in BOOK_PATH_MARKERS)
+                    or any(x in fl for x in RESEARCH_PATH_MARKERS)
+                )
+            )
+            is_mb = (
+                (fl.endswith(".md") or fl.endswith(".txt"))
+                and "/en_us/" in fl
+                and any(x in fl for x in MD_PATH_MARKERS)
+            )
+            if (is_jb or is_mb) and _books.is_formatkit_book_path(item.filename):
+                try:
+                    source_text = zin.read(item).decode("utf-8-sig")
+                    target_path = _books.target_path_for_book(item.filename, target_code)
+                    assert target_path is not None
+                    target_text = None
+                    if target_path.lower() in locale:
+                        target_text = zin.read(locale[target_path.lower()]).decode("utf-8-sig")
+                    work = _books.plan_book_work(
+                        item.filename, source_text, target_code, target_regex, target_text, "append"
+                    )
+                    assert work is not None
+                    translated = work.total_translatable - len(work.pending)
+                    if work.adapter_name.startswith("patchouli-"):
+                        b_en += work.total_translatable
+                        b_tr += translated
+                    else:
+                        m_en += work.total_translatable
+                        m_tr += translated
+                    continue
+                except (UnicodeError, OSError, ValueError):
+                    continue
+
+            if is_jb:
+                try:
+                    en = load_lenient_json(zin.read(item))
+                    tr_path = fl.replace("/en_us/", f"/{target_code}/")
+                    tr = load_lenient_json(zin.read(locale[tr_path])) if tr_path in locale else {}
+                    en_s = [
+                        s for _p, s in iter_translatable_strings(en)
+                        if s.strip() and looks_like_source_language(s)
+                    ]
+                    tr_s = [s for _p, s in iter_translatable_strings(tr)] if tr else []
+                    b_en += len(en_s)
+                    for idx, s in enumerate(en_s):
+                        if idx < len(tr_s) and tr_s[idx] != s and tr_s[idx].strip():
+                            b_tr += 1
+                except (json.JSONDecodeError, OSError):
+                    pass
+            elif is_mb:
+                try:
+                    en_t = zin.read(item).decode("utf-8-sig", errors="ignore")
+                    tr_path = fl.replace("/en_us/", f"/{target_code}/") if "/en_us/" in fl else fl
+                    tr_t = zin.read(locale[tr_path]).decode("utf-8-sig", errors="ignore") if tr_path in locale else ""
+                    tr_lines = tr_t.split("\n")
+                    in_yaml = False
+                    for idx, line in enumerate(en_t.split("\n")):
+                        if line.strip() == "---":
+                            in_yaml = not in_yaml
+                            continue
+                        if in_yaml:
+                            match = re.match(r'^(\s*title\s*:\s*[\'"]?)(.*?)([\'"]?)$', line, re.IGNORECASE)
+                            if match and looks_like_source_language(match.group(2)):
+                                m_en += 1
+                                if idx < len(tr_lines) and already_translated(tr_lines[idx], target_regex):
+                                    m_tr += 1
+                            continue
+                        if line.strip().startswith("<") or line.strip().startswith("!["):
+                            continue
+                        if line.strip() and looks_like_source_language(line) and not is_technical_term(line):
+                            m_en += 1
+                            if idx < len(tr_lines) and already_translated(tr_lines[idx], target_regex):
+                                m_tr += 1
+                except OSError:
+                    pass
+
+        modono_en = 0
+        for item in zin.infolist():
+            if not ModonomiconBookJsonAdapter().matches(item.filename):
+                continue
+            try:
+                source_text = zin.read(item).decode("utf-8-sig")
+                work = _books.plan_book_work(
+                    item.filename, source_text, target_code, target_regex, None, "append"
+                )
+                if work is not None:
+                    modono_en += work.total_translatable
+            except (OSError, UnicodeError, ValueError):
+                continue
+        if modono_en:
+            b_en += modono_en
+            on_row("📘", mod_name, "Modonomicon/FormatKit", 0, modono_en, 0)
+
+        if b_en:
+            on_row("📖", mod_name, "Книга(JSON)", b_tr, b_en, int(b_tr / b_en * 100))
+        if m_en:
+            on_row("📝", mod_name, "Книга(MD)", m_tr, m_en, int(m_tr / m_en * 100))
+        return b_en + m_en, b_tr + m_tr
+
+
+__all__ = [
+    "FormatKitBooksJarProcessor",
+    "FormatKitBooksStringEstimator",
+    "FormatKitModpackAnalyzer",
+]

--- a/mineai/processors/formatkit_books_pilot_v341.py
+++ b/mineai/processors/formatkit_books_pilot_v341.py
@@ -1,8 +1,85 @@
 from __future__ import annotations
 
+from copy import copy
+
 from mineai import formatkit_books_bridge as _books
+from mineai.engines.service import TranslationService
 from mineai.processors.formatkit_books_pilot import FormatKitBooksJarProcessor as _BaseBooksJarProcessor
 from mineai.processors.selection import skip_threshold_reached
+
+
+_MARKDOWN_CACHE_SCOPE = "__mineai_markdown_v2__\n"
+
+
+class _MarkdownScopedCache:
+    """Isolate Markdown cache entries from older unscoped line translations.
+
+    The first scoped miss also removes the legacy unscoped value for the same
+    source line. This quarantines semantic line-shift results produced by older
+    batched GuideME runs without discarding unrelated locale/book cache entries.
+    """
+
+    def __init__(self, backend) -> None:
+        self._backend = backend
+
+    @staticmethod
+    def _source(source_text: str) -> str:
+        return _MARKDOWN_CACHE_SCOPE + source_text
+
+    def get(self, api_code: str, source_text: str):
+        hit, imported = self._backend.get(api_code, self._source(source_text))
+        if hit is not None:
+            return hit, imported
+
+        legacy_hit, legacy_imported = self._backend.get(api_code, source_text)
+        if legacy_hit is not None:
+            self._backend.discard(
+                api_code,
+                source_text,
+                include_imported=legacy_imported,
+            )
+        return None, False
+
+    def set(self, api_code: str, source_text: str, translated: str) -> None:
+        self._backend.set(api_code, self._source(source_text), translated)
+
+    def set_identity(self, api_code: str, source_text: str) -> None:
+        # Keep the scoped key, but return the original (unscoped) text on lookup.
+        self._backend.set(api_code, self._source(source_text), source_text)
+
+    def discard(
+        self,
+        api_code: str,
+        source_text: str,
+        *,
+        include_imported: bool = False,
+    ) -> None:
+        self._backend.discard(
+            api_code,
+            self._source(source_text),
+            include_imported=include_imported,
+        )
+
+    def save_if_threshold(self, every: int = 500) -> None:
+        self._backend.save_if_threshold(every)
+
+    def save(self) -> None:
+        self._backend.save()
+
+    def __len__(self) -> int:
+        return len(self._backend)
+
+
+def _markdown_translation_service(service):
+    """Return a per-call service view with isolated cache and AI singleton batches."""
+    if not isinstance(service, TranslationService):
+        return service
+
+    guarded = copy(service)
+    guarded.cache = _MarkdownScopedCache(service.cache)
+    if guarded.engine_name not in ("google", "deepl"):
+        guarded.ai_batch = 1
+    return guarded
 
 
 class FormatKitBooksJarProcessor(_BaseBooksJarProcessor):
@@ -12,6 +89,35 @@ class FormatKitBooksJarProcessor(_BaseBooksJarProcessor):
     overridden so parent candidates can be validated against the already resolved
     semantic child payload without changing unrelated jar/locale/book behavior.
     """
+
+    def _process_book_md(
+        self, zin, zout, item, locale_files, target_lang, mode,
+        output_mode, pack_writer, mod_name, written_inplace,
+    ) -> bool:
+        """Run Markdown through an isolated cache and one AI item per request.
+
+        GuideME pages are physically wrapped into short continuation lines. Weak
+        LLMs can shift a neighbour's translation onto the current JSON key when
+        many of those fragments share one batch. A one-item AI batch removes that
+        cross-key failure mode. The scoped cache prevents already accepted values
+        from older batched runs from being reused after this policy change.
+        """
+        original_service = self.service
+        guarded_service = _markdown_translation_service(original_service)
+        if guarded_service is original_service:
+            return super()._process_book_md(
+                zin, zout, item, locale_files, target_lang, mode,
+                output_mode, pack_writer, mod_name, written_inplace,
+            )
+
+        self.service = guarded_service
+        try:
+            return super()._process_book_md(
+                zin, zout, item, locale_files, target_lang, mode,
+                output_mode, pack_writer, mod_name, written_inplace,
+            )
+        finally:
+            self.service = original_service
 
     def _process_formatkit_book(
         self, zin, zout, item, locale_files, target_lang, mode,

--- a/mineai/processors/formatkit_books_pilot_v341.py
+++ b/mineai/processors/formatkit_books_pilot_v341.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from mineai import formatkit_books_bridge as _books
+from mineai.processors.formatkit_books_pilot import FormatKitBooksJarProcessor as _BaseBooksJarProcessor
+from mineai.processors.selection import skip_threshold_reached
+
+
+class FormatKitBooksJarProcessor(_BaseBooksJarProcessor):
+    """v3.4.1 runtime wrapper: resolve semantic children before parent prose.
+
+    The v3.4 processor remains untouched. Only the FormatKit-owned book method is
+    overridden so parent candidates can be validated against the already resolved
+    semantic child payload without changing unrelated jar/locale/book behavior.
+    """
+
+    def _process_formatkit_book(
+        self, zin, zout, item, locale_files, target_lang, mode,
+        output_mode, pack_writer, mod_name, written_inplace,
+    ) -> bool:
+        try:
+            raw_source = zin.read(item)
+            source_bom = raw_source.startswith(b"\xef\xbb\xbf")
+            source_text = raw_source.decode("utf-8-sig")
+            tr_path = _books.target_path_for_book(item.filename, target_lang["file"])
+            assert tr_path is not None
+            tr_key = tr_path.lower()
+            target_text = None
+            if mode != "force" and tr_key in locale_files:
+                try:
+                    target_text = zin.read(locale_files[tr_key]).decode("utf-8-sig")
+                except (OSError, UnicodeError):
+                    target_text = None
+            work = _books.plan_book_work(
+                item.filename,
+                source_text,
+                target_lang["file"],
+                target_lang["regex"],
+                target_text,
+                mode,
+            )
+            assert work is not None
+        except (OSError, UnicodeError, ValueError) as exc:
+            self.callbacks.on_log(f"⚠ FormatKit книга пропущена {item.filename}: {exc}", "yellow")
+            return False
+
+        if work.target_parse_error:
+            self.callbacks.on_log(
+                "⚠ FormatKit отбросил небезопасную существующую книгу "
+                f"{work.target_path}: {work.target_parse_error}",
+                "yellow",
+            )
+        emit_structural_copy = work.adapter_name == "patchouli-template-json"
+        if work.total_translatable == 0 and not emit_structural_copy:
+            return False
+
+        skip_file = mode == "skip" and work.total_translatable > 0 and skip_threshold_reached(
+            work.total_translatable, len(work.pending)
+        )
+        translated: dict[str, str] = {}
+        if work.pending and not skip_file:
+            if work.adapter_name == "patchouli-book-json":
+                label = "Patchouli/FormatKit"
+            elif work.adapter_name == "patchouli-template-json":
+                label = "Patchouli Template/FormatKit"
+            elif work.adapter_name == "modonomicon-book-json":
+                label = "Modonomicon/FormatKit"
+            else:
+                label = "IE Manual/FormatKit"
+            self.callbacks.on_log(
+                f"⚡ Перевод {mod_name} [{label}] — {len(work.pending)} строк",
+                "magenta",
+            )
+
+            semantic_children, remaining = _books.split_semantic_book_pending(work)
+            if semantic_children:
+                translated.update(
+                    self.service.translate_dict(
+                        semantic_children,
+                        target_lang,
+                        self.callbacks,
+                        context=mod_name,
+                        candidate_validator=lambda unit_id, candidate: _books.validate_book_candidate(
+                            work, unit_id, candidate
+                        ),
+                        preserve_source_structure=True,
+                    )
+                )
+            if remaining:
+                resolved_semantic = _books.semantic_resolved_values(work, translated)
+                translated.update(
+                    self.service.translate_dict(
+                        remaining,
+                        target_lang,
+                        self.callbacks,
+                        context=mod_name,
+                        candidate_validator=lambda unit_id, candidate: _books.validate_book_candidate(
+                            work,
+                            unit_id,
+                            candidate,
+                            resolved_semantic=resolved_semantic,
+                        ),
+                        preserve_source_structure=True,
+                    )
+                )
+
+        if not self.state.should_run():
+            return False
+        try:
+            output_text = _books.build_book_output(work, translated)
+        except ValueError as exc:
+            self.callbacks.on_log(
+                f"❌ FormatKit отклонил реконструкцию книги {item.filename}: {exc}",
+                "red",
+            )
+            return False
+
+        payload = output_text.encode("utf-8")
+        if source_bom:
+            payload = b"\xef\xbb\xbf" + payload
+        if output_mode == "resourcepack" and pack_writer:
+            pack_writer.write(work.target_path, payload)
+            return True
+        if zout:
+            zout.writestr(work.target_path, payload)
+            written_inplace.add(work.target_path)
+            return True
+        return False
+
+
+__all__ = ["FormatKitBooksJarProcessor"]

--- a/mineai/processors/formatkit_pilot.py
+++ b/mineai/processors/formatkit_pilot.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from mineai.formatkit_bridge import (
+    FORMATKIT_SOURCE_SHA,
+    build_locale_output,
+    is_formatkit_locale_path,
+    plan_locale_work,
+    validate_locale_candidate,
+)
+from mineai.processors.estimator import StringEstimator as LegacyStringEstimator
+from mineai.processors.jar import JarProcessor as LegacyJarProcessor
+from mineai.processors.selection import skip_threshold_reached
+
+
+class FormatKitJarProcessor(LegacyJarProcessor):
+    """Pilot JAR processor: FormatKit owns recognized Minecraft locale structure."""
+
+    def _process_lang_entry(
+        self,
+        zin,
+        zout,
+        item,
+        locale_files,
+        target_file,
+        target_lang,
+        mode,
+        output_mode,
+        pack_writer,
+        mod_name,
+        written_inplace,
+    ) -> bool:
+        if not is_formatkit_locale_path(item.filename):
+            return super()._process_lang_entry(
+                zin,
+                zout,
+                item,
+                locale_files,
+                target_file,
+                target_lang,
+                mode,
+                output_mode,
+                pack_writer,
+                mod_name,
+                written_inplace,
+            )
+
+        try:
+            raw_source = zin.read(item)
+            source_bom = raw_source.startswith(b"\xef\xbb\xbf")
+            source_text = raw_source.decode("utf-8-sig")
+
+            # Current FormatKit's public Minecraft locale profile is already
+            # Modonomicon-aware. v3.4 therefore has one deterministic locale
+            # path instead of sniffing the JAR and swapping parser subclasses.
+            preliminary = plan_locale_work(
+                item.filename,
+                source_text,
+                target_lang["file"],
+                None,
+                mode,
+            )
+            assert preliminary is not None
+            tr_path = preliminary.target_path
+            tr_key = tr_path.lower()
+
+            target_text = None
+            if mode != "force" and tr_key in locale_files:
+                try:
+                    target_text = zin.read(locale_files[tr_key]).decode("utf-8-sig")
+                except (OSError, UnicodeError):
+                    target_text = None
+
+            work = plan_locale_work(
+                item.filename,
+                source_text,
+                target_lang["file"],
+                target_text,
+                mode,
+            )
+            assert work is not None
+        except (OSError, UnicodeError, ValueError) as exc:
+            self.callbacks.on_log(
+                f"⚠ FormatKit пропустил {item.filename}: {exc}",
+                "yellow",
+            )
+            return False
+
+        if work.target_parse_error:
+            self.callbacks.on_log(
+                "⚠ FormatKit отбросил повреждённую существующую локализацию "
+                f"{work.target_path}: {work.target_parse_error}",
+                "yellow",
+            )
+
+        if work.total_translatable == 0:
+            return False
+
+        if mode == "skip" and skip_threshold_reached(
+            work.total_translatable,
+            len(work.pending),
+        ):
+            return self._copy_existing(
+                zin,
+                locale_files,
+                tr_key,
+                tr_path,
+                output_mode,
+                pack_writer,
+                {},
+                {},
+                mode,
+            )
+
+        translated: dict[str, str] = {}
+        if work.pending:
+            self.callbacks.on_log(
+                f"⚡ Перевод {mod_name} [Интерфейс/FormatKit] — "
+                f"{len(work.pending)} строк",
+                "cyan",
+            )
+            translated = self.service.translate_dict(
+                dict(work.pending),
+                target_lang,
+                self.callbacks,
+                context=mod_name,
+                candidate_validator=lambda unit_id, candidate: validate_locale_candidate(
+                    work, unit_id, candidate
+                ),
+                preserve_source_structure=True,
+            )
+
+        if not self.state.should_run():
+            return False
+
+        try:
+            output_text = build_locale_output(work, translated)
+        except ValueError as exc:
+            self.callbacks.on_log(
+                f"❌ FormatKit отклонил реконструкцию {item.filename}: {exc}",
+                "red",
+            )
+            return False
+
+        payload = output_text.encode("utf-8")
+        if source_bom:
+            payload = b"\xef\xbb\xbf" + payload
+
+        if output_mode == "resourcepack" and pack_writer:
+            pack_writer.write(tr_path, payload)
+            return True
+        if zout:
+            zout.writestr(tr_path, payload)
+            written_inplace.add(tr_path)
+            return True
+        return False
+
+
+class FormatKitStringEstimator(LegacyStringEstimator):
+    """Estimator counterpart for the exact JAR locale pilot above."""
+
+    def _count_lang(
+        self,
+        archive,
+        item,
+        locale,
+        target_file,
+        mode,
+        target_regex,
+    ) -> int:
+        if not is_formatkit_locale_path(item.filename):
+            return super()._count_lang(
+                archive,
+                item,
+                locale,
+                target_file,
+                mode,
+                target_regex,
+            )
+
+        try:
+            source_text = archive.read(item).decode("utf-8-sig")
+            preliminary = plan_locale_work(
+                item.filename,
+                source_text,
+                target_file[:-5],
+                None,
+                mode,
+            )
+            assert preliminary is not None
+            target_key = preliminary.target_path.lower()
+
+            target_text = None
+            if mode != "force" and target_key in locale:
+                try:
+                    target_text = archive.read(locale[target_key]).decode("utf-8-sig")
+                except (OSError, UnicodeError):
+                    target_text = None
+
+            work = plan_locale_work(
+                item.filename,
+                source_text,
+                target_file[:-5],
+                target_text,
+                mode,
+            )
+            assert work is not None
+        except (OSError, UnicodeError, ValueError):
+            return 0
+
+        if mode == "skip" and skip_threshold_reached(
+            work.total_translatable,
+            len(work.pending),
+        ):
+            return 0
+        return len(work.pending)
+
+
+__all__ = [
+    "FORMATKIT_SOURCE_SHA",
+    "FormatKitJarProcessor",
+    "FormatKitStringEstimator",
+]

--- a/mineai/processors/jar.py
+++ b/mineai/processors/jar.py
@@ -3,7 +3,7 @@ import os
 import re
 import zipfile
 
-from mineai.constants import BOOK_PATH_MARKERS, MD_PATH_MARKERS, RESEARCH_PATH_MARKERS
+from mineai.constants import BOOK_PATH_MARKERS, RESEARCH_PATH_MARKERS
 from mineai.engines.base import EngineCallbacks
 from mineai.engines.service import TranslationService
 from mineai.json_utils import (
@@ -17,6 +17,11 @@ from mineai.output.pack_writer import PackWriter
 from mineai.processors.locale_keys import (
     collect_lang_keys_to_translate,
     count_translatable_lang_entries,
+)
+from mineai.processors.markdown_guides import (
+    get_markdown_target_path,
+    is_source_markdown_guide,
+    is_target_markdown_locale_path,
 )
 from mineai.processors.selection import (
     build_book_json_output,
@@ -75,6 +80,10 @@ class JarProcessor:
                     for item in zin.infolist()
                     if target_file in item.filename.lower()
                     or f"/{target_lang['file']}/" in item.filename.lower()
+                    or is_target_markdown_locale_path(
+                        item.filename,
+                        target_lang["file"],
+                    )
                 }
 
                 try:
@@ -90,6 +99,10 @@ class JarProcessor:
                             if (
                                 target_file not in fl
                                 and f"/{target_lang['file']}/" not in fl
+                                and not is_target_markdown_locale_path(
+                                    item.filename,
+                                    target_lang["file"],
+                                )
                             ):
                                 zout.writestr(item, zin.read(item))
 
@@ -101,11 +114,7 @@ class JarProcessor:
                                 or any(m in fl for m in RESEARCH_PATH_MARKERS)
                             )
                         )
-                        is_book_md = (
-                            (fl.endswith(".md") or fl.endswith(".txt"))
-                            and "/en_us/" in fl
-                            and any(m in fl for m in MD_PATH_MARKERS)
-                        )
+                        is_book_md = is_source_markdown_guide(item.filename)
                         is_lang = fl.endswith("en_us.json") and not is_book_json
 
                         if translate_mods and is_lang:
@@ -155,6 +164,10 @@ class JarProcessor:
                             is_target = (
                                 target_file in fl
                                 or f"/{target_lang['file']}/" in fl
+                                or is_target_markdown_locale_path(
+                                    item.filename,
+                                    target_lang["file"],
+                                )
                             )
                             if is_target and item.filename not in written_inplace:
                                 zout.writestr(item, zin.read(item))
@@ -363,16 +376,9 @@ class JarProcessor:
         self, zin, zout, item, locale_files, target_lang, mode,
         output_mode, pack_writer, mod_name, written_inplace,
     ) -> bool:
-        fl = item.filename.lower()
-        tr_path = (
-            re.sub(
-                r"/en_us/",
-                f"/{target_lang['file']}/",
-                item.filename,
-                flags=re.IGNORECASE,
-            )
-            if "/en_us/" in fl
-            else item.filename
+        tr_path = get_markdown_target_path(
+            item.filename,
+            target_lang["file"],
         )
         tr_key = tr_path.lower()
         try:
@@ -459,4 +465,3 @@ class JarProcessor:
             written_inplace.add(tr_path)
             return True
         return False
-

--- a/mineai/processors/markdown_guides.py
+++ b/mineai/processors/markdown_guides.py
@@ -1,0 +1,67 @@
+"""Shared Markdown guide classification and locale-path helpers."""
+
+from __future__ import annotations
+
+import re
+
+from mineai.constants import MD_PATH_MARKERS
+
+
+_GUIDEME_ROOT = "/ae2guide/"
+_GUIDEME_LOCALE_DIR_RE = re.compile(r"^_?[a-z]{2}_[a-z]{2}$", re.IGNORECASE)
+_GUIDEME_ROOT_RE = re.compile(r"(^|/)(ae2guide/)", re.IGNORECASE)
+_SOURCE_LOCALE_RE = re.compile(r"/en_us/", re.IGNORECASE)
+
+
+def _slash_path(path: str) -> str:
+    return path.replace("\\", "/")
+
+
+def _normalized(path: str) -> str:
+    return "/" + _slash_path(path).lstrip("/").lower()
+
+
+def is_source_markdown_guide(path: str) -> bool:
+    """Return whether a JAR entry is a supported source-language MD/TXT guide."""
+    normalized = _normalized(path)
+    if not normalized.endswith((".md", ".txt")):
+        return False
+
+    # Preserve the project's existing /en_us/ guide support exactly.
+    if "/en_us/" in normalized:
+        return any(marker in normalized for marker in MD_PATH_MARKERS)
+
+    # GuideME/AE2 stores its default-language pages directly below ae2guide,
+    # while translations live below _<language_code>/.
+    if _GUIDEME_ROOT not in normalized:
+        return False
+
+    tail = normalized.split(_GUIDEME_ROOT, 1)[1]
+    first_segment = tail.split("/", 1)[0]
+    return not _GUIDEME_LOCALE_DIR_RE.fullmatch(first_segment)
+
+
+def get_markdown_target_path(path: str, target_code: str) -> str:
+    """Resolve a supported source guide path to its target-locale path."""
+    slash_path = _slash_path(path)
+    if _SOURCE_LOCALE_RE.search(slash_path):
+        return _SOURCE_LOCALE_RE.sub(
+            f"/{target_code}/",
+            slash_path,
+            count=1,
+        )
+
+    if _GUIDEME_ROOT_RE.search(slash_path):
+        return _GUIDEME_ROOT_RE.sub(
+            lambda match: f"{match.group(1)}{match.group(2)}_{target_code}/",
+            slash_path,
+            count=1,
+        )
+
+    raise ValueError(f"Unsupported Markdown guide source path: {path}")
+
+
+def is_target_markdown_locale_path(path: str, target_code: str) -> bool:
+    """Return whether a path belongs to a GuideME target-locale subtree."""
+    normalized = _normalized(path)
+    return f"/_{target_code.lower()}/" in normalized

--- a/mineai/processors/selection.py
+++ b/mineai/processors/selection.py
@@ -9,16 +9,23 @@ from mineai.json_utils import (
     path_to_key,
 )
 from mineai.text_processing import (
-    apply_smart_glue,
+    PLACEHOLDER_PATTERN,
     is_technical_term,
     looks_like_source_language,
+    mask_protected_fragments,
 )
 
 
 YAML_TITLE_RE = re.compile(
-    r'^(\s*title\s*:\s*[\'"]?)(.*?)([\'"]?)$',
+    r'^(\s*title\s*:\s*[\'\"]?)(.*?)([\'\"]?)$',
     re.IGNORECASE,
 )
+_MARKDOWN_BLOCK_MARKER_RE = re.compile(
+    r"^(?:#{1,6}[ \t]+|[-+*][ \t]+|\d+[.)][ \t]+|>[ \t]*)"
+)
+_MARKDOWN_LIST_MARKER_RE = re.compile(r"^(?:[-+*]|\d+[.)])[ \t]+$")
+_MARKDOWN_TASK_MARKER_RE = re.compile(r"^\[[ xX]\][ \t]+")
+_FENCED_CODE_RE = re.compile(r"^[ \t]{0,3}(?P<fence>`{3,}|~{3,})")
 
 
 def skip_threshold_reached(total_translatable: int, pending_count: int) -> bool:
@@ -93,6 +100,9 @@ class MarkdownSelection:
     source_text: str
     lines_out: list[str]
     pending: dict[str, str]
+    # Exact structural affixes reconstructed by JarProcessor after translation.
+    # The historical field name is kept so the writer does not need a parallel
+    # Markdown-only translation path.
     title_meta: dict[str, tuple[str, str]]
     total_translatable: int
 
@@ -104,6 +114,72 @@ def _extract_yaml_title(line: str) -> tuple[str, str, str] | None:
     return match.group(1), match.group(2), match.group(3)
 
 
+def split_markdown_block_structure(line: str) -> tuple[str, str, str]:
+    """Return exact ``(prefix, payload, suffix)`` for a Markdown prose line.
+
+    Block-level syntax is kept out of TranslationService. This is deliberately
+    lightweight rather than an AST: preserve leading indentation, consume
+    heading/list/quote/task markers, and preserve trailing whitespace/hard-break
+    syntax. The remaining payload can safely use the shared inline masker.
+    """
+    leading = re.match(r"^[ \t]*", line)
+    prefix = leading.group(0) if leading else ""
+    payload = line[len(prefix) :]
+
+    for _ in range(8):
+        marker_match = _MARKDOWN_BLOCK_MARKER_RE.match(payload)
+        if not marker_match:
+            break
+        marker = marker_match.group(0)
+        prefix += marker
+        payload = payload[len(marker) :]
+
+        if _MARKDOWN_LIST_MARKER_RE.fullmatch(marker):
+            task_match = _MARKDOWN_TASK_MARKER_RE.match(payload)
+            if task_match:
+                task_marker = task_match.group(0)
+                prefix += task_marker
+                payload = payload[len(task_marker) :]
+
+    suffix = ""
+
+    # Closing ATX heading markers are structural as well, e.g. ``## Title ##``.
+    if re.match(r"^[ \t]*#{1,6}[ \t]+", prefix):
+        closing = re.match(r"^(.*?)([ \t]+#+[ \t]*)$", payload)
+        if closing:
+            payload, suffix = closing.group(1), closing.group(2)
+
+    # Preserve trailing spaces/tabs exactly. In Markdown, two trailing spaces are
+    # a hard line break and must never be normalized by the translation service.
+    if not suffix:
+        trailing = re.match(r"^(.*?)([ \t]+)$", payload)
+        if trailing:
+            payload, suffix = trailing.group(1), trailing.group(2)
+
+    return prefix, payload, suffix
+
+
+def _markdown_payload_has_translatable_prose(payload: str) -> bool:
+    if not payload.strip():
+        return False
+
+    # At this point block-level Markdown structure has already been removed.
+    # Titanium Shield therefore only needs to hide inline technical fragments.
+    masked, _mapping = mask_protected_fragments(payload)
+    residual = PLACEHOLDER_PATTERN.sub("", masked).strip()
+    return bool(
+        residual
+        and looks_like_source_language(residual)
+        and not is_technical_term(residual)
+    )
+
+
+def markdown_line_has_translatable_prose(line: str) -> bool:
+    """Return True when a Markdown line contains human-readable source prose."""
+    _prefix, payload, _suffix = split_markdown_block_structure(line)
+    return _markdown_payload_has_translatable_prose(payload)
+
+
 def collect_book_markdown_selection(
     source_text: str,
     target_text: str,
@@ -112,26 +188,37 @@ def collect_book_markdown_selection(
     smart_glue: bool,
 ) -> MarkdownSelection:
     """Build one shared Markdown/YAML translation plan for estimator and writer."""
-    if smart_glue:
-        source_text = apply_smart_glue(source_text)
-
+    # Do not apply smart glue to the complete Markdown document. TranslationService
+    # applies it to selected payloads, while gluing a whole document can join YAML
+    # fences, images, tables, lists or component lines and change structure.
     source_lines = source_text.split("\n")
     target_lines = target_text.split("\n") if target_text else []
     lines_out = list(source_lines)
     pending: dict[str, str] = {}
-    title_meta: dict[str, tuple[str, str]] = {}
+    structural_meta: dict[str, tuple[str, str]] = {}
     total_translatable = 0
-    in_yaml = False
+
+    # YAML front matter is structural only when it starts the document. A later
+    # ``---`` is a horizontal rule and must not accidentally reopen YAML mode.
+    has_frontmatter = bool(
+        source_lines
+        and source_lines[0].lstrip("\ufeff").strip() == "---"
+    )
+    in_yaml = has_frontmatter
+    in_fenced_code = False
+    fence_char = ""
+    fence_len = 0
 
     for index, line in enumerate(source_lines):
         stripped = line.strip()
-        if stripped == "---":
-            in_yaml = not in_yaml
+
+        if has_frontmatter and index == 0 and stripped == "---":
             continue
 
-        existing_line = target_lines[index] if index < len(target_lines) else ""
-
         if in_yaml:
+            if stripped == "---":
+                in_yaml = False
+                continue
             if not stripped.lower().startswith("title:"):
                 continue
             source_title = _extract_yaml_title(line)
@@ -146,7 +233,8 @@ def collect_book_markdown_selection(
                 continue
 
             total_translatable += 1
-            title_meta[str(index)] = (prefix, suffix)
+            structural_meta[str(index)] = (prefix, suffix)
+            existing_line = target_lines[index] if index < len(target_lines) else ""
             existing_title_parts = _extract_yaml_title(existing_line)
             existing_title = (
                 existing_title_parts[1] if existing_title_parts else ""
@@ -157,18 +245,31 @@ def collect_book_markdown_selection(
                 lines_out[index] = existing_line
             continue
 
-        if stripped.startswith("<") or stripped.startswith("!["):
+        fence_match = _FENCED_CODE_RE.match(line)
+        if fence_match:
+            fence = fence_match.group("fence")
+            if not in_fenced_code:
+                in_fenced_code = True
+                fence_char = fence[0]
+                fence_len = len(fence)
+            elif fence[0] == fence_char and len(fence) >= fence_len:
+                in_fenced_code = False
+                fence_char = ""
+                fence_len = 0
             continue
-        if (
-            not stripped
-            or not looks_like_source_language(line)
-            or is_technical_term(line)
-        ):
+        if in_fenced_code:
+            continue
+
+        block_prefix, payload, block_suffix = split_markdown_block_structure(line)
+        if not _markdown_payload_has_translatable_prose(payload):
             continue
 
         total_translatable += 1
+        existing_line = target_lines[index] if index < len(target_lines) else ""
         if _needs_translation(line, existing_line, mode):
-            pending[str(index)] = line
+            pending[str(index)] = payload
+            if block_prefix or block_suffix:
+                structural_meta[str(index)] = (block_prefix, block_suffix)
         else:
             lines_out[index] = existing_line
 
@@ -176,7 +277,7 @@ def collect_book_markdown_selection(
         source_text=source_text,
         lines_out=lines_out,
         pending=pending,
-        title_meta=title_meta,
+        title_meta=structural_meta,
         total_translatable=total_translatable,
     )
 

--- a/mineai/runtime/job.py
+++ b/mineai/runtime/job.py
@@ -9,10 +9,10 @@ from mineai.constants import LANGUAGES
 from mineai.engines.base import EngineCallbacks
 from mineai.engines.service import TranslationService
 from mineai.output.pack_writer import PackWriter
-from mineai.processors.analyzer import ModpackAnalyzer
+from mineai.processors.formatkit_books_pilot import FormatKitModpackAnalyzer as ModpackAnalyzer
 from mineai.processors.discovery import discover_jar_files, discover_loose_lang_files, discover_snbt_files, discover_bq_files
-from mineai.processors.estimator import StringEstimator
-from mineai.processors.jar import JarProcessor
+from mineai.processors.formatkit_books_pilot import FormatKitBooksStringEstimator as StringEstimator
+from mineai.processors.formatkit_books_pilot_v341 import FormatKitBooksJarProcessor as JarProcessor
 from mineai.processors.bq_json import BQProcessor
 from mineai.processors.loose_json import LooseJsonProcessor
 from mineai.processors.snbt import SnbtProcessor
@@ -358,13 +358,21 @@ class TranslationJob:
         elif not self.state.should_run():
             self.on_log("\n🛑 ОСТАНОВЛЕНО.", "red")
             self.on_status("Остановлено", self.state.line_progress())
-        elif failed_files:
-            self.on_log(
-                f"\n⚠️ ЗАВЕРШЕНО С ОШИБКАМИ: пропущено файлов — {failed_files}.",
-                "yellow",
-            )
-            self.on_status("Завершено с ошибками", 1.0)
         else:
+            failed_strings = self.state.snapshot().failed_strings
+            if failed_files or failed_strings:
+                details: list[str] = []
+                if failed_files:
+                    details.append(f"пропущено файлов — {failed_files}")
+                if failed_strings:
+                    details.append(f"ошибок строк — {failed_strings}")
+                self.on_log(
+                    f"\n⚠️ ЗАВЕРШЕНО С ОШИБКАМИ: {'; '.join(details)}.",
+                    "yellow",
+                )
+                self.on_status("Завершено с ошибками", 1.0)
+                return
+
             self.on_log("\n✅ ПЕРЕВОД УСПЕШНО ЗАВЕРШЕН!", "green")
             if options.output_mode == "resourcepack":
                 self.on_log("💡 Включите ресурспак и датапак в игре.", "yellow")

--- a/mineai/text_processing.py
+++ b/mineai/text_processing.py
@@ -19,14 +19,17 @@ FORMAT_PATTERN = re.compile(
     r"[&§][0-9a-fk-orlmn]|"
     r"<[^>]+>|"
     r"\{[^\}]+\}|"
+    r"(?<=\])\([^)]+\)|"
     r"\]\([^)]+\)|"
     r"!\[[^\]]*\]|"
     r"\[[a-z0-9_.-]+:[a-z0-9_./-]+\]|"
+    r"\[(?=[^\]\n]+\]\([^)]+\))|"
     r"\([a-z0-9_.-]+:[a-z0-9_./-]+\)|"
     r"\([A-Za-z0-9_./-]+\.md[#a-zA-Z0-9_-]*\)|"
+    r"\||"
     r"\\[nrt]|"
     r"\n|"
-    r"\\+(?![\"])|"
+    r"\\+(?![\\\"])|"
     r"%[0-9.,]*\$?[a-zA-Z%]"
     r")",
     flags=re.IGNORECASE,
@@ -109,7 +112,12 @@ def polish_translation(text: str) -> str:
 
 
 def mask_protected_fragments(text: str) -> tuple[str, dict[str, str]]:
-    """Replace format codes and protected terms with collision-free placeholders."""
+    """Replace inline format codes and protected terms with placeholders.
+
+    Format-level structure (for example Markdown list/heading prefixes) must be
+    removed by its processor before calling TranslationService. This function
+    intentionally protects only fragments that can occur inside text payloads.
+    """
     mapping: dict[str, str] = {}
     reserved_ids = set(PLACEHOLDER_PATTERN.findall(text))
     next_id = 0
@@ -131,7 +139,11 @@ def mask_protected_fragments(text: str) -> tuple[str, dict[str, str]]:
 def unmask_translation(text: str, mapping: dict[str, str]) -> str:
     for token, original in mapping.items():
         idx = token.strip("#[]")
-        text = re.sub(rf"\[\s*#\s*{re.escape(idx)}\s*#\s*\]", lambda _m, o=original: o, text)
+        text = re.sub(
+            rf"\[\s*#\s*{re.escape(idx)}\s*#\s*\]",
+            lambda _m, o=original: o,
+            text,
+        )
     return text
 
 

--- a/mineai_formatkit/__init__.py
+++ b/mineai_formatkit/__init__.py
@@ -1,0 +1,74 @@
+"""Pinned public MineAI-FormatKit slice used by MineAI Pilot v3.4.1.
+
+Every functional parser/reconstruction module vendored in this directory is a
+byte-for-byte copy from LifeViwer/MineAI-FormatKit at ``FORMATKIT_SOURCE_SHA``.
+This small facade intentionally exports only the already-certified MineAI pilot
+slice so syncing the SDK cannot silently enable unrelated formats.
+"""
+
+from .config_locales import CollapsibleGroupsConfigLangJsonAdapter, JaopcaConfigLangJsonAdapter
+from .core import ProtectedFragment, TranslationPlan, TranslationUnit, ValidationError
+from .ie_manual import ImmersiveEngineeringManualAdapter
+from .locale_merge import LocaleMergePlan
+from .modonomicon import (
+    ModonomiconAwareLocaleMergePlanner,
+    ModonomiconAwareMinecraftLangJsonAdapter,
+    ModonomiconBookJsonAdapter as _SdkModonomiconBookJsonAdapter,
+)
+from .patchouli_safe import PatchouliBookJsonAdapter
+
+FORMATKIT_SOURCE_SHA = "5cfd1e28c1581caf144f9a5ef767c631d9199f8c"
+FORMATKIT_PILOT_HARDENING = (
+    "sdk-sync-v3.4.1:current-main+host-exact-order+per-unit-fallback+semantic-anchor+description-id-guards"
+)
+
+# Exact upstream Git blob ids for every SDK-owned functional module in the
+# active v3.4.1 slice.  MineAI host policy is deliberately not stored here.
+FORMATKIT_VENDOR_BLOBS = {
+    "config_locales.py": "02336a92a06a47514501f76697526c547462031c",
+    "core.py": "955b772b6d36dc07b07bb1a56fee550979d60d18",
+    "ie_manual.py": "acdc6c671d0dacad3f7c0564f3a9aa459dd430af",
+    "ie_manual_base.py": "f5875644a566718bef43e4c40bfd9befe4f29151",
+    "locale_merge.py": "d7548d20e6c8a989ef09d4255ed50c0dfae9623d",
+    "locale_safe.py": "bf85f81a6de7f4cc8b02f6693abdb1884ada5eaf",
+    "minecraft_lang.py": "e2f882e72f7c35bb70a85debd9df054aa84540d4",
+    "minecraft_text.py": "82961fffbb2b18fe6ffb55ede96e6bfa313de42b",
+    "modonomicon.py": "2142c96bcba04b515440b4128bc12c98f7213189",
+    "modonomicon_gson.py": "3271700b375bc446313fe3ea75fee1aab4f6c663",
+    "patchouli.py": "18bf54c9e4128d68f8dd62dc8dd150192fbe0bd0",
+    "patchouli_base.py": "27417f507cba377b846972d7b8ea3a87334e1675",
+    "patchouli_safe.py": "9d9f4e94103c45a96e41a668bce5680019bc2c7b",
+    "runtime_locale.py": "aed4cdf34207c6b7cd38f9bf209c3f8113ba441f",
+    "structured_locale.py": "37d80a343db24d28adc8c711143813bb384ad3de",
+}
+
+# Long-standing public aliases remain the current upstream public adapters.
+MinecraftLangJsonAdapter = ModonomiconAwareMinecraftLangJsonAdapter
+LocaleMergePlanner = ModonomiconAwareLocaleMergePlanner
+
+
+class ModonomiconBookJsonAdapter(_SdkModonomiconBookJsonAdapter):
+    """Backward-compatible facade with MineAI's historical candidate hook."""
+
+    def validate_candidate(self, plan, unit_id: str, candidate: str) -> None:
+        if unit_id not in plan.by_id():
+            raise ValidationError(f"Unknown translation unit id: {unit_id}")
+        self.apply(plan, {unit_id: candidate})
+
+__all__ = [
+    "CollapsibleGroupsConfigLangJsonAdapter",
+    "FORMATKIT_PILOT_HARDENING",
+    "FORMATKIT_SOURCE_SHA",
+    "FORMATKIT_VENDOR_BLOBS",
+    "ImmersiveEngineeringManualAdapter",
+    "JaopcaConfigLangJsonAdapter",
+    "LocaleMergePlan",
+    "LocaleMergePlanner",
+    "MinecraftLangJsonAdapter",
+    "ModonomiconBookJsonAdapter",
+    "PatchouliBookJsonAdapter",
+    "ProtectedFragment",
+    "TranslationPlan",
+    "TranslationUnit",
+    "ValidationError",
+]

--- a/mineai_formatkit/config_locales.py
+++ b/mineai_formatkit/config_locales.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import re
+
+from .locale_safe import MinecraftLangJsonAdapter
+
+
+_COLLAPSIBLE_CONFIG_RE = re.compile(
+    r"(^|/)config/collapsiblegroups/lang/en_us\.json$",
+    re.IGNORECASE,
+)
+_JAOPCA_CONFIG_RE = re.compile(
+    r"(^|/)config/jaopca/lang/en_us\.json$",
+    re.IGNORECASE,
+)
+
+
+class _ConfigLocaleAdapter(MinecraftLangJsonAdapter):
+    source_pattern: re.Pattern[str]
+
+    def matches(self, path: str) -> bool:
+        slash = "/" + path.replace("\\", "/").lstrip("/")
+        return bool(self.source_pattern.search(slash))
+
+    def target_path(self, path: str, target_code: str) -> str:
+        slash = path.replace("\\", "/")
+        if not self.matches(slash):
+            raise ValueError(f"Unsupported runtime config locale source path: {path}")
+        return re.sub(r"en_us\.json$", f"{target_code}.json", slash, flags=re.IGNORECASE)
+
+
+class CollapsibleGroupsConfigLangJsonAdapter(_ConfigLocaleAdapter):
+    """Runtime locale deployed/read from ``config/collapsiblegroups/lang``."""
+
+    name = "collapsible-groups-config-lang-json"
+    source_pattern = _COLLAPSIBLE_CONFIG_RE
+
+
+class JaopcaConfigLangJsonAdapter(_ConfigLocaleAdapter):
+    """JAOPCA's runtime/downloader locale catalog under ``config/jaopca/lang``."""
+
+    name = "jaopca-config-lang-json"
+    source_pattern = _JAOPCA_CONFIG_RE

--- a/mineai_formatkit/core.py
+++ b/mineai_formatkit/core.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Mapping
+
+
+class ValidationError(ValueError):
+    """Raised when translated content violates a format invariant."""
+
+
+@dataclass(frozen=True)
+class ProtectedFragment:
+    placeholder: str
+    value: str
+
+
+@dataclass(frozen=True)
+class TranslationUnit:
+    """One replaceable semantic span inside an immutable source document.
+
+    ``text`` is what the translator receives. Technical fragments may be
+    represented by placeholders. ``start``/``end`` address the original source
+    text, so serialization never has to reformat the rest of the document.
+    """
+
+    id: str
+    text: str
+    start: int
+    end: int
+    kind: str
+    context: str = ""
+    protected: tuple[ProtectedFragment, ...] = ()
+
+    @property
+    def source_span_length(self) -> int:
+        return self.end - self.start
+
+
+@dataclass(frozen=True)
+class TranslationPlan:
+    path: str
+    source_text: str
+    units: tuple[TranslationUnit, ...]
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for unit in self.units:
+            if unit.start < 0 or unit.end <= unit.start:
+                raise ValueError(f"Invalid translation unit range: {unit.id}")
+            if unit.end > len(self.source_text):
+                raise ValueError(f"Translation unit exceeds source: {unit.id}")
+
+    def by_id(self) -> dict[str, TranslationUnit]:
+        return {unit.id: unit for unit in self.units}

--- a/mineai_formatkit/ie_manual.py
+++ b/mineai_formatkit/ie_manual.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Mapping
+
+from . import ie_manual_base as _base
+from .core import ProtectedFragment, TranslationPlan, TranslationUnit, ValidationError
+from .ie_manual_base import IeManualFingerprint
+
+
+_PLACEHOLDER_RE = re.compile(r"\[#(\d+)#\]")
+
+
+@dataclass(frozen=True)
+class _IeSemanticAnchor:
+    placeholder: str
+    child_id: str
+    prefix: str
+    suffix: str
+
+
+class ImmersiveEngineeringManualAdapter(_base.ImmersiveEngineeringManualAdapter):
+    """IE manual adapter with source-owned explicit style/reset spans."""
+
+    def prepare(self, path: str, source_text: str) -> TranslationPlan:
+        spans: list[TranslationUnit] = []
+        semantic_anchors: dict[str, tuple[_IeSemanticAnchor, ...]] = {}
+        cursor = 0
+        token_index = 0
+        for token_match in _base._TOKEN_RE.finditer(source_text):
+            self._add_plain_units_semantic(
+                path,
+                source_text,
+                cursor,
+                token_match.start(),
+                spans,
+                semantic_anchors,
+            )
+            self._add_token_units(path, source_text, token_match, token_index, spans)
+            cursor = token_match.end()
+            token_index += 1
+        self._add_plain_units_semantic(
+            path,
+            source_text,
+            cursor,
+            len(source_text),
+            spans,
+            semantic_anchors,
+        )
+        spans.sort(
+            key=lambda unit: (
+                unit.start,
+                0 if unit.kind == "ie-manual-prose" else 1,
+                unit.id,
+            )
+        )
+        return TranslationPlan(
+            path=path,
+            source_text=source_text,
+            units=tuple(spans),
+            metadata={
+                "fingerprint": self.fingerprint(source_text),
+                "semantic_payloads": {unit.id: unit.text for unit in spans},
+                "semantic_anchors": semantic_anchors,
+            },
+        )
+
+    def apply(self, plan: TranslationPlan, translations: Mapping[str, str]) -> str:
+        known = {unit.id for unit in plan.units}
+        unknown = set(translations) - known
+        if unknown:
+            raise ValidationError(f"Unknown translation unit ids: {sorted(unknown)!r}")
+        anchors_meta = plan.metadata.get("semantic_anchors", {})
+        if not isinstance(anchors_meta, dict):
+            raise ValidationError("IE manual plan is missing semantic anchor metadata")
+        by_id = {unit.id: unit for unit in plan.units}
+        replacements: list[tuple[int, int, str]] = []
+
+        for unit in plan.units:
+            if unit.kind == "ie-format-semantic-child":
+                continue
+            anchors = anchors_meta.get(unit.id, ())
+            related = {unit.id}
+            for anchor in anchors:
+                if not isinstance(anchor, _IeSemanticAnchor):
+                    raise ValidationError(f"Invalid IE semantic anchor metadata for {unit.id}")
+                related.add(anchor.child_id)
+            if not any(unit_id in translations for unit_id in related):
+                continue
+            candidate = translations.get(unit.id, unit.text)
+            self._validate_candidate_text(unit, candidate)
+            restored = self._restore_protected(unit, candidate)
+            for anchor in anchors:
+                child = by_id.get(anchor.child_id)
+                if child is None:
+                    raise ValidationError(f"Missing IE semantic child {anchor.child_id}")
+                child_candidate = translations.get(child.id, child.text)
+                self._validate_candidate_text(child, child_candidate)
+                child_restored = self._restore_protected(child, child_candidate)
+                if restored.count(anchor.placeholder) != 1:
+                    raise ValidationError(f"Unit {unit.id} changed semantic anchor placement")
+                restored = restored.replace(
+                    anchor.placeholder,
+                    anchor.prefix + child_restored + anchor.suffix,
+                    1,
+                )
+            replacements.append((unit.start, unit.end, restored))
+
+        output = plan.source_text
+        for start, end, replacement in sorted(replacements, reverse=True):
+            output = output[:start] + replacement + output[end:]
+        self.validate(plan.source_text, output)
+        return output
+
+    @staticmethod
+    def _validate_candidate_text(unit: TranslationUnit, translated: str) -> None:
+        if "\n" in translated or "\r" in translated:
+            raise ValidationError(f"Unit {unit.id} introduced a newline")
+        if unit.kind in {"ie-link-label", "ie-config-label"} and any(
+            delimiter in translated for delimiter in (";", "<", ">")
+        ):
+            raise ValidationError(f"Unit {unit.id} changed manual-token delimiters")
+
+    def _add_plain_units_semantic(
+        self,
+        path: str,
+        text: str,
+        start: int,
+        end: int,
+        out: list[TranslationUnit],
+        semantic_anchors: dict[str, tuple[_IeSemanticAnchor, ...]],
+    ) -> None:
+        if start >= end:
+            return
+        block = text[start:end]
+        for match in re.finditer(r"[^\r\n]+", block):
+            raw = match.group(0)
+            leading = len(raw) - len(raw.lstrip(" \t"))
+            payload = raw.strip(" \t")
+            if not payload or not self._has_prose(payload):
+                continue
+            unit_start = start + match.start() + leading
+            unit_end = unit_start + len(payload)
+            outer_id = f"span:{unit_start}:prose"
+            anchor_spans = self._semantic_format_spans(payload)
+            outer_parts: list[str] = []
+            reserved: list[str] = []
+            anchors: list[_IeSemanticAnchor] = []
+            cursor = 0
+            literal_ids = [int(m.group(1)) for m in _PLACEHOLDER_RE.finditer(payload)]
+            next_marker = max(literal_ids) + 1 if literal_ids else 0
+            for anchor_index, (a_start, a_end, prefix, body, suffix) in enumerate(anchor_spans):
+                outer_parts.append(payload[cursor:a_start])
+                placeholder = f"[#{next_marker}#]"
+                next_marker += 1
+                outer_parts.append(placeholder)
+                reserved.append(placeholder)
+                child_id = f"{outer_id}#anchor:{anchor_index}"
+                child_masked, child_protected = self._protect_formatting(body)
+                out.append(
+                    TranslationUnit(
+                        id=child_id,
+                        text=child_masked,
+                        start=unit_start,
+                        end=unit_end,
+                        kind="ie-format-semantic-child",
+                        context=f"{path}:format-anchor:{anchor_index}",
+                        protected=child_protected,
+                    )
+                )
+                anchors.append(_IeSemanticAnchor(placeholder, child_id, prefix, suffix))
+                cursor = a_end
+            outer_parts.append(payload[cursor:])
+            outer_source = "".join(outer_parts)
+            masked, protected = self._protect_formatting_reserved(
+                outer_source,
+                tuple(reserved),
+            )
+            if not anchors and not self._has_prose(_PLACEHOLDER_RE.sub(" ", masked)):
+                continue
+            out.append(
+                TranslationUnit(
+                    id=outer_id,
+                    text=masked,
+                    start=unit_start,
+                    end=unit_end,
+                    kind="ie-manual-prose",
+                    context=path,
+                    protected=protected,
+                )
+            )
+            if anchors:
+                semantic_anchors[outer_id] = tuple(anchors)
+
+    def _protect_formatting_reserved(
+        self,
+        text: str,
+        reserved_placeholders: tuple[str, ...],
+    ) -> tuple[str, tuple[ProtectedFragment, ...]]:
+        reserved = set(reserved_placeholders)
+        spans = [
+            (match.start(), match.end())
+            for match in _base._SECTION_RESET_BOUNDARY_RE.finditer(text)
+        ]
+        spans.extend(
+            (match.start(), match.end())
+            for match in _base._SECTION_FORMAT_RE.finditer(text)
+        )
+        placeholder_matches = list(_PLACEHOLDER_RE.finditer(text))
+        literal_ids = [int(match.group(1)) for match in placeholder_matches]
+        spans.extend(
+            (match.start(), match.end())
+            for match in placeholder_matches
+            if match.group(0) not in reserved
+        )
+        merged: list[list[int]] = []
+        for span_start, span_end in sorted(spans):
+            if not merged or span_start >= merged[-1][1]:
+                merged.append([span_start, span_end])
+            elif span_end > merged[-1][1]:
+                merged[-1][1] = span_end
+        base = max(literal_ids) + 1 if literal_ids else 0
+        cursor = 0
+        masked: list[str] = []
+        protected: list[ProtectedFragment] = []
+        for offset, (span_start, span_end) in enumerate(merged):
+            masked.append(text[cursor:span_start])
+            placeholder = f"[#{base + offset}#]"
+            while placeholder in reserved:
+                base += 1
+                placeholder = f"[#{base + offset}#]"
+            masked.append(placeholder)
+            protected.append(ProtectedFragment(placeholder, text[span_start:span_end]))
+            cursor = span_end
+        masked.append(text[cursor:])
+        return "".join(masked), tuple(protected)
+
+    @staticmethod
+    def _restore_protected(unit: TranslationUnit, translated: str) -> str:
+        expected = [match.group(0) for match in _PLACEHOLDER_RE.finditer(unit.text)]
+        actual = [match.group(0) for match in _PLACEHOLDER_RE.finditer(translated)]
+        if actual != expected:
+            raise ValidationError(f"Unit {unit.id} changed protected placeholder order")
+        restored = translated
+        for fragment in unit.protected:
+            restored = restored.replace(fragment.placeholder, fragment.value)
+        return restored
+
+    def _semantic_format_spans(
+        self,
+        text: str,
+    ) -> list[tuple[int, int, str, str, str]]:
+        out: list[tuple[int, int, str, str, str]] = []
+        index = 0
+        opener_re = re.compile(r"(?:§[0-9A-FK-Oa-fk-o])+")
+        while index < len(text):
+            opener = opener_re.search(text, index)
+            if opener is None:
+                break
+            reset = _base._SECTION_FORMAT_RE.search(text, opener.end())
+            if reset is None or reset.group(0).lower() != "§r":
+                index = opener.end()
+                continue
+            body = text[opener.end():reset.start()]
+            if (
+                not body
+                or body != body.strip()
+                or "\n" in body
+                or "\r" in body
+                or not self._has_prose(body)
+            ):
+                index = reset.end()
+                continue
+            suffix_end = reset.end()
+            boundary = _base._SECTION_RESET_BOUNDARY_RE.match(text, reset.start())
+            if boundary is not None:
+                suffix_end = boundary.end()
+            out.append(
+                (
+                    opener.start(),
+                    suffix_end,
+                    text[opener.start():opener.end()],
+                    body,
+                    text[reset.start():suffix_end],
+                )
+            )
+            index = suffix_end
+        return out
+
+
+__all__ = ["ImmersiveEngineeringManualAdapter", "IeManualFingerprint"]

--- a/mineai_formatkit/ie_manual_base.py
+++ b/mineai_formatkit/ie_manual_base.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Mapping
+
+from .core import ProtectedFragment, TranslationPlan, TranslationUnit, ValidationError
+
+
+_MANUAL_PATH_RE = re.compile(
+    r"(^|/)assets/[^/]+/manual/en_us/.+\.txt$",
+    re.IGNORECASE,
+)
+_TOKEN_RE = re.compile(r"<[^>\r\n]+>")
+_SECTION_FORMAT_RE = re.compile(r"§[0-9A-FK-ORa-fk-or]")
+_SECTION_RESET_BOUNDARY_RE = re.compile(
+    r"§r(?:[^\w\r\n<§]*[ \t]+|[^\w\s\r\n<§]+)",
+    re.IGNORECASE,
+)
+_PLACEHOLDER_RE = re.compile(r"\[#(\d+)#\]")
+_WORD_RE = re.compile(r"[A-Za-zА-Яа-яЁё]{2,}")
+
+
+@dataclass(frozen=True)
+class IeManualFingerprint:
+    line_count: int
+    newline_count: int
+    tokens: tuple[str, ...]
+
+
+class ImmersiveEngineeringManualAdapter:
+    """Span-preserving adapter for Immersive Engineering manual ``.txt`` files.
+
+    It translates prose, link labels, and the documented display branches of
+    boolean ``<config;...>`` tokens. Targets, anchors, config keys, keybinds,
+    page/line controls and every other manual directive stay immutable.
+    """
+
+    name = "immersive-engineering-manual"
+
+    def matches(self, path: str) -> bool:
+        slash = "/" + path.replace("\\", "/").lstrip("/")
+        return bool(_MANUAL_PATH_RE.search(slash))
+
+    def target_path(self, path: str, target_code: str) -> str:
+        slash = path.replace("\\", "/")
+        if not self.matches(slash):
+            raise ValueError(f"Unsupported Immersive Engineering manual source path: {path}")
+        return re.sub(
+            r"/manual/en_us/",
+            f"/manual/{target_code}/",
+            slash,
+            count=1,
+            flags=re.IGNORECASE,
+        )
+
+    def prepare(self, path: str, source_text: str) -> TranslationPlan:
+        spans: list[TranslationUnit] = []
+        cursor = 0
+        token_index = 0
+        for token_match in _TOKEN_RE.finditer(source_text):
+            self._add_plain_units(path, source_text, cursor, token_match.start(), spans)
+            self._add_token_units(path, source_text, token_match, token_index, spans)
+            cursor = token_match.end()
+            token_index += 1
+        self._add_plain_units(path, source_text, cursor, len(source_text), spans)
+        spans.sort(key=lambda unit: unit.start)
+        return TranslationPlan(
+            path=path,
+            source_text=source_text,
+            units=tuple(spans),
+            metadata={"fingerprint": self.fingerprint(source_text)},
+        )
+
+    def apply(self, plan: TranslationPlan, translations: Mapping[str, str]) -> str:
+        known = {unit.id for unit in plan.units}
+        unknown = set(translations) - known
+        if unknown:
+            raise ValidationError(f"Unknown translation unit ids: {sorted(unknown)!r}")
+
+        replacements: list[tuple[int, int, str]] = []
+        for unit in plan.units:
+            if unit.id not in translations:
+                continue
+            translated = translations[unit.id]
+            if "\n" in translated or "\r" in translated:
+                raise ValidationError(f"Unit {unit.id} introduced a newline")
+            if unit.kind in {"ie-link-label", "ie-config-label"} and any(
+                delimiter in translated for delimiter in (";", "<", ">")
+            ):
+                raise ValidationError(f"Unit {unit.id} changed manual-token delimiters")
+            restored = self._restore_protected(unit, translated)
+            replacements.append((unit.start, unit.end, restored))
+
+        output = plan.source_text
+        for start, end, replacement in sorted(replacements, reverse=True):
+            output = output[:start] + replacement + output[end:]
+        self.validate(plan.source_text, output)
+        return output
+
+    def validate(self, source_text: str, output_text: str) -> None:
+        if self.fingerprint(source_text) != self.fingerprint(output_text):
+            raise ValidationError("Immersive Engineering manual structure changed")
+
+    def fingerprint(self, text: str) -> IeManualFingerprint:
+        normalized: list[str] = []
+        for match in _TOKEN_RE.finditer(text):
+            normalized.append(self._normalize_token(match.group(0)))
+        return IeManualFingerprint(
+            line_count=len(text.splitlines()),
+            newline_count=text.count("\n"),
+            tokens=tuple(normalized),
+        )
+
+    def _add_plain_units(
+        self,
+        path: str,
+        text: str,
+        start: int,
+        end: int,
+        out: list[TranslationUnit],
+    ) -> None:
+        if start >= end:
+            return
+        block = text[start:end]
+        for match in re.finditer(r"[^\r\n]+", block):
+            raw = match.group(0)
+            leading = len(raw) - len(raw.lstrip(" \t"))
+            payload = raw.strip(" \t")
+            if not payload or not self._has_prose(payload):
+                continue
+            unit_start = start + match.start() + leading
+            unit_end = unit_start + len(payload)
+            masked, protected = self._protect_formatting(payload)
+            if not self._has_prose(_PLACEHOLDER_RE.sub(" ", masked)):
+                continue
+            out.append(
+                TranslationUnit(
+                    id=f"span:{unit_start}:prose",
+                    text=masked,
+                    start=unit_start,
+                    end=unit_end,
+                    kind="ie-manual-prose",
+                    context=path,
+                    protected=protected,
+                )
+            )
+
+    def _add_token_units(
+        self,
+        path: str,
+        text: str,
+        match: re.Match[str],
+        token_index: int,
+        out: list[TranslationUnit],
+    ) -> None:
+        token = match.group(0)
+        body = token[1:-1]
+        parts = body.split(";")
+        if not parts:
+            return
+        token_type = parts[0].lower()
+        indices: tuple[int, ...] = ()
+        kind = ""
+        if token_type == "link" and len(parts) in (3, 4):
+            indices = (2,)
+            kind = "ie-link-label"
+        elif token_type == "config" and len(parts) in (4, 5) and parts[1].lower() == "b":
+            indices = tuple(range(3, len(parts)))
+            kind = "ie-config-label"
+        else:
+            return
+
+        # Exact field spans inside the original token. ``split(';')`` is valid
+        # because the official parser uses semicolon-delimited fields too.
+        offsets: list[tuple[int, int]] = []
+        field_start = 1  # after '<'
+        for part in parts:
+            field_end = field_start + len(part)
+            offsets.append((field_start, field_end))
+            field_start = field_end + 1
+
+        for field_index in indices:
+            value = parts[field_index]
+            if not value or not self._has_prose(value):
+                continue
+            local_start, local_end = offsets[field_index]
+            unit_start = match.start() + local_start
+            unit_end = match.start() + local_end
+            masked, protected = self._protect_formatting(value)
+            out.append(
+                TranslationUnit(
+                    id=f"token:{token_index}:field:{field_index}",
+                    text=masked,
+                    start=unit_start,
+                    end=unit_end,
+                    kind=kind,
+                    context=path,
+                    protected=protected,
+                )
+            )
+
+    @staticmethod
+    def _normalize_token(token: str) -> str:
+        body = token[1:-1]
+        parts = body.split(";")
+        if parts and parts[0].lower() == "link" and len(parts) in (3, 4):
+            parts[2] = "<mineai-text>"
+            return "<" + ";".join(parts) + ">"
+        if (
+            parts
+            and parts[0].lower() == "config"
+            and len(parts) in (4, 5)
+            and parts[1].lower() == "b"
+        ):
+            for index in range(3, len(parts)):
+                parts[index] = "<mineai-text>"
+            return "<" + ";".join(parts) + ">"
+        return token
+
+    @staticmethod
+    def _has_prose(text: str) -> bool:
+        return bool(_WORD_RE.search(text))
+
+    def _protect_formatting(self, text: str) -> tuple[str, tuple[ProtectedFragment, ...]]:
+        spans = [
+            (match.start(), match.end())
+            for match in _SECTION_RESET_BOUNDARY_RE.finditer(text)
+        ]
+        spans.extend(
+            (match.start(), match.end()) for match in _SECTION_FORMAT_RE.finditer(text)
+        )
+        literal_ids = [int(match.group(1)) for match in _PLACEHOLDER_RE.finditer(text)]
+        spans.extend((match.start(), match.end()) for match in _PLACEHOLDER_RE.finditer(text))
+        merged: list[list[int]] = []
+        for start, end in sorted(spans):
+            if not merged or start >= merged[-1][1]:
+                merged.append([start, end])
+            elif end > merged[-1][1]:
+                merged[-1][1] = end
+        base = max(literal_ids) + 1 if literal_ids else 0
+        cursor = 0
+        masked: list[str] = []
+        protected: list[ProtectedFragment] = []
+        for index, (start, end) in enumerate(merged):
+            masked.append(text[cursor:start])
+            placeholder = f"[#{base + index}#]"
+            masked.append(placeholder)
+            protected.append(ProtectedFragment(placeholder, text[start:end]))
+            cursor = end
+        masked.append(text[cursor:])
+        return "".join(masked), tuple(protected)
+
+    @staticmethod
+    def _restore_protected(unit: TranslationUnit, translated: str) -> str:
+        expected = [fragment.placeholder for fragment in unit.protected]
+        actual = [f"[#{value}#]" for value in _PLACEHOLDER_RE.findall(translated)]
+        if actual != expected:
+            raise ValidationError(f"Unit {unit.id} changed protected placeholder order")
+        restored = translated
+        for fragment in unit.protected:
+            restored = restored.replace(fragment.placeholder, fragment.value)
+        return restored

--- a/mineai_formatkit/locale_merge.py
+++ b/mineai_formatkit/locale_merge.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter
+from dataclasses import dataclass
+from typing import Mapping
+
+from .core import TranslationPlan, ValidationError
+from .minecraft_lang import MinecraftLangJsonAdapter
+
+
+_PRINTF_RE = re.compile(
+    r"%(?!\s)(?:(?:\d+\$)?[-+#0 ,(<]*\d*(?:\.\d+)?"
+    r"(?:[bBhHsScCdoxXeEfgGaA]|[tT][HIklMSLNpzZsQBbhAaCYyjmdeRTrDFc])|[%n])"
+)
+_MESSAGE_FORMAT_RE = re.compile(r"\{\d+(?:,[^{}]+)?\}")
+
+
+@dataclass(frozen=True)
+class LocaleMergePlan:
+    source_plan: TranslationPlan
+    target_path: str
+    mode: str
+    pending_ids: tuple[str, ...]
+    existing_values: Mapping[str, str]
+    missing_keys: tuple[str, ...]
+    orphan_target_keys: tuple[str, ...]
+    invalid_existing_keys: tuple[str, ...]
+    target_parse_error: str | None = None
+
+
+class LocaleMergePlanner:
+    """Plan locale work with ``en_us`` as the canonical key/structure source.
+
+    Existing target locale text is optional reusable content. Its key order,
+    stale keys and formatting never define output structure.
+    """
+
+    VALID_MODES = {"append", "force", "skip"}
+
+    def __init__(self, adapter: MinecraftLangJsonAdapter | None = None) -> None:
+        self.adapter = adapter or MinecraftLangJsonAdapter()
+
+    def plan(
+        self,
+        source_path: str,
+        source_text: str,
+        target_code: str,
+        target_text: str | None = None,
+        mode: str = "append",
+    ) -> LocaleMergePlan:
+        if mode not in self.VALID_MODES:
+            raise ValueError(f"Unsupported locale merge mode: {mode}")
+        source_plan = self.adapter.prepare(source_path, source_text)
+        source_units = {u.context: u for u in source_plan.units}
+        source_values_meta = source_plan.metadata.get("original_values")
+        if not isinstance(source_values_meta, dict):
+            raise ValidationError("Source locale plan is missing original values")
+        source_values = {u.context: source_values_meta[u.id] for u in source_plan.units}
+        target_values = self._catalog(target_text) if target_text is not None else {}
+
+        source_keys = set(source_units)
+        target_keys = set(target_values)
+        missing = tuple(sorted(source_keys - target_keys))
+        orphan = tuple(sorted(target_keys - source_keys))
+        invalid: list[str] = []
+        existing: dict[str, str] = {}
+        pending: list[str] = []
+
+        for key, unit in source_units.items():
+            current = target_values.get(key)
+            if mode == "force":
+                pending.append(unit.id)
+                continue
+            if current is None or current == "":
+                pending.append(unit.id)
+                continue
+            if not self._critical_placeholders_match(source_values[key], current):
+                invalid.append(key)
+                pending.append(unit.id)
+                continue
+            if mode == "append" and current == source_values[key]:
+                pending.append(unit.id)
+                continue
+            existing[unit.id] = current
+
+        return LocaleMergePlan(
+            source_plan=source_plan,
+            target_path=self.adapter.target_path(source_path, target_code),
+            mode=mode,
+            pending_ids=tuple(pending),
+            existing_values=existing,
+            missing_keys=missing,
+            orphan_target_keys=orphan,
+            invalid_existing_keys=tuple(sorted(invalid)),
+        )
+
+    def build(self, plan: LocaleMergePlan, translations: Mapping[str, str]) -> str:
+        required = set(plan.pending_ids)
+        unknown = set(translations) - required
+        if unknown:
+            raise ValidationError(f"Translations contain non-pending ids: {sorted(unknown)!r}")
+        missing = required - set(translations)
+        if missing:
+            raise ValidationError(f"Missing translations for pending ids: {sorted(missing)!r}")
+
+        replacements: list[tuple[int, int, str]] = []
+        for unit in plan.source_plan.units:
+            if unit.id in plan.existing_values:
+                value = plan.existing_values[unit.id]
+            elif unit.id in translations:
+                value = self.adapter._restore_protected(unit, translations[unit.id])
+            else:
+                continue
+            replacements.append((unit.start, unit.end, json.dumps(value, ensure_ascii=False)))
+
+        output = plan.source_plan.source_text
+        for start, end, token in sorted(replacements, reverse=True):
+            output = output[:start] + token + output[end:]
+        self.adapter.validate(plan.source_plan.source_text, output)
+        return output
+
+    def _catalog(self, text: str) -> dict[str, str]:
+        entries = self.adapter._parse_entries(text)
+        out: dict[str, str] = {}
+        for entry in entries:
+            if entry.is_string:
+                assert isinstance(entry.value, str)
+                out[entry.key] = entry.value
+        return out
+
+    @staticmethod
+    def _critical_placeholders(text: str) -> Counter[str]:
+        return Counter(_PRINTF_RE.findall(text) + _MESSAGE_FORMAT_RE.findall(text))
+
+    def _critical_placeholders_match(self, source: str, target: str) -> bool:
+        return self._critical_placeholders(source) == self._critical_placeholders(target)

--- a/mineai_formatkit/locale_safe.py
+++ b/mineai_formatkit/locale_safe.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter
+from dataclasses import replace
+
+from .core import ProtectedFragment, TranslationPlan, ValidationError
+from .locale_merge import LocaleMergePlan
+from .minecraft_lang import _IGNORED_METADATA_KEYS, _JsonEntry, _PLACEHOLDER_RE
+from .structured_locale import (
+    LocaleMergePlanner as _StructuredLocaleMergePlanner,
+    MinecraftLangJsonAdapter as _StructuredMinecraftLangJsonAdapter,
+)
+
+# Proven by the FTB Evolution KubeJS locale corpus. Keep these deliberately
+# narrower than a generic ampersand/brace/private-character matcher.
+_FTB_FORMAT_RE = re.compile(r"&[0-9a-fk-orz]")
+_FTB_IMAGE_RE = re.compile(r"\{image:[^{}\r\n]+\}")
+_PRIVATE_USE_RE = re.compile(r"[\ue000-\uf8ff]")
+_FTB_FORMAT_COUNTER_TOKEN = "<mineai-ftb-format-code>"
+
+# Malum's codex renderer consumes these markers from ordinary lang values.
+# Inline $i/$b pairs wrap human text; $m<number>/$ is a complete scale token.
+# The patterns intentionally require a balanced inline close or a numeric scale
+# so ordinary dollar prose is not generalized into markup.
+_MALUM_INLINE_RE = re.compile(r"\$(?P<code>[ib])(?P<body>[^$\r\n]*?)/\$")
+_MALUM_SCALE_RE = re.compile(r"\$m\d+(?:\.\d+)?/\$")
+
+
+class MinecraftLangJsonAdapter(_StructuredMinecraftLangJsonAdapter):
+    """Public locale adapter with live-modpack safety hardening.
+
+    In addition to the reviewed runtime/structured locale layers, this accepts
+    repeated ordinary string keys only when every repeated value is identical.
+    One logical TranslationUnit is exposed and a changed translation is written
+    back to every identical occurrence. Conflicting duplicates still fail
+    closed.
+
+    The adapter also protects corpus-proven FTB ampersand formatting, FTB image
+    directives, BMP Private Use Area glyphs used by custom-font resources, and
+    balanced Malum codex markup embedded in ordinary locale values.
+    """
+
+    name = "minecraft-lang-json"
+
+    def _parse_entries(self, text: str) -> tuple[_JsonEntry, ...]:
+        decoder = json.JSONDecoder()
+        length = len(text)
+        index = self._skip_ws(text, 0)
+        if index >= length or text[index] != "{":
+            raise ValidationError("Minecraft lang JSON must be a top-level object")
+        index += 1
+
+        entries: list[_JsonEntry] = []
+        first_by_key: dict[str, _JsonEntry] = {}
+
+        while True:
+            index = self._skip_ws(text, index)
+            if index >= length:
+                raise ValidationError("Unexpected end of Minecraft lang JSON")
+            if text[index] == "}":
+                index += 1
+                break
+            if text[index] != '"':
+                raise ValidationError("Minecraft lang JSON keys must be strings")
+
+            key_end = self._scan_string_end(text, index)
+            try:
+                key = json.loads(text[index:key_end])
+            except json.JSONDecodeError as exc:
+                raise ValidationError("Invalid JSON key string") from exc
+            index = self._skip_ws(text, key_end)
+            if index >= length or text[index] != ":":
+                raise ValidationError(f"Missing ':' after Minecraft lang key {key!r}")
+            index = self._skip_ws(text, index + 1)
+            if index >= length:
+                raise ValidationError(f"Missing value for Minecraft lang key {key!r}")
+
+            value_start = index
+            if text[index] == '"':
+                value_end = self._scan_string_end(text, index)
+                try:
+                    value = json.loads(text[value_start:value_end])
+                except json.JSONDecodeError as exc:
+                    raise ValidationError(f"Invalid JSON string for key {key!r}") from exc
+                is_string = True
+            else:
+                try:
+                    value, value_end = decoder.raw_decode(text, index)
+                except json.JSONDecodeError as exc:
+                    raise ValidationError(f"Invalid JSON value for key {key!r}") from exc
+                is_string = False
+
+            entry = _JsonEntry(
+                key=key,
+                value=value,
+                value_start=value_start,
+                value_end=value_end,
+                is_string=is_string,
+            )
+            previous = first_by_key.get(key)
+            if previous is not None and key not in _IGNORED_METADATA_KEYS:
+                if not (
+                    previous.is_string
+                    and entry.is_string
+                    and previous.value == entry.value
+                ):
+                    # Keep the historical failure wording for callers/tests.
+                    raise ValidationError(f"Duplicate Minecraft lang key: {key}")
+            else:
+                first_by_key.setdefault(key, entry)
+            entries.append(entry)
+
+            index = self._skip_ws(text, value_end)
+            if index >= length:
+                raise ValidationError("Unexpected end of Minecraft lang JSON")
+            if text[index] == ",":
+                index += 1
+                continue
+            if text[index] == "}":
+                index += 1
+                break
+            raise ValidationError(f"Expected ',' or '}}' after Minecraft lang key {key!r}")
+
+        if self._skip_ws(text, index) != length:
+            raise ValidationError("Trailing data after Minecraft lang JSON object")
+        return tuple(entries)
+
+    def prepare(self, path: str, source_text: str) -> TranslationPlan:
+        raw_plan = super().prepare(path, source_text)
+        unique_units = []
+        first_units = {}
+        alias_spans: dict[str, list[tuple[int, int]]] = {}
+
+        for unit in raw_plan.units:
+            previous = first_units.get(unit.id)
+            if previous is None:
+                first_units[unit.id] = unit
+                unique_units.append(unit)
+                continue
+            if (
+                previous.text != unit.text
+                or previous.kind != unit.kind
+                or previous.context != unit.context
+                or previous.protected != unit.protected
+            ):
+                raise ValidationError(
+                    f"Duplicate locale unit {unit.id!r} is not semantically identical"
+                )
+            alias_spans.setdefault(unit.id, []).append((unit.start, unit.end))
+
+        metadata = dict(raw_plan.metadata)
+        metadata["duplicate_alias_spans"] = {
+            unit_id: tuple(spans) for unit_id, spans in alias_spans.items()
+        }
+        return TranslationPlan(
+            path=raw_plan.path,
+            source_text=raw_plan.source_text,
+            units=tuple(unique_units),
+            metadata=metadata,
+        )
+
+    def apply(self, plan: TranslationPlan, translations) -> str:
+        return super().apply(self._expand_alias_units(plan), translations)
+
+    def _expand_alias_units(self, plan: TranslationPlan) -> TranslationPlan:
+        alias_spans = plan.metadata.get("duplicate_alias_spans", {})
+        if not isinstance(alias_spans, dict) or not alias_spans:
+            return plan
+
+        expanded = []
+        for unit in plan.units:
+            expanded.append(unit)
+            spans = alias_spans.get(unit.id, ())
+            if not isinstance(spans, (tuple, list)):
+                raise ValidationError("Invalid duplicate locale alias metadata")
+            for span in spans:
+                if not (
+                    isinstance(span, (tuple, list))
+                    and len(span) == 2
+                    and all(isinstance(value, int) for value in span)
+                ):
+                    raise ValidationError("Invalid duplicate locale alias span")
+                expanded.append(replace(unit, start=span[0], end=span[1]))
+        return replace(plan, units=tuple(expanded))
+
+    def _protect(self, text: str) -> tuple[str, tuple[ProtectedFragment, ...]]:
+        masked, protected = super()._protect(text)
+        spans: list[tuple[int, int]] = []
+        for regex in (_FTB_FORMAT_RE, _FTB_IMAGE_RE, _PRIVATE_USE_RE):
+            for match in regex.finditer(masked):
+                # Never swallow a placeholder created by an earlier safety
+                # layer into a new fragment; restoration validates every
+                # placeholder independently.
+                if _PLACEHOLDER_RE.search(masked[match.start() : match.end()]):
+                    continue
+                spans.append((match.start(), match.end()))
+
+        # Preserve Malum's runtime markup but leave the wrapped human prose
+        # visible to the translator.
+        for match in _MALUM_INLINE_RE.finditer(masked):
+            spans.append((match.start(), match.start() + 2))
+            spans.append((match.end() - 2, match.end()))
+        spans.extend((match.start(), match.end()) for match in _MALUM_SCALE_RE.finditer(masked))
+
+        merged = self._merge_spans(spans)
+        if not merged:
+            return masked, protected
+
+        placeholder_ids = [int(match.group(1)) for match in _PLACEHOLDER_RE.finditer(masked)]
+        next_id = max(placeholder_ids) + 1 if placeholder_ids else 0
+        out: list[str] = []
+        extra: list[ProtectedFragment] = []
+        cursor = 0
+        for offset, (start, end) in enumerate(merged):
+            out.append(masked[cursor:start])
+            placeholder = f"[#{next_id + offset}#]"
+            out.append(placeholder)
+            extra.append(ProtectedFragment(placeholder, masked[start:end]))
+            cursor = end
+        out.append(masked[cursor:])
+        return "".join(out), protected + tuple(extra)
+
+
+class LocaleMergePlanner(_StructuredLocaleMergePlanner):
+    """Structured locale planner aligned with the live-pack safety contract."""
+
+    def __init__(self, adapter: MinecraftLangJsonAdapter | None = None) -> None:
+        super().__init__(adapter or MinecraftLangJsonAdapter())
+
+    def plan(
+        self,
+        source_path: str,
+        source_text: str,
+        target_code: str,
+        target_text: str | None = None,
+        mode: str = "append",
+    ) -> LocaleMergePlan:
+        # Force mode is source-only by definition. Never let an optional broken
+        # target block a complete rebuild from canonical English.
+        if mode == "force":
+            return super().plan(
+                source_path,
+                source_text,
+                target_code,
+                target_text=None,
+                mode=mode,
+            )
+
+        if target_text is not None:
+            try:
+                self._catalog_extended(target_text)
+            except ValidationError as exc:
+                # Existing target wording is optional. If it is malformed,
+                # discard it as a reuse source and keep planning from EN. The
+                # error is retained for host diagnostics.
+                fallback = super().plan(
+                    source_path,
+                    source_text,
+                    target_code,
+                    target_text=None,
+                    mode=mode,
+                )
+                return replace(fallback, target_parse_error=str(exc))
+
+        return super().plan(
+            source_path,
+            source_text,
+            target_code,
+            target_text=target_text,
+            mode=mode,
+        )
+
+    @staticmethod
+    def _critical_placeholders(text: str) -> Counter[str]:
+        critical = _StructuredLocaleMergePlanner._critical_placeholders(text)
+        # A target may intentionally choose another FTB colour/style code, but
+        # losing or adding a formatting boundary is still suspicious. Compare
+        # only the count, not the exact code values.
+        format_count = len(_FTB_FORMAT_RE.findall(text))
+        if format_count:
+            critical[_FTB_FORMAT_COUNTER_TOKEN] += format_count
+        critical.update(_FTB_IMAGE_RE.findall(text))
+        critical.update(_PRIVATE_USE_RE.findall(text))
+
+        # Malum inline markers are structural styling, while scale tokens also
+        # carry a numeric rendering value. Compare both exactly when present.
+        for match in _MALUM_INLINE_RE.finditer(text):
+            critical[f"<mineai-malum-{match.group('code')}-pair>"] += 1
+        critical.update(_MALUM_SCALE_RE.findall(text))
+        return critical
+
+    def build(self, plan: LocaleMergePlan, translations) -> str:
+        expanded_source = self.adapter._expand_alias_units(plan.source_plan)
+        if expanded_source is plan.source_plan:
+            return super().build(plan, translations)
+        return super().build(replace(plan, source_plan=expanded_source), translations)

--- a/mineai_formatkit/minecraft_lang.py
+++ b/mineai_formatkit/minecraft_lang.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter
+from dataclasses import dataclass
+from typing import Mapping
+
+from .core import ProtectedFragment, TranslationPlan, TranslationUnit, ValidationError
+
+
+_SOURCE_PATH_RE = re.compile(
+    r"(^|/)assets/([^/]+)/lang/en_us\.json$",
+    re.IGNORECASE,
+)
+_FORMAT_RE = re.compile(
+    r"%(?!\s)(?:(?:\d+\$)?[-+#0 ,(<]*\d*(?:\.\d+)?"
+    r"(?:[bBhHsScCdoxXeEfgGaA]|[tT][HIklMSLNpzZsQBbhAaCYyjmdeRTrDFc])|[%n])"
+)
+_MINECRAFT_FORMAT_RE = re.compile(r"§[0-9A-FK-ORa-fk-or]")
+_MESSAGE_FORMAT_RE = re.compile(r"\{\d+(?:,[^{}]+)?\}")
+_PLACEHOLDER_RE = re.compile(r"\[#(\d+)#\]")
+_LINE_BREAK_RE = re.compile(r"\r\n|\r|\n")
+_IGNORED_METADATA_KEYS = frozenset({"_comment", "comment_id"})
+
+
+@dataclass(frozen=True)
+class _JsonEntry:
+    key: str
+    value: object
+    value_start: int
+    value_end: int
+    is_string: bool
+
+
+@dataclass(frozen=True)
+class LangJsonFingerprint:
+    keys: tuple[str, ...]
+    skeleton: str
+
+
+class MinecraftLangJsonAdapter:
+    """Structure-preserving adapter for Minecraft ``lang/*.json`` files.
+
+    The source document stays immutable. Only complete JSON string value tokens
+    are replaced, so key ordering, whitespace, commas and unrelated data are
+    preserved exactly. Technical formatting fragments are represented by
+    placeholders before a value is handed to a translator.
+    """
+
+    name = "minecraft-lang-json"
+
+    def matches(self, path: str) -> bool:
+        slash = path.replace("\\", "/")
+        return bool(_SOURCE_PATH_RE.search("/" + slash.lstrip("/")))
+
+    def target_path(self, path: str, target_code: str) -> str:
+        slash = path.replace("\\", "/")
+        normalized = "/" + slash.lstrip("/")
+        match = _SOURCE_PATH_RE.search(normalized)
+        if not match:
+            raise ValueError(f"Unsupported Minecraft lang source path: {path}")
+        prefix_len = 1 if not slash.startswith("/") else 0
+        start = match.end() - len("en_us.json") - prefix_len
+        end = start + len("en_us.json")
+        return slash[:start] + f"{target_code}.json" + slash[end:]
+
+    def prepare(self, path: str, source_text: str) -> TranslationPlan:
+        entries = self._parse_entries(source_text)
+        ignored_metadata = self._repeated_metadata_keys(entries)
+        units: list[TranslationUnit] = []
+        original_values: dict[str, str] = {}
+        unsupported_non_string_keys: list[str] = []
+        ignored_metadata_keys: list[str] = []
+
+        for entry in entries:
+            if entry.key in ignored_metadata:
+                ignored_metadata_keys.append(entry.key)
+                continue
+            if not entry.is_string:
+                unsupported_non_string_keys.append(entry.key)
+                continue
+            assert isinstance(entry.value, str)
+            if not entry.value:
+                continue
+            masked, protected = self._protect(entry.value)
+            unit_id = f"key:{entry.key}"
+            units.append(
+                TranslationUnit(
+                    id=unit_id,
+                    text=masked,
+                    start=entry.value_start,
+                    end=entry.value_end,
+                    kind="minecraft-lang-value",
+                    context=entry.key,
+                    protected=protected,
+                )
+            )
+            original_values[unit_id] = entry.value
+
+        return TranslationPlan(
+            path=path,
+            source_text=source_text,
+            units=tuple(units),
+            metadata={
+                "fingerprint": self.fingerprint(source_text),
+                "original_values": original_values,
+                "unsupported_non_string_keys": tuple(unsupported_non_string_keys),
+                "ignored_metadata_keys": tuple(dict.fromkeys(ignored_metadata_keys)),
+            },
+        )
+
+    def apply(self, plan: TranslationPlan, translations: Mapping[str, str]) -> str:
+        known = {unit.id for unit in plan.units}
+        unknown = set(translations) - known
+        if unknown:
+            raise ValidationError(f"Unknown translation unit ids: {sorted(unknown)!r}")
+
+        original_values = plan.metadata.get("original_values")
+        if not isinstance(original_values, dict):
+            raise ValidationError("Translation plan is missing original locale values")
+
+        replacements: list[tuple[int, int, str]] = []
+        for unit in plan.units:
+            if unit.id not in translations:
+                continue
+            translated = translations[unit.id]
+            restored = self._restore_protected(unit, translated)
+            original_value = original_values.get(unit.id)
+
+            # Identity translations must preserve the exact original JSON token,
+            # including its original escape spelling.
+            if restored == original_value:
+                encoded = plan.source_text[unit.start : unit.end]
+            else:
+                encoded = json.dumps(restored, ensure_ascii=False)
+            replacements.append((unit.start, unit.end, encoded))
+
+        output = plan.source_text
+        for start, end, value in sorted(replacements, reverse=True):
+            output = output[:start] + value + output[end:]
+
+        self.validate(plan.source_text, output)
+        return output
+
+    def validate(self, source_text: str, output_text: str) -> None:
+        before = self.fingerprint(source_text)
+        after = self.fingerprint(output_text)
+        if before != after:
+            raise ValidationError(
+                "Minecraft lang JSON structure changed during reconstruction"
+            )
+
+    def fingerprint(self, text: str) -> LangJsonFingerprint:
+        entries = self._parse_entries(text)
+        ignored_metadata = self._repeated_metadata_keys(entries)
+        string_spans = [
+            (entry.value_start, entry.value_end)
+            for entry in entries
+            if entry.is_string and entry.key not in ignored_metadata
+        ]
+        skeleton_parts: list[str] = []
+        cursor = 0
+        for start, end in string_spans:
+            skeleton_parts.append(text[cursor:start])
+            skeleton_parts.append('"<mineai-value>"')
+            cursor = end
+        skeleton_parts.append(text[cursor:])
+        return LangJsonFingerprint(
+            keys=tuple(entry.key for entry in entries),
+            skeleton="".join(skeleton_parts),
+        )
+
+    @staticmethod
+    def _repeated_metadata_keys(entries: tuple[_JsonEntry, ...]) -> frozenset[str]:
+        counts = Counter(entry.key for entry in entries)
+        return frozenset(
+            key for key, count in counts.items()
+            if count > 1 and key in _IGNORED_METADATA_KEYS
+        )
+
+    def _parse_entries(self, text: str) -> tuple[_JsonEntry, ...]:
+        decoder = json.JSONDecoder()
+        length = len(text)
+        index = self._skip_ws(text, 0)
+        if index >= length or text[index] != "{":
+            raise ValidationError("Minecraft lang JSON must be a top-level object")
+        index += 1
+
+        entries: list[_JsonEntry] = []
+        seen: set[str] = set()
+
+        while True:
+            index = self._skip_ws(text, index)
+            if index >= length:
+                raise ValidationError("Unexpected end of Minecraft lang JSON")
+            if text[index] == "}":
+                index += 1
+                break
+            if text[index] != '"':
+                raise ValidationError("Minecraft lang JSON keys must be strings")
+
+            key_end = self._scan_string_end(text, index)
+            try:
+                key = json.loads(text[index:key_end])
+            except json.JSONDecodeError as exc:
+                raise ValidationError("Invalid JSON key string") from exc
+            if key in seen and key not in _IGNORED_METADATA_KEYS:
+                raise ValidationError(f"Duplicate Minecraft lang key: {key}")
+            seen.add(key)
+            index = self._skip_ws(text, key_end)
+            if index >= length or text[index] != ":":
+                raise ValidationError(f"Missing ':' after Minecraft lang key {key!r}")
+            index = self._skip_ws(text, index + 1)
+            if index >= length:
+                raise ValidationError(f"Missing value for Minecraft lang key {key!r}")
+
+            value_start = index
+            if text[index] == '"':
+                value_end = self._scan_string_end(text, index)
+                try:
+                    value = json.loads(text[value_start:value_end])
+                except json.JSONDecodeError as exc:
+                    raise ValidationError(f"Invalid JSON string for key {key!r}") from exc
+                is_string = True
+            else:
+                try:
+                    value, value_end = decoder.raw_decode(text, index)
+                except json.JSONDecodeError as exc:
+                    raise ValidationError(f"Invalid JSON value for key {key!r}") from exc
+                is_string = False
+
+            entries.append(
+                _JsonEntry(
+                    key=key,
+                    value=value,
+                    value_start=value_start,
+                    value_end=value_end,
+                    is_string=is_string,
+                )
+            )
+            index = self._skip_ws(text, value_end)
+            if index >= length:
+                raise ValidationError("Unexpected end of Minecraft lang JSON")
+            if text[index] == ",":
+                index += 1
+                continue
+            if text[index] == "}":
+                index += 1
+                break
+            raise ValidationError(f"Expected ',' or '}}' after Minecraft lang key {key!r}")
+
+        if self._skip_ws(text, index) != length:
+            raise ValidationError("Trailing data after Minecraft lang JSON object")
+        return tuple(entries)
+
+    @staticmethod
+    def _skip_ws(text: str, index: int) -> int:
+        while index < len(text) and text[index] in " \t\r\n":
+            index += 1
+        return index
+
+    @staticmethod
+    def _scan_string_end(text: str, start: int) -> int:
+        index = start + 1
+        escaped = False
+        while index < len(text):
+            char = text[index]
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                return index + 1
+            elif ord(char) < 0x20:
+                raise ValidationError("Unescaped control character in JSON string")
+            index += 1
+        raise ValidationError("Unterminated JSON string")
+
+    def _protect(self, text: str) -> tuple[str, tuple[ProtectedFragment, ...]]:
+        spans: list[tuple[int, int]] = []
+        literal_ids = [int(match.group(1)) for match in _PLACEHOLDER_RE.finditer(text)]
+        spans.extend((m.start(), m.end()) for m in _PLACEHOLDER_RE.finditer(text))
+        for regex in (
+            _FORMAT_RE,
+            _MINECRAFT_FORMAT_RE,
+            _MESSAGE_FORMAT_RE,
+            _LINE_BREAK_RE,
+        ):
+            spans.extend((match.start(), match.end()) for match in regex.finditer(text))
+
+        merged = self._merge_spans(spans)
+        protected: list[ProtectedFragment] = []
+        out: list[str] = []
+        cursor = 0
+        base_id = (max(literal_ids) + 1) if literal_ids else 0
+        for offset, (start, end) in enumerate(merged):
+            out.append(text[cursor:start])
+            placeholder = f"[#{base_id + offset}#]"
+            out.append(placeholder)
+            protected.append(ProtectedFragment(placeholder, text[start:end]))
+            cursor = end
+        out.append(text[cursor:])
+        return "".join(out), tuple(protected)
+
+    @staticmethod
+    def _merge_spans(spans: list[tuple[int, int]]) -> list[tuple[int, int]]:
+        merged: list[list[int]] = []
+        for start, end in sorted(spans):
+            if start >= end:
+                continue
+            if not merged or start >= merged[-1][1]:
+                merged.append([start, end])
+            elif end > merged[-1][1]:
+                merged[-1][1] = end
+        return [(start, end) for start, end in merged]
+
+    @staticmethod
+    def _restore_protected(unit: TranslationUnit, translated: str) -> str:
+        expected = Counter(fragment.placeholder for fragment in unit.protected)
+        actual = Counter(f"[#{value}#]" for value in _PLACEHOLDER_RE.findall(translated))
+        if actual != expected:
+            raise ValidationError(
+                f"Unit {unit.id} changed protected placeholders: "
+                f"expected {expected}, got {actual}"
+            )
+        restored = translated
+        for fragment in unit.protected:
+            restored = restored.replace(fragment.placeholder, fragment.value)
+        return restored

--- a/mineai_formatkit/minecraft_text.py
+++ b/mineai_formatkit/minecraft_text.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter
+from dataclasses import dataclass
+from typing import Mapping
+
+from .core import ProtectedFragment, TranslationPlan, TranslationUnit, ValidationError
+
+
+_PATH_RE = re.compile(
+    r"(^|/)data/[^/]+/(?:advancements?|loot_tables?|enchantments?)/.+\.json$",
+    re.IGNORECASE,
+)
+_FORMAT_RE = re.compile(
+    r"%(?!\s)(?:(?:\d+\$)?[-+#0 ,(<]*\d*(?:\.\d+)?"
+    r"(?:[bBhHsScCdoxXeEfgGaA]|[tT][HIklMSLNpzZsQBbhAaCYyjmdeRTrDFc])|[%n])"
+)
+_MC_FORMAT_RE = re.compile(r"§[0-9A-FK-ORa-fk-or]")
+_MESSAGE_FORMAT_RE = re.compile(r"\{\d+(?:,[^{}]+)?\}")
+_PLACEHOLDER_RE = re.compile(r"\[#(\d+)#\]")
+_LINE_BREAK_RE = re.compile(r"\r\n|\r|\n")
+_WORD_RE = re.compile(r"[A-Za-zА-Яа-яЁё]{2,}")
+_RESOURCE_LOCATION_RE = re.compile(r"^[a-z0-9_.-]+:[a-z0-9_./-]+$", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class _Member:
+    key: str
+    value: "_Node"
+
+
+@dataclass(frozen=True)
+class _Node:
+    kind: str
+    start: int
+    end: int
+    value: object
+    members: tuple[_Member, ...] = ()
+    items: tuple["_Node", ...] = ()
+
+
+@dataclass(frozen=True)
+class TextComponentFingerprint:
+    locators: tuple[str, ...]
+    skeleton: str
+
+
+class MinecraftTextComponentAdapter:
+    """Extract only known player-visible Minecraft JSON text-component fields."""
+
+    name = "minecraft-text-components"
+
+    def matches(self, path: str) -> bool:
+        slash = "/" + path.replace("\\", "/").lstrip("/")
+        return bool(_PATH_RE.search(slash))
+
+    def prepare(self, path: str, source_text: str) -> TranslationPlan:
+        root = self._parse(source_text)
+        targets: list[tuple[str, _Node, str, str]] = []
+        self._collect(root, "", targets)
+        units: list[TranslationUnit] = []
+        encodings: dict[str, str] = {}
+        originals: dict[str, str] = {}
+        for locator, node, text, encoding in targets:
+            if not self._has_prose(text):
+                continue
+            masked, protected = self._protect(text)
+            unit_id = f"json:{locator}"
+            units.append(TranslationUnit(
+                id=unit_id,
+                text=masked,
+                start=node.start,
+                end=node.end,
+                kind="minecraft-text-component",
+                context=locator,
+                protected=protected,
+            ))
+            encodings[unit_id] = encoding
+            originals[unit_id] = text
+        return TranslationPlan(
+            path=path,
+            source_text=source_text,
+            units=tuple(units),
+            metadata={
+                "fingerprint": self.fingerprint(source_text),
+                "encodings": encodings,
+                "originals": originals,
+            },
+        )
+
+    def apply(self, plan: TranslationPlan, translations: Mapping[str, str]) -> str:
+        known = {u.id for u in plan.units}
+        unknown = set(translations) - known
+        if unknown:
+            raise ValidationError(f"Unknown translation unit ids: {sorted(unknown)!r}")
+        encodings = plan.metadata.get("encodings")
+        if not isinstance(encodings, dict):
+            raise ValidationError("Translation plan is missing text-component encodings")
+        originals = plan.metadata.get("originals")
+        if not isinstance(originals, dict):
+            raise ValidationError("Translation plan is missing original text values")
+        replacements: list[tuple[int, int, str]] = []
+        for unit in plan.units:
+            if unit.id not in translations:
+                continue
+            restored = self._restore(unit, translations[unit.id])
+            encoding = encodings[unit.id]
+            if restored == originals.get(unit.id):
+                token = plan.source_text[unit.start:unit.end]
+            elif encoding == "json-string":
+                token = json.dumps(restored, ensure_ascii=False)
+            elif encoding == "nested-json-string":
+                token = json.dumps(json.dumps(restored, ensure_ascii=False), ensure_ascii=False)
+            else:
+                raise ValidationError(f"Unknown encoding {encoding!r}")
+            replacements.append((unit.start, unit.end, token))
+        output = plan.source_text
+        for start, end, token in sorted(replacements, reverse=True):
+            output = output[:start] + token + output[end:]
+        self.validate(plan.source_text, output)
+        return output
+
+    def validate(self, source_text: str, output_text: str) -> None:
+        if self.fingerprint(source_text) != self.fingerprint(output_text):
+            raise ValidationError("Minecraft text-component structure changed")
+
+    def fingerprint(self, text: str) -> TextComponentFingerprint:
+        root = self._parse(text)
+        targets: list[tuple[str, _Node, str, str]] = []
+        self._collect(root, "", targets)
+        spans = [(n.start, n.end, loc) for loc, n, value, enc in targets if self._has_prose(value)]
+        out: list[str] = []
+        cursor = 0
+        for start, end, _ in spans:
+            out.append(text[cursor:start])
+            out.append('"<mineai-text>"')
+            cursor = end
+        out.append(text[cursor:])
+        return TextComponentFingerprint(tuple(loc for _, _, loc in spans), "".join(out))
+
+    def _collect(self, node: _Node, path: str, out: list[tuple[str, _Node, str, str]]) -> None:
+        if node.kind == "object":
+            members = {m.key: m.value for m in node.members}
+            translate = members.get("translate")
+            fallback = members.get("fallback")
+            if translate and translate.kind == "string" and fallback and fallback.kind == "string":
+                value = fallback.value
+                assert isinstance(value, str)
+                if not _RESOURCE_LOCATION_RE.fullmatch(value):
+                    out.append((path + "/fallback", fallback, value, "json-string"))
+            text_node = members.get("text")
+            if text_node and text_node.kind == "string":
+                value = text_node.value
+                assert isinstance(value, str)
+                out.append((path + "/text", text_node, value, "json-string"))
+
+            function_node = members.get("function")
+            function = function_node.value if function_node and function_node.kind == "string" else None
+            if function == "minecraft:set_name":
+                name = members.get("name")
+                if name and name.kind == "string":
+                    assert isinstance(name.value, str)
+                    out.append((path + "/name", name, name.value, "json-string"))
+            if function == "minecraft:set_lore":
+                lore = members.get("lore")
+                if lore and lore.kind == "array":
+                    for idx, item in enumerate(lore.items):
+                        if item.kind == "string":
+                            assert isinstance(item.value, str)
+                            out.append((f"{path}/lore/{idx}", item, item.value, "json-string"))
+            components = members.get("components")
+            if function == "minecraft:set_components" and components and components.kind == "object":
+                for member in components.members:
+                    if member.key == "minecraft:custom_name" and member.value.kind == "string":
+                        raw = member.value.value
+                        assert isinstance(raw, str)
+                        try:
+                            nested = json.loads(raw)
+                        except json.JSONDecodeError:
+                            nested = None
+                        if isinstance(nested, str):
+                            out.append((path + "/components/minecraft:custom_name", member.value, nested, "nested-json-string"))
+            for member in node.members:
+                self._collect(member.value, path + "/" + self._escape(member.key), out)
+        elif node.kind == "array":
+            for idx, item in enumerate(node.items):
+                self._collect(item, f"{path}/{idx}", out)
+
+    def _parse(self, text: str) -> _Node:
+        node, index = self._parse_value(text, self._skip_ws(text, 0))
+        if self._skip_ws(text, index) != len(text):
+            raise ValidationError("Trailing data after JSON document")
+        return node
+
+    def _parse_value(self, text: str, index: int) -> tuple[_Node, int]:
+        index = self._skip_ws(text, index)
+        if index >= len(text):
+            raise ValidationError("Unexpected end of JSON")
+        if text[index] == '"':
+            end = self._scan_string_end(text, index)
+            try:
+                value = json.loads(text[index:end])
+            except json.JSONDecodeError as exc:
+                raise ValidationError("Invalid JSON string") from exc
+            return _Node("string", index, end, value), end
+        if text[index] == "{":
+            start = index
+            index += 1
+            members: list[_Member] = []
+            seen: set[str] = set()
+            while True:
+                index = self._skip_ws(text, index)
+                if index < len(text) and text[index] == "}":
+                    return _Node("object", start, index + 1, None, tuple(members)), index + 1
+                if index >= len(text) or text[index] != '"':
+                    raise ValidationError("JSON object key must be a string")
+                key_end = self._scan_string_end(text, index)
+                key = json.loads(text[index:key_end])
+                if key in seen:
+                    raise ValidationError(f"Duplicate JSON key: {key}")
+                seen.add(key)
+                index = self._skip_ws(text, key_end)
+                if index >= len(text) or text[index] != ":":
+                    raise ValidationError("Missing ':' after JSON key")
+                value, index = self._parse_value(text, index + 1)
+                members.append(_Member(key, value))
+                index = self._skip_ws(text, index)
+                if index < len(text) and text[index] == ",":
+                    index += 1
+                    continue
+                if index < len(text) and text[index] == "}":
+                    return _Node("object", start, index + 1, None, tuple(members)), index + 1
+                raise ValidationError("Expected ',' or '}' in JSON object")
+        if text[index] == "[":
+            start = index
+            index += 1
+            items: list[_Node] = []
+            while True:
+                index = self._skip_ws(text, index)
+                if index < len(text) and text[index] == "]":
+                    return _Node("array", start, index + 1, None, items=tuple(items)), index + 1
+                item, index = self._parse_value(text, index)
+                items.append(item)
+                index = self._skip_ws(text, index)
+                if index < len(text) and text[index] == ",":
+                    index += 1
+                    continue
+                if index < len(text) and text[index] == "]":
+                    return _Node("array", start, index + 1, None, items=tuple(items)), index + 1
+                raise ValidationError("Expected ',' or ']' in JSON array")
+        decoder = json.JSONDecoder()
+        try:
+            value, end = decoder.raw_decode(text, index)
+        except json.JSONDecodeError as exc:
+            raise ValidationError("Invalid JSON value") from exc
+        return _Node("scalar", index, end, value), end
+
+    @staticmethod
+    def _skip_ws(text: str, index: int) -> int:
+        while index < len(text) and text[index] in " \t\r\n":
+            index += 1
+        return index
+
+    @staticmethod
+    def _scan_string_end(text: str, start: int) -> int:
+        index = start + 1
+        while index < len(text):
+            if text[index] == "\\":
+                index += 2
+                continue
+            if text[index] == '"':
+                return index + 1
+            index += 1
+        raise ValidationError("Unterminated JSON string")
+
+    @staticmethod
+    def _escape(value: str) -> str:
+        return value.replace("~", "~0").replace("/", "~1")
+
+    @staticmethod
+    def _has_prose(text: str) -> bool:
+        return bool(_WORD_RE.search(text))
+
+    def _protect(self, text: str) -> tuple[str, tuple[ProtectedFragment, ...]]:
+        spans: list[tuple[int, int]] = []
+        literal_ids = [int(m.group(1)) for m in _PLACEHOLDER_RE.finditer(text)]
+        spans.extend((m.start(), m.end()) for m in _PLACEHOLDER_RE.finditer(text))
+        for regex in (_FORMAT_RE, _MC_FORMAT_RE, _MESSAGE_FORMAT_RE, _LINE_BREAK_RE):
+            spans.extend((m.start(), m.end()) for m in regex.finditer(text))
+        merged: list[list[int]] = []
+        for start, end in sorted(spans):
+            if not merged or start >= merged[-1][1]:
+                merged.append([start, end])
+            elif end > merged[-1][1]:
+                merged[-1][1] = end
+        base = max(literal_ids) + 1 if literal_ids else 0
+        out: list[str] = []
+        protected: list[ProtectedFragment] = []
+        cursor = 0
+        for idx, (start, end) in enumerate(merged):
+            out.append(text[cursor:start])
+            placeholder = f"[#{base + idx}#]"
+            out.append(placeholder)
+            protected.append(ProtectedFragment(placeholder, text[start:end]))
+            cursor = end
+        out.append(text[cursor:])
+        return "".join(out), tuple(protected)
+
+    @staticmethod
+    def _restore(unit: TranslationUnit, translated: str) -> str:
+        expected = Counter(f.placeholder for f in unit.protected)
+        actual = Counter(f"[#{v}#]" for v in _PLACEHOLDER_RE.findall(translated))
+        if expected != actual:
+            raise ValidationError(f"Unit {unit.id} changed protected placeholders")
+        restored = translated
+        for fragment in unit.protected:
+            restored = restored.replace(fragment.placeholder, fragment.value)
+        return restored

--- a/mineai_formatkit/modonomicon.py
+++ b/mineai_formatkit/modonomicon.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import re
+from dataclasses import replace
+
+from .core import ProtectedFragment, TranslationPlan, ValidationError
+from .locale_safe import (
+    LocaleMergePlanner as _BaseLocaleMergePlanner,
+    MinecraftLangJsonAdapter as _BaseMinecraftLangJsonAdapter,
+)
+from .modonomicon_gson import ModonomiconGsonSpanJsonAdapter as _SpanJsonAdapter
+
+
+_BOOK_PATH_RE = re.compile(
+    r"(^|/)data/[^/]+/modonomicon/books/[^/]+/"
+    r"(?:book\.json|(?:categories|entries|commands)/.+\.json)$",
+    re.IGNORECASE,
+)
+_DESCRIPTION_ID_RE = re.compile(r"^[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+){2,}$")
+_RESOURCE_LOCATION_RE = re.compile(r"^[a-z0-9_.-]+:[a-z0-9_./-]+$", re.IGNORECASE)
+_PLACEHOLDER_RE = re.compile(r"\[#(\d+)#\]")
+
+# Real Modonomicon 1.21.1 corpus + current upstream localization syntax.
+_NESTED_TRANSLATION_RE = re.compile(r"<t>[^<>\r\n]+(?:</t>|<t>)")
+_COLOR_TOKEN_RE = re.compile(r"\[#\]\([^()\r\n]*\)")
+_LINK_DEST_RE = re.compile(
+    r"(?<=\])\((?:entry|category|item|command|page)://[^()\r\n]+\)",
+    re.IGNORECASE,
+)
+_STAR_RUN_RE = re.compile(r"(?<!\\)\*{1,3}")
+_UNDERLINE_RE = re.compile(r"(?<!\\)\+\+")
+_STRIKE_RE = re.compile(r"(?<!\\)~~")
+
+_TOP_LEVEL_TEXT_KEYS = frozenset(
+    {"name", "description", "tooltip", "success_message", "failure_message"}
+)
+_PAGE_TEXT_KEYS = frozenset(
+    {"text", "title", "title1", "title2", "multiblock_name"}
+)
+
+
+def _merge_spans(spans: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    merged: list[list[int]] = []
+    for start, end in sorted(spans):
+        if start >= end:
+            continue
+        if not merged or start >= merged[-1][1]:
+            merged.append([start, end])
+        elif end > merged[-1][1]:
+            merged[-1][1] = end
+    return [(start, end) for start, end in merged]
+
+
+def modonomicon_markup_spans(text: str) -> list[tuple[int, int]]:
+    """Return exact source spans that are structural Modonomicon markup."""
+
+    spans: list[tuple[int, int]] = []
+    for regex in (
+        _NESTED_TRANSLATION_RE,
+        _COLOR_TOKEN_RE,
+        _LINK_DEST_RE,
+        _STAR_RUN_RE,
+        _UNDERLINE_RE,
+        _STRIKE_RE,
+    ):
+        spans.extend((match.start(), match.end()) for match in regex.finditer(text))
+    return _merge_spans(spans)
+
+
+def protect_modonomicon_markup(
+    text: str,
+    protected: tuple[ProtectedFragment, ...] = (),
+) -> tuple[str, tuple[ProtectedFragment, ...]]:
+    """Layer Modonomicon markup protection after an existing token layer."""
+
+    spans = []
+    for start, end in modonomicon_markup_spans(text):
+        if _PLACEHOLDER_RE.search(text[start:end]):
+            continue
+        spans.append((start, end))
+    spans = _merge_spans(spans)
+    if not spans:
+        return text, protected
+
+    placeholder_ids = [int(match.group(1)) for match in _PLACEHOLDER_RE.finditer(text)]
+    next_id = max(placeholder_ids) + 1 if placeholder_ids else 0
+    out: list[str] = []
+    extra: list[ProtectedFragment] = []
+    cursor = 0
+    for offset, (start, end) in enumerate(spans):
+        out.append(text[cursor:start])
+        placeholder = f"[#{next_id + offset}#]"
+        out.append(placeholder)
+        extra.append(ProtectedFragment(placeholder, text[start:end]))
+        cursor = end
+    out.append(text[cursor:])
+    masked = "".join(out)
+    fragments = protected + tuple(extra)
+    ordered = tuple(
+        sorted(fragments, key=lambda fragment: masked.index(fragment.placeholder))
+    )
+    return masked, ordered
+
+
+def modonomicon_markup_fingerprint(text: str) -> tuple[str, ...]:
+    spans = modonomicon_markup_spans(text)
+    return tuple(text[start:end] for start, end in spans)
+
+
+def _is_description_id(value: str) -> bool:
+    return bool(_DESCRIPTION_ID_RE.fullmatch(value))
+
+
+def _is_resource_location(value: str) -> bool:
+    return bool(_RESOURCE_LOCATION_RE.fullmatch(value))
+
+
+def _is_modonomicon_lang_key(value: str) -> bool:
+    return value.startswith("book.")
+
+
+class ModonomiconBookJsonAdapter(_SpanJsonAdapter):
+    """Span-preserving adapter for legacy inline Modonomicon book prose."""
+
+    name = "modonomicon-book-json"
+
+    def matches(self, path: str) -> bool:
+        slash = "/" + path.replace("\\", "/").lstrip("/")
+        return bool(_BOOK_PATH_RE.search(slash))
+
+    def target_path(self, path: str, target_code: str) -> str:
+        raise ValueError(
+            "Modonomicon book JSON has no locale-specific target path; modern books use lang JSON"
+        )
+
+    def _collect(self, root, path: str, out: list) -> None:
+        if root.kind != "object":
+            raise ValidationError("Modonomicon book document must be a JSON object")
+
+        members = {member.key: member.value for member in root.members}
+        # Preserve physical source order. Stable unit order matters to external
+        # translators, XLIFF and future translation-memory keys.
+        for member in root.members:
+            if member.key not in _TOP_LEVEL_TEXT_KEYS or member.value.kind != "string":
+                continue
+            value = member.value.value
+            assert isinstance(value, str)
+            if self._is_inline_prose(value):
+                out.append((f"/{self._escape(member.key)}", member.value, value))
+
+        pages = members.get("pages")
+        if pages is not None:
+            if pages.kind != "array":
+                raise ValidationError("Modonomicon 'pages' must be an array")
+            for index, page in enumerate(pages.items):
+                if page.kind != "object":
+                    raise ValidationError("Modonomicon page must be an object")
+                for member in page.members:
+                    if member.value.kind != "string":
+                        continue
+                    key = member.key
+                    if key not in _PAGE_TEXT_KEYS and not key.endswith((".text", ".title")):
+                        continue
+                    value = member.value.value
+                    assert isinstance(value, str)
+                    if self._is_inline_prose(value):
+                        out.append(
+                            (
+                                f"/pages/{index}/{self._escape(key)}",
+                                member.value,
+                                value,
+                            )
+                        )
+
+    @staticmethod
+    def _is_inline_prose(value: str) -> bool:
+        if not value or _is_description_id(value) or _is_resource_location(value):
+            return False
+        return _SpanJsonAdapter._has_prose(value)
+
+    def _protect(self, text: str) -> tuple[str, tuple[ProtectedFragment, ...]]:
+        masked, protected = super()._protect(text)
+        return protect_modonomicon_markup(masked, protected)
+
+    def validate(self, source_text: str, output_text: str) -> None:
+        super().validate(source_text, output_text)
+        before = self._markup_by_locator(source_text)
+        after = self._markup_by_locator(output_text)
+        if before != after:
+            raise ValidationError("Modonomicon inline markup changed during reconstruction")
+
+    def _markup_by_locator(self, text: str) -> tuple[tuple[str, tuple[str, ...]], ...]:
+        root = self._parse(text)
+        targets: list[tuple[str, object, str]] = []
+        self._collect(root, "", targets)
+        return tuple(
+            (locator, modonomicon_markup_fingerprint(value))
+            for locator, _node, value in targets
+        )
+
+
+class ModonomiconAwareMinecraftLangJsonAdapter(_BaseMinecraftLangJsonAdapter):
+    """Minecraft lang adapter hardened only for proven Modonomicon book keys."""
+
+    name = "minecraft-lang-json"
+
+    def prepare(self, path: str, source_text: str) -> TranslationPlan:
+        plan = super().prepare(path, source_text)
+        units = []
+        for unit in plan.units:
+            if _is_modonomicon_lang_key(unit.context):
+                masked, protected = protect_modonomicon_markup(unit.text, unit.protected)
+                unit = replace(unit, text=masked, protected=protected)
+            units.append(unit)
+        return replace(plan, units=tuple(units))
+
+    def validate(self, source_text: str, output_text: str) -> None:
+        super().validate(source_text, output_text)
+        before = self._markup_by_key(source_text)
+        after = self._markup_by_key(output_text)
+        if before != after:
+            raise ValidationError("Modonomicon lang markup changed during reconstruction")
+
+    def _markup_by_key(self, text: str) -> tuple[tuple[str, tuple[str, ...]], ...]:
+        entries = self._parse_entries(text)
+        out = []
+        for entry in entries:
+            if not (
+                entry.is_string
+                and isinstance(entry.value, str)
+                and _is_modonomicon_lang_key(entry.key)
+            ):
+                continue
+            fingerprint = modonomicon_markup_fingerprint(entry.value)
+            if fingerprint:
+                out.append((entry.key, fingerprint))
+        return tuple(out)
+
+
+class ModonomiconAwareLocaleMergePlanner(_BaseLocaleMergePlanner):
+    """Public locale merge planner using the Modonomicon-aware lang adapter."""
+
+    def __init__(self, adapter: ModonomiconAwareMinecraftLangJsonAdapter | None = None) -> None:
+        super().__init__(adapter or ModonomiconAwareMinecraftLangJsonAdapter())

--- a/mineai_formatkit/modonomicon_gson.py
+++ b/mineai_formatkit/modonomicon_gson.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+import re
+
+from .core import ProtectedFragment, ValidationError
+from .patchouli_base import PatchouliBookJsonAdapter, _Node
+
+
+_PLACEHOLDER_RE = re.compile(r"\[#(\d+)#\]")
+
+
+class ModonomiconGsonSpanJsonAdapter(PatchouliBookJsonAdapter):
+    """Patchouli-style span parser with the narrow Gson leniency Modonomicon uses.
+
+    Modonomicon 1.21.1 loads book data through Minecraft's
+    ``SimpleJsonResourceReloadListener`` with a normal Gson instance. Legacy
+    Gson accepts raw LF/CR/TAB characters inside quoted values. Some real
+    Modonomicon books rely on that behavior even though strict RFC JSON parsers
+    reject the same bytes.
+
+    Keep the compatibility surface deliberately small: object keys, numbers,
+    arrays/objects and all other syntax still use the strict span parser. Only
+    quoted *values* may contain the three whitespace controls observed in the
+    real corpus. Identity reconstruction preserves the original source bytes;
+    changed strings are emitted by the parent adapter through ``json.dumps``
+    and therefore become strict JSON.
+    """
+
+    def _parse_value(self, text: str, index: int) -> tuple[_Node, int]:
+        index = self._skip_ws(text, index)
+        if index < len(text) and text[index] == '"':
+            end = self._scan_gson_string_end(text, index)
+            token = text[index:end]
+            try:
+                value = json.loads(token)
+            except json.JSONDecodeError:
+                value = self._decode_gson_lenient_string(token)
+            return _Node("string", index, end, value), end
+        return super()._parse_value(text, index)
+
+    @staticmethod
+    def _scan_gson_string_end(text: str, start: int) -> int:
+        index = start + 1
+        while index < len(text):
+            char = text[index]
+            if char == "\\":
+                if index + 1 >= len(text):
+                    raise ValidationError("Unterminated Modonomicon JSON escape")
+                index += 2
+                continue
+            if char == '"':
+                return index + 1
+            if ord(char) < 0x20 and char not in "\t\r\n":
+                raise ValidationError(
+                    "Unsupported control character in Gson-lenient Modonomicon string"
+                )
+            index += 1
+        raise ValidationError("Unterminated Modonomicon JSON string")
+
+    @classmethod
+    def _decode_gson_lenient_string(cls, token: str) -> str:
+        if len(token) < 2 or token[0] != '"' or token[-1] != '"':
+            raise ValidationError("Invalid Modonomicon JSON string token")
+        inner = token[1:-1]
+        out: list[str] = []
+        index = 0
+        escapes = {
+            '"': '"',
+            "'": "'",
+            "\\": "\\",
+            "/": "/",
+            "b": "\b",
+            "f": "\f",
+            "n": "\n",
+            "r": "\r",
+            "t": "\t",
+        }
+        while index < len(inner):
+            char = inner[index]
+            if char != "\\":
+                if ord(char) < 0x20 and char not in "\t\r\n":
+                    raise ValidationError(
+                        "Unsupported control character in Gson-lenient Modonomicon string"
+                    )
+                out.append(char)
+                index += 1
+                continue
+
+            if index + 1 >= len(inner):
+                raise ValidationError("Unterminated Modonomicon JSON escape")
+            escaped = inner[index + 1]
+            if escaped == "u":
+                if index + 6 > len(inner):
+                    raise ValidationError("Truncated Unicode escape in Modonomicon JSON string")
+                raw = inner[index + 2 : index + 6]
+                try:
+                    code = int(raw, 16)
+                except ValueError as exc:
+                    raise ValidationError(
+                        "Invalid Unicode escape in Modonomicon JSON string"
+                    ) from exc
+                index += 6
+                if (
+                    0xD800 <= code <= 0xDBFF
+                    and inner[index : index + 2] == "\\u"
+                    and index + 6 <= len(inner)
+                ):
+                    try:
+                        low = int(inner[index + 2 : index + 6], 16)
+                    except ValueError:
+                        low = -1
+                    if 0xDC00 <= low <= 0xDFFF:
+                        out.append(chr(0x10000 + ((code - 0xD800) << 10) + low - 0xDC00))
+                        index += 6
+                        continue
+                out.append(chr(code))
+                continue
+
+            # Gson's legacy reader accepts escaped raw line breaks and a few
+            # otherwise non-standard escapes. Preserve the escaped character
+            # exactly as the runtime presents it to book parsing.
+            out.append(escapes.get(escaped, escaped))
+            index += 2
+        return "".join(out)
+
+    def _protect(self, text: str) -> tuple[str, tuple[ProtectedFragment, ...]]:
+        masked, protected = super()._protect(text)
+        # Parent protection already masks CR/LF. Raw TABs are source-owned
+        # formatting in the corpus and must not be editable by a translator.
+        tab_positions = [index for index, char in enumerate(masked) if char == "\t"]
+        if not tab_positions:
+            return masked, protected
+
+        existing = [int(match.group(1)) for match in _PLACEHOLDER_RE.finditer(masked)]
+        next_id = max(existing) + 1 if existing else 0
+        out: list[str] = []
+        extra: list[ProtectedFragment] = []
+        cursor = 0
+        for offset, start in enumerate(tab_positions):
+            out.append(masked[cursor:start])
+            placeholder = f"[#{next_id + offset}#]"
+            out.append(placeholder)
+            extra.append(ProtectedFragment(placeholder, "\t"))
+            cursor = start + 1
+        out.append(masked[cursor:])
+        final_masked = "".join(out)
+        fragments = protected + tuple(extra)
+        ordered = tuple(
+            sorted(fragments, key=lambda fragment: final_masked.index(fragment.placeholder))
+        )
+        return final_masked, ordered

--- a/mineai_formatkit/patchouli.py
+++ b/mineai_formatkit/patchouli.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Mapping
+
+from . import patchouli_base as _base
+from .core import ProtectedFragment, TranslationPlan, TranslationUnit, ValidationError
+from .patchouli_base import PatchouliFingerprint
+
+
+_PLACEHOLDER_RE = re.compile(r"\[#(\d+)#\]")
+
+
+@dataclass(frozen=True)
+class _SemanticAnchor:
+    placeholder: str
+    child_id: str
+    prefix: str
+    suffix: str
+
+
+class PatchouliBookJsonAdapter(_base.PatchouliBookJsonAdapter):
+    """Patchouli adapter with source-owned semantic style/link wrappers.
+
+    Explicit balanced wrappers become nested payloads: the outer sentence owns
+    one anchor placeholder while the visible body is translated as a child.
+    Ambiguous directives keep the base adapter's protected-token behavior.
+    """
+
+    def prepare(self, path: str, source_text: str) -> TranslationPlan:
+        root = self._parse(source_text)
+        targets = []
+        self._collect(root, "", targets)
+        units: list[TranslationUnit] = []
+        originals: dict[str, str] = {}
+        semantic_payloads: dict[str, str] = {}
+        field_originals: dict[str, str] = {}
+        semantic_anchors: dict[str, tuple[_SemanticAnchor, ...]] = {}
+
+        for locator, node, value in targets:
+            if not self._has_prose(value):
+                continue
+            field_id = f"json:{locator}"
+            spans = self._semantic_anchor_spans(value)
+            reserved: list[str] = []
+            anchors: list[_SemanticAnchor] = []
+            outer_parts: list[str] = []
+            cursor = 0
+            literal_ids = [int(match.group(1)) for match in _PLACEHOLDER_RE.finditer(value)]
+            next_marker = max(literal_ids) + 1 if literal_ids else 0
+
+            for anchor_index, (start, end, prefix, body, suffix) in enumerate(spans):
+                outer_parts.append(value[cursor:start])
+                placeholder = f"[#{next_marker}#]"
+                next_marker += 1
+                outer_parts.append(placeholder)
+                reserved.append(placeholder)
+                child_id = f"{field_id}#anchor:{anchor_index}"
+                child_text, child_protected = self._protect(body)
+                units.append(
+                    TranslationUnit(
+                        id=child_id,
+                        text=child_text,
+                        start=node.start,
+                        end=node.end,
+                        kind="patchouli-semantic-child",
+                        context=f"{path}:{locator}:anchor:{anchor_index}",
+                        protected=child_protected,
+                    )
+                )
+                originals[child_id] = body
+                semantic_payloads[child_id] = child_text
+                anchors.append(_SemanticAnchor(placeholder, child_id, prefix, suffix))
+                cursor = end
+
+            outer_parts.append(value[cursor:])
+            outer_source = "".join(outer_parts)
+            masked, protected = self._protect_reserved(outer_source, tuple(reserved))
+            units.append(
+                TranslationUnit(
+                    id=field_id,
+                    text=masked,
+                    start=node.start,
+                    end=node.end,
+                    kind="patchouli-text",
+                    context=f"{path}:{locator}",
+                    protected=protected,
+                )
+            )
+            originals[field_id] = value
+            semantic_payloads[field_id] = masked
+            field_originals[field_id] = value
+            if anchors:
+                semantic_anchors[field_id] = tuple(anchors)
+
+        units.sort(key=lambda unit: (unit.start, 0 if unit.kind == "patchouli-text" else 1, unit.id))
+        return TranslationPlan(
+            path=path,
+            source_text=source_text,
+            units=tuple(units),
+            metadata={
+                "fingerprint": self.fingerprint(source_text),
+                "originals": originals,
+                "semantic_payloads": semantic_payloads,
+                "field_originals": field_originals,
+                "semantic_anchors": semantic_anchors,
+            },
+        )
+
+    def apply(self, plan: TranslationPlan, translations: Mapping[str, str]) -> str:
+        known = {unit.id for unit in plan.units}
+        unknown = set(translations) - known
+        if unknown:
+            raise ValidationError(f"Unknown translation unit ids: {sorted(unknown)!r}")
+        field_originals = plan.metadata.get("field_originals")
+        anchors_meta = plan.metadata.get("semantic_anchors", {})
+        if not isinstance(field_originals, dict) or not isinstance(anchors_meta, dict):
+            raise ValidationError("Patchouli plan is missing semantic field metadata")
+        by_id = {unit.id: unit for unit in plan.units}
+        replacements: list[tuple[int, int, str]] = []
+
+        for unit in plan.units:
+            if unit.kind != "patchouli-text":
+                continue
+            anchors = anchors_meta.get(unit.id, ())
+            related = {unit.id}
+            for anchor in anchors:
+                if not isinstance(anchor, _SemanticAnchor):
+                    raise ValidationError(f"Invalid Patchouli semantic anchor metadata for {unit.id}")
+                related.add(anchor.child_id)
+            if not any(unit_id in translations for unit_id in related):
+                continue
+
+            outer = self._restore(unit, translations.get(unit.id, unit.text))
+            for anchor in anchors:
+                child = by_id.get(anchor.child_id)
+                if child is None:
+                    raise ValidationError(f"Missing Patchouli semantic child {anchor.child_id}")
+                child_value = self._restore(child, translations.get(child.id, child.text))
+                if outer.count(anchor.placeholder) != 1:
+                    raise ValidationError(f"Unit {unit.id} changed semantic anchor placement")
+                outer = outer.replace(
+                    anchor.placeholder,
+                    anchor.prefix + child_value + anchor.suffix,
+                    1,
+                )
+
+            original = field_originals.get(unit.id)
+            if not isinstance(original, str):
+                raise ValidationError(f"Missing original Patchouli field for {unit.id}")
+            if self._line_breaks(outer) != self._line_breaks(original):
+                raise ValidationError(f"Patchouli unit {unit.id} changed line-break structure")
+            token = (
+                plan.source_text[unit.start:unit.end]
+                if outer == original
+                else __import__("json").dumps(outer, ensure_ascii=False)
+            )
+            replacements.append((unit.start, unit.end, token))
+
+        output = plan.source_text
+        for start, end, token in sorted(replacements, reverse=True):
+            output = output[:start] + token + output[end:]
+        self.validate(plan.source_text, output)
+        return output
+
+    def _protect_reserved(
+        self,
+        text: str,
+        reserved_placeholders: tuple[str, ...],
+    ) -> tuple[str, tuple[ProtectedFragment, ...]]:
+        reserved = set(reserved_placeholders)
+        spans: list[tuple[int, int]] = []
+        placeholder_matches = list(_PLACEHOLDER_RE.finditer(text))
+        literal_ids = [int(match.group(1)) for match in placeholder_matches]
+        spans.extend(
+            (match.start(), match.end())
+            for match in placeholder_matches
+            if match.group(0) not in reserved
+        )
+        backtick_dollar_re = getattr(_base, "_BACKTICK_DOLLAR_RE", None)
+        if backtick_dollar_re is None:
+            backtick_dollar_re = _base._CODE_DOLLAR_RE
+        for regex in (
+            _base._PATCHOULI_TOKEN_RE,
+            backtick_dollar_re,
+            _base._FORMAT_RE,
+            _base._MC_FORMAT_RE,
+            _base._MESSAGE_FORMAT_RE,
+            _base._LINE_BREAK_RE,
+        ):
+            spans.extend((match.start(), match.end()) for match in regex.finditer(text))
+        merged: list[list[int]] = []
+        for start, end in sorted(spans):
+            if start >= end:
+                continue
+            if not merged or start >= merged[-1][1]:
+                merged.append([start, end])
+            elif end > merged[-1][1]:
+                merged[-1][1] = end
+        base = max(literal_ids) + 1 if literal_ids else 0
+        out: list[str] = []
+        protected: list[ProtectedFragment] = []
+        cursor = 0
+        for offset, (start, end) in enumerate(merged):
+            out.append(text[cursor:start])
+            placeholder = f"[#{base + offset}#]"
+            while placeholder in reserved:
+                base += 1
+                placeholder = f"[#{base + offset}#]"
+            out.append(placeholder)
+            protected.append(ProtectedFragment(placeholder, text[start:end]))
+            cursor = end
+        out.append(text[cursor:])
+        return "".join(out), tuple(protected)
+
+    @staticmethod
+    def _restore(unit: TranslationUnit, translated: str) -> str:
+        expected = [match.group(0) for match in _PLACEHOLDER_RE.finditer(unit.text)]
+        actual = [match.group(0) for match in _PLACEHOLDER_RE.finditer(translated)]
+        if expected != actual:
+            raise ValidationError(f"Unit {unit.id} changed protected placeholder order")
+        restored = translated
+        for fragment in unit.protected:
+            restored = restored.replace(fragment.placeholder, fragment.value)
+        return restored
+
+    def _semantic_anchor_spans(
+        self,
+        text: str,
+    ) -> list[tuple[int, int, str, str, str]]:
+        tokens = list(_base._PATCHOULI_TOKEN_RE.finditer(text))
+        out: list[tuple[int, int, str, str, str]] = []
+        index = 0
+        while index < len(tokens):
+            token = tokens[index]
+            if not self._is_anchor_opener(token.group(0)):
+                index += 1
+                continue
+            opener_start = token.start()
+            opener_end = token.end()
+            openers = [token.group(0)]
+            cursor = index + 1
+            while (
+                cursor < len(tokens)
+                and tokens[cursor].start() == opener_end
+                and self._is_anchor_opener(tokens[cursor].group(0))
+            ):
+                openers.append(tokens[cursor].group(0))
+                opener_end = tokens[cursor].end()
+                cursor += 1
+            if cursor >= len(tokens):
+                index += 1
+                continue
+            closer = tokens[cursor]
+            body = text[opener_end:closer.start()]
+            if (
+                not body
+                or body != body.strip()
+                or "\n" in body
+                or "\r" in body
+                or not self._has_prose(body)
+                or not self._is_anchor_closer(closer.group(0))
+            ):
+                index += 1
+                continue
+            closers = [closer.group(0)]
+            closer_end = closer.end()
+            cursor += 1
+            while (
+                cursor < len(tokens)
+                and tokens[cursor].start() == closer_end
+                and self._is_anchor_closer(tokens[cursor].group(0))
+            ):
+                closers.append(tokens[cursor].group(0))
+                closer_end = tokens[cursor].end()
+                cursor += 1
+            if not self._anchor_closure_is_proven(openers, closers):
+                index += 1
+                continue
+            out.append(
+                (
+                    opener_start,
+                    closer_end,
+                    text[opener_start:opener_end],
+                    body,
+                    text[closer.start():closer_end],
+                )
+            )
+            index = cursor
+        return out
+
+    @staticmethod
+    def _is_anchor_opener(token: str) -> bool:
+        if token == "/$" or not token.startswith("$(") or not token.endswith(")"):
+            return False
+        body = token[2:-1]
+        if not body or body.startswith("/"):
+            return False
+        lower = body.lower()
+        if lower in {"br", "br1", "br2", "p", "li", "np"}:
+            return False
+        if lower.startswith("k:"):
+            return False
+        return True
+
+    @staticmethod
+    def _is_anchor_closer(token: str) -> bool:
+        return token in {"$()", "/$", "$(/l)"}
+
+    @staticmethod
+    def _anchor_closure_is_proven(openers: list[str], closers: list[str]) -> bool:
+        link_open = any(token.lower().startswith("$(l:") for token in openers)
+        style_open = any(not token.lower().startswith("$(l:") for token in openers)
+        if link_open and "$(/l)" in closers:
+            return not style_open or any(token in {"$()", "/$"} for token in closers)
+        if len(openers) == 1 and any(token in {"$()", "/$"} for token in closers):
+            return True
+        if not link_open and any(token in {"$()", "/$"} for token in closers):
+            return True
+        return False
+
+
+__all__ = ["PatchouliBookJsonAdapter", "PatchouliFingerprint"]

--- a/mineai_formatkit/patchouli_base.py
+++ b/mineai_formatkit/patchouli_base.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Mapping
+
+from .core import ProtectedFragment, TranslationPlan, TranslationUnit, ValidationError
+
+
+_SOURCE_PATH_RE = re.compile(
+    r"(^|/)patchouli_books/[^/]+/en_us/(?:categories|entries)/.+\.json$",
+    re.IGNORECASE,
+)
+_PLACEHOLDER_RE = re.compile(r"\[#(\d+)#\]")
+_PATCHOULI_TOKEN_RE = re.compile(r"\$\([^)]*\)|/\$")
+_FORMAT_RE = re.compile(
+    r"%(?!\s)(?:(?:\d+\$)?[-+#0 ,(<]*\d*(?:\.\d+)?"
+    r"(?:[bBhHsScCdoxXeEfgGaA]|[tT][HIklMSLNpzZsQBbhAaCYyjmdeRTrDFc])|[%n])"
+)
+_MC_FORMAT_RE = re.compile(r"§[0-9A-FK-ORa-fk-or]")
+_MESSAGE_FORMAT_RE = re.compile(r"\{\d+(?:,[^{}]+)?\}")
+_LINE_BREAK_RE = re.compile(r"\r\n|\r|\n")
+_BACKTICK_DOLLAR_RE = re.compile(r"`\$`")
+_WORD_RE = re.compile(r"[A-Za-zА-Яа-яЁё]{2,}")
+
+_TRANSLATABLE_TOP_LEVEL = {"name", "description"}
+_TRANSLATABLE_PAGE_KEYS = {"text", "title", "heading", "name"}
+
+
+@dataclass(frozen=True)
+class _Member:
+    key: str
+    value: "_Node"
+
+
+@dataclass(frozen=True)
+class _Node:
+    kind: str
+    start: int
+    end: int
+    value: object
+    members: tuple[_Member, ...] = ()
+    items: tuple["_Node", ...] = ()
+
+
+@dataclass(frozen=True)
+class PatchouliFingerprint:
+    locators: tuple[str, ...]
+    skeleton: str
+
+
+class PatchouliBookJsonAdapter:
+    """Span-preserving adapter for localized Patchouli category/entry JSON.
+
+    The adapter is intentionally context-aware. It translates only proven
+    player-visible fields while resource locations, page types, recipes,
+    icons, advancements, anchors and custom-page machine data stay immutable.
+    Patchouli formatting/link directives are protected as exact placeholders.
+    """
+
+    name = "patchouli-book-json"
+
+    def matches(self, path: str) -> bool:
+        slash = "/" + path.replace("\\", "/").lstrip("/")
+        return bool(_SOURCE_PATH_RE.search(slash))
+
+    def target_path(self, path: str, target_code: str) -> str:
+        slash = path.replace("\\", "/")
+        normalized = "/" + slash.lstrip("/")
+        match = _SOURCE_PATH_RE.search(normalized)
+        if not match:
+            raise ValueError(f"Unsupported Patchouli source path: {path}")
+        marker = "/en_us/"
+        lower = slash.lower()
+        index = lower.find(marker)
+        if index < 0:
+            raise ValueError(f"Unsupported Patchouli source path: {path}")
+        return slash[:index] + f"/{target_code}/" + slash[index + len(marker):]
+
+    def prepare(self, path: str, source_text: str) -> TranslationPlan:
+        root = self._parse(source_text)
+        targets: list[tuple[str, _Node, str]] = []
+        self._collect(root, "", targets)
+        units: list[TranslationUnit] = []
+        originals: dict[str, str] = {}
+        for locator, node, value in targets:
+            if not self._has_prose(value):
+                continue
+            masked, protected = self._protect(value)
+            unit_id = f"json:{locator}"
+            units.append(
+                TranslationUnit(
+                    id=unit_id,
+                    text=masked,
+                    start=node.start,
+                    end=node.end,
+                    kind="patchouli-text",
+                    context=f"{path}:{locator}",
+                    protected=protected,
+                )
+            )
+            originals[unit_id] = value
+        return TranslationPlan(
+            path=path,
+            source_text=source_text,
+            units=tuple(units),
+            metadata={
+                "fingerprint": self.fingerprint(source_text),
+                "originals": originals,
+            },
+        )
+
+    def apply(self, plan: TranslationPlan, translations: Mapping[str, str]) -> str:
+        known = {unit.id for unit in plan.units}
+        unknown = set(translations) - known
+        if unknown:
+            raise ValidationError(f"Unknown translation unit ids: {sorted(unknown)!r}")
+        originals = plan.metadata.get("originals")
+        if not isinstance(originals, dict):
+            raise ValidationError("Patchouli plan is missing original values")
+
+        replacements: list[tuple[int, int, str]] = []
+        for unit in plan.units:
+            if unit.id not in translations:
+                continue
+            restored = self._restore(unit, translations[unit.id])
+            original = originals.get(unit.id)
+            if not isinstance(original, str):
+                raise ValidationError(f"Missing original Patchouli value for {unit.id}")
+            if self._line_breaks(restored) != self._line_breaks(original):
+                raise ValidationError(f"Patchouli unit {unit.id} changed line-break structure")
+            token = (
+                plan.source_text[unit.start:unit.end]
+                if restored == original
+                else json.dumps(restored, ensure_ascii=False)
+            )
+            replacements.append((unit.start, unit.end, token))
+
+        output = plan.source_text
+        for start, end, token in sorted(replacements, reverse=True):
+            output = output[:start] + token + output[end:]
+        self.validate(plan.source_text, output)
+        return output
+
+    def validate(self, source_text: str, output_text: str) -> None:
+        if self.fingerprint(source_text) != self.fingerprint(output_text):
+            raise ValidationError("Patchouli JSON structure changed during reconstruction")
+
+    def fingerprint(self, text: str) -> PatchouliFingerprint:
+        root = self._parse(text)
+        targets: list[tuple[str, _Node, str]] = []
+        self._collect(root, "", targets)
+        selected = [(loc, node) for loc, node, value in targets if self._has_prose(value)]
+        out: list[str] = []
+        cursor = 0
+        for locator, node in sorted(selected, key=lambda item: item[1].start):
+            out.append(text[cursor:node.start])
+            out.append('"<mineai-patchouli-text>"')
+            cursor = node.end
+        out.append(text[cursor:])
+        return PatchouliFingerprint(
+            locators=tuple(locator for locator, _ in selected),
+            skeleton="".join(out),
+        )
+
+    def _collect(self, root: _Node, path: str, out: list[tuple[str, _Node, str]]) -> None:
+        if root.kind != "object":
+            raise ValidationError("Patchouli document must be a JSON object")
+        members = {member.key: member.value for member in root.members}
+        for key in _TRANSLATABLE_TOP_LEVEL:
+            node = members.get(key)
+            if node is not None and node.kind == "string":
+                assert isinstance(node.value, str)
+                out.append((f"/{self._escape(key)}", node, node.value))
+
+        pages = members.get("pages")
+        if pages is None:
+            return
+        if pages.kind != "array":
+            raise ValidationError("Patchouli 'pages' must be an array")
+        for index, page in enumerate(pages.items):
+            if page.kind != "object":
+                raise ValidationError("Patchouli page must be an object")
+            for member in page.members:
+                if member.value.kind != "string":
+                    continue
+                key = member.key
+                if (
+                    key in _TRANSLATABLE_PAGE_KEYS
+                    or key.endswith(".heading")
+                    or key.endswith(".text")
+                ):
+                    assert isinstance(member.value.value, str)
+                    out.append(
+                        (
+                            f"/pages/{index}/{self._escape(key)}",
+                            member.value,
+                            member.value.value,
+                        )
+                    )
+
+    def _parse(self, text: str) -> _Node:
+        node, end = self._parse_value(text, self._skip_ws(text, 0))
+        if self._skip_ws(text, end) != len(text):
+            raise ValidationError("Trailing data after Patchouli JSON")
+        return node
+
+    def _parse_value(self, text: str, index: int) -> tuple[_Node, int]:
+        index = self._skip_ws(text, index)
+        if index >= len(text):
+            raise ValidationError("Unexpected end of Patchouli JSON")
+        if text[index] == '"':
+            end = self._scan_string_end(text, index)
+            try:
+                value = json.loads(text[index:end])
+            except json.JSONDecodeError as exc:
+                raise ValidationError("Invalid Patchouli JSON string") from exc
+            return _Node("string", index, end, value), end
+        if text[index] == "{":
+            start = index
+            index += 1
+            members: list[_Member] = []
+            seen: set[str] = set()
+            while True:
+                index = self._skip_ws(text, index)
+                if index < len(text) and text[index] == "}":
+                    return _Node("object", start, index + 1, None, tuple(members)), index + 1
+                if index >= len(text) or text[index] != '"':
+                    raise ValidationError("Patchouli JSON object key must be a string")
+                key_end = self._scan_string_end(text, index)
+                try:
+                    key = json.loads(text[index:key_end])
+                except json.JSONDecodeError as exc:
+                    raise ValidationError("Invalid Patchouli JSON key") from exc
+                if key in seen:
+                    raise ValidationError(f"Duplicate Patchouli JSON key: {key}")
+                seen.add(key)
+                index = self._skip_ws(text, key_end)
+                if index >= len(text) or text[index] != ":":
+                    raise ValidationError("Missing ':' after Patchouli JSON key")
+                value, index = self._parse_value(text, index + 1)
+                members.append(_Member(key, value))
+                index = self._skip_ws(text, index)
+                if index < len(text) and text[index] == ",":
+                    index += 1
+                    continue
+                if index < len(text) and text[index] == "}":
+                    return _Node("object", start, index + 1, None, tuple(members)), index + 1
+                raise ValidationError("Expected ',' or '}' in Patchouli JSON object")
+        if text[index] == "[":
+            start = index
+            index += 1
+            items: list[_Node] = []
+            while True:
+                index = self._skip_ws(text, index)
+                if index < len(text) and text[index] == "]":
+                    return _Node("array", start, index + 1, None, items=tuple(items)), index + 1
+                item, index = self._parse_value(text, index)
+                items.append(item)
+                index = self._skip_ws(text, index)
+                if index < len(text) and text[index] == ",":
+                    index += 1
+                    continue
+                if index < len(text) and text[index] == "]":
+                    return _Node("array", start, index + 1, None, items=tuple(items)), index + 1
+                raise ValidationError("Expected ',' or ']' in Patchouli JSON array")
+        decoder = json.JSONDecoder()
+        try:
+            value, end = decoder.raw_decode(text, index)
+        except json.JSONDecodeError as exc:
+            raise ValidationError("Invalid Patchouli JSON value") from exc
+        return _Node("scalar", index, end, value), end
+
+    @staticmethod
+    def _skip_ws(text: str, index: int) -> int:
+        while index < len(text) and text[index] in " \t\r\n":
+            index += 1
+        return index
+
+    @staticmethod
+    def _scan_string_end(text: str, start: int) -> int:
+        index = start + 1
+        while index < len(text):
+            if text[index] == "\\":
+                index += 2
+                continue
+            if text[index] == '"':
+                return index + 1
+            if ord(text[index]) < 0x20:
+                raise ValidationError("Unescaped control character in Patchouli JSON string")
+            index += 1
+        raise ValidationError("Unterminated Patchouli JSON string")
+
+    def _protect(self, text: str) -> tuple[str, tuple[ProtectedFragment, ...]]:
+        spans: list[tuple[int, int]] = []
+        literal_ids = [int(match.group(1)) for match in _PLACEHOLDER_RE.finditer(text)]
+        spans.extend((match.start(), match.end()) for match in _PLACEHOLDER_RE.finditer(text))
+        for regex in (
+            _PATCHOULI_TOKEN_RE,
+            _FORMAT_RE,
+            _MC_FORMAT_RE,
+            _MESSAGE_FORMAT_RE,
+            _LINE_BREAK_RE,
+            _BACKTICK_DOLLAR_RE,
+        ):
+            spans.extend((match.start(), match.end()) for match in regex.finditer(text))
+        merged: list[list[int]] = []
+        for start, end in sorted(spans):
+            if start >= end:
+                continue
+            if not merged or start >= merged[-1][1]:
+                merged.append([start, end])
+            elif end > merged[-1][1]:
+                merged[-1][1] = end
+        base = max(literal_ids) + 1 if literal_ids else 0
+        out: list[str] = []
+        protected: list[ProtectedFragment] = []
+        cursor = 0
+        for offset, (start, end) in enumerate(merged):
+            out.append(text[cursor:start])
+            placeholder = f"[#{base + offset}#]"
+            out.append(placeholder)
+            protected.append(ProtectedFragment(placeholder, text[start:end]))
+            cursor = end
+        out.append(text[cursor:])
+        return "".join(out), tuple(protected)
+
+    @staticmethod
+    def _restore(unit: TranslationUnit, translated: str) -> str:
+        expected = [fragment.placeholder for fragment in unit.protected]
+        actual = [f"[#{value}#]" for value in _PLACEHOLDER_RE.findall(translated)]
+        if expected != actual:
+            raise ValidationError(f"Unit {unit.id} changed protected placeholder order")
+        restored = translated
+        for fragment in unit.protected:
+            restored = restored.replace(fragment.placeholder, fragment.value)
+        return restored
+
+    @staticmethod
+    def _line_breaks(value: str) -> tuple[int, int]:
+        return value.count("\n"), value.count("\r")
+
+    @staticmethod
+    def _escape(value: str) -> str:
+        return value.replace("~", "~0").replace("/", "~1")
+
+    @staticmethod
+    def _has_prose(value: str) -> bool:
+        return bool(_WORD_RE.search(value))

--- a/mineai_formatkit/patchouli_safe.py
+++ b/mineai_formatkit/patchouli_safe.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import re
+from typing import Mapping
+
+from .core import TranslationPlan, ValidationError
+from .patchouli import PatchouliBookJsonAdapter as _BasePatchouliBookJsonAdapter
+
+
+_TEMPLATE_SOURCE_PATH_RE = re.compile(
+    r"(^|/)patchouli_books/[^/]+/en_us/templates/.+\.json$",
+    re.IGNORECASE,
+)
+_TEMPLATE_PLACEHOLDER_RE = re.compile(r"#[A-Za-z_][A-Za-z0-9_.:-]*#?")
+
+
+class PatchouliBookJsonAdapter(_BasePatchouliBookJsonAdapter):
+    """Patchouli adapter with corpus-proven locale and template safety.
+
+    Category/entry JSON exposes only proven player-visible fields. Patchouli's
+    ``link_text`` button label is exposed only when it is literal human prose;
+    dotted no-whitespace translation keys remain immutable.
+
+    Patchouli ``templates`` are a different surface: real FTB Evolution mods
+    use processor-owned variables such as ``#recipe``, ``#tier#``, ``#item1``
+    and ``#energy`` inside otherwise ordinary JSON strings. Until a template
+    grammar proves which literals are safely localizable, templates are owned
+    structurally but expose zero translation units and are reconstructed
+    byte-for-byte from the canonical English source.
+    """
+
+    name = "patchouli-book-json"
+
+    def matches(self, path: str) -> bool:
+        return super().matches(path) or self._is_template_path(path)
+
+    def target_path(self, path: str, target_code: str) -> str:
+        slash = path.replace("\\", "/")
+        if self._is_template_path(slash):
+            return re.sub(
+                r"/en_us/templates/",
+                f"/{target_code}/templates/",
+                slash,
+                count=1,
+                flags=re.IGNORECASE,
+            )
+        return super().target_path(path, target_code)
+
+    def prepare(self, path: str, source_text: str) -> TranslationPlan:
+        if not self._is_template_path(path):
+            return super().prepare(path, source_text)
+
+        root = self._parse(source_text)
+        if root.kind != "object":
+            raise ValidationError("Patchouli template document must be a JSON object")
+        placeholders = tuple(
+            match.group(0) for match in _TEMPLATE_PLACEHOLDER_RE.finditer(source_text)
+        )
+        return TranslationPlan(
+            path=path,
+            source_text=source_text,
+            units=(),
+            metadata={
+                "patchouli_template_immutable": True,
+                "template_placeholders": placeholders,
+            },
+        )
+
+    def apply(self, plan: TranslationPlan, translations: Mapping[str, str]) -> str:
+        if plan.metadata.get("patchouli_template_immutable") is not True:
+            return super().apply(plan, translations)
+        if translations:
+            raise ValidationError("Patchouli templates do not accept translation units")
+        root = self._parse(plan.source_text)
+        if root.kind != "object":
+            raise ValidationError("Patchouli template document must be a JSON object")
+        return plan.source_text
+
+    def _collect(self, root, path: str, out) -> None:
+        super()._collect(root, path, out)
+
+        members = {member.key: member.value for member in root.members}
+        pages = members.get("pages")
+        if pages is None:
+            return
+        for index, page in enumerate(pages.items):
+            for member in page.members:
+                if member.key != "link_text" or member.value.kind != "string":
+                    continue
+                value = member.value.value
+                assert isinstance(value, str)
+                if self._is_literal_link_text(value):
+                    out.append(
+                        (
+                            f"/pages/{index}/{self._escape('link_text')}",
+                            member.value,
+                            value,
+                        )
+                    )
+
+    @classmethod
+    def _is_literal_link_text(cls, value: str) -> bool:
+        return any(char.isspace() for char in value) and cls._has_prose(value)
+
+    @staticmethod
+    def _is_template_path(path: str) -> bool:
+        slash = "/" + path.replace("\\", "/").lstrip("/")
+        return bool(_TEMPLATE_SOURCE_PATH_RE.search(slash))

--- a/mineai_formatkit/runtime_locale.py
+++ b/mineai_formatkit/runtime_locale.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import re
+from collections import Counter
+
+from .core import ProtectedFragment
+from .locale_merge import LocaleMergePlanner as _BaseLocaleMergePlanner
+from .minecraft_lang import (
+    MinecraftLangJsonAdapter as _BaseMinecraftLangJsonAdapter,
+    _FORMAT_RE,
+    _LINE_BREAK_RE,
+    _MESSAGE_FORMAT_RE,
+    _MINECRAFT_FORMAT_RE,
+    _PLACEHOLDER_RE,
+)
+
+
+_DOUBLE_DOLLAR_VAR_RE = re.compile(r"\$\$[A-Za-z_][A-Za-z0-9_]*")
+_KEYBIND_TOKEN_RE = re.compile(r"%kkey\.[A-Za-z0-9_.:-]+%")
+_URL_RE = re.compile(
+    r"https?://[A-Za-z0-9][^\s\"'<>()[\]{},;!?]*",
+    re.IGNORECASE,
+)
+_SLASH_COMMAND_CORE_RE = re.compile(
+    r"/[A-Za-z][A-Za-z0-9_:-]*(?=$|[\s,.;:!?)}\]>\"'])"
+)
+_MC_FORMAT_CODE_RE = re.compile(r"§[0-9A-FK-ORa-fk-or]")
+
+
+def _slash_command_spans(text: str) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    for match in _SLASH_COMMAND_CORE_RE.finditer(text):
+        start = match.start()
+        if start == 0:
+            spans.append((start, match.end()))
+            continue
+        previous = text[start - 1]
+        # Commands are token-like. A slash immediately following any Unicode
+        # alphanumeric character is part of prose/path-like text, not a command
+        # boundary (real FancyMenu RU: ``стрелками/Tab`` and
+        # ``Документация/Wiki``). Keep the historical resource/path guards too.
+        if not (previous.isalnum() or previous in "_./:-"):
+            spans.append((start, match.end()))
+            continue
+        # A real command may immediately follow a Minecraft formatting code,
+        # e.g. ``§a/create``. The formatting code itself remains protected too.
+        if start >= 2 and text[start - 2] == "§" and _MC_FORMAT_CODE_RE.fullmatch(text[start - 2 : start]):
+            spans.append((start, match.end()))
+    return spans
+
+
+def _extra_runtime_spans(text: str, *, include_urls: bool) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    for regex in (_DOUBLE_DOLLAR_VAR_RE, _KEYBIND_TOKEN_RE):
+        spans.extend((match.start(), match.end()) for match in regex.finditer(text))
+    spans.extend(_slash_command_spans(text))
+    if include_urls:
+        spans.extend((match.start(), match.end()) for match in _URL_RE.finditer(text))
+    return spans
+
+
+def _critical_runtime_tokens(text: str) -> list[str]:
+    tokens = [match.group(0) for match in _DOUBLE_DOLLAR_VAR_RE.finditer(text)]
+    tokens.extend(match.group(0) for match in _KEYBIND_TOKEN_RE.finditer(text))
+    tokens.extend(text[start:end] for start, end in _slash_command_spans(text))
+    return tokens
+
+
+class MinecraftLangJsonAdapter(_BaseMinecraftLangJsonAdapter):
+    """Minecraft locale adapter with corpus-proven runtime-token protection.
+
+    This remains the public ``minecraft-lang-json`` adapter. The reviewed base
+    parser/reconstructor is unchanged; only the protection contract is extended
+    for syntax proven by real mods: FancyMenu ``$$variables``, Hexerei
+    ``%kkey...%`` keybinds, URLs, and boundary-safe slash commands.
+    """
+
+    name = "minecraft-lang-json"
+
+    def _protect(self, text: str) -> tuple[str, tuple[ProtectedFragment, ...]]:
+        spans: list[tuple[int, int]] = []
+        literal_ids = [int(match.group(1)) for match in _PLACEHOLDER_RE.finditer(text)]
+        spans.extend((match.start(), match.end()) for match in _PLACEHOLDER_RE.finditer(text))
+        for regex in (
+            _FORMAT_RE,
+            _MINECRAFT_FORMAT_RE,
+            _MESSAGE_FORMAT_RE,
+            _LINE_BREAK_RE,
+        ):
+            spans.extend((match.start(), match.end()) for match in regex.finditer(text))
+        spans.extend(_extra_runtime_spans(text, include_urls=True))
+
+        merged = self._merge_spans(spans)
+        protected: list[ProtectedFragment] = []
+        out: list[str] = []
+        cursor = 0
+        base_id = max(literal_ids) + 1 if literal_ids else 0
+        for offset, (start, end) in enumerate(merged):
+            out.append(text[cursor:start])
+            placeholder = f"[#{base_id + offset}#]"
+            out.append(placeholder)
+            protected.append(ProtectedFragment(placeholder, text[start:end]))
+            cursor = end
+        out.append(text[cursor:])
+        return "".join(out), tuple(protected)
+
+
+class LocaleMergePlanner(_BaseLocaleMergePlanner):
+    """Locale merge planner that rejects damaged runtime-critical target syntax."""
+
+    def __init__(self, adapter: _BaseMinecraftLangJsonAdapter | None = None) -> None:
+        super().__init__(adapter or MinecraftLangJsonAdapter())
+
+    @staticmethod
+    def _critical_placeholders(text: str) -> Counter[str]:
+        critical = _BaseLocaleMergePlanner._critical_placeholders(text)
+        critical.update(_critical_runtime_tokens(text))
+        return critical

--- a/mineai_formatkit/structured_locale.py
+++ b/mineai_formatkit/structured_locale.py
@@ -1,0 +1,697 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Mapping
+
+from .core import TranslationPlan, TranslationUnit, ValidationError
+from .locale_merge import LocaleMergePlan
+from .minecraft_text import MinecraftTextComponentAdapter
+from .runtime_locale import (
+    LocaleMergePlanner as _RuntimeLocaleMergePlanner,
+    MinecraftLangJsonAdapter as _RuntimeMinecraftLangJsonAdapter,
+)
+
+_GAG_COMPONENT_KEYS = frozenset({"text", "extra", "strikethrough"})
+_TEMPAD_COMPONENT_KEYS = frozenset({"text", "color", "index"})
+_SERIALIZED_COMPONENT_KEYS = frozenset({"text", "color", "clickEvent"})
+_SERIALIZED_CLICK_EVENT_KEYS = frozenset({"action", "value"})
+_NESTED_LOCALE_JSON_STRING = "nested-locale-json-string"
+
+
+@dataclass(frozen=True)
+class StructuredLangFingerprint:
+    keys: tuple[str, ...]
+    component_locators: tuple[tuple[str, str], ...]
+    skeleton: str
+
+
+@dataclass(frozen=True)
+class _TargetValue:
+    kind: str
+    value: str | None = None
+    leaves: Mapping[str, str] | None = None
+    fingerprint: str | None = None
+
+
+class MinecraftLangJsonAdapter(_RuntimeMinecraftLangJsonAdapter):
+    """Minecraft locale adapter with strict, corpus-proven Component safety.
+
+    Supported structured locale values are deliberately schema-driven rather
+    than recursive JSON translation:
+
+    * the original GAG ``text``/``extra``/``strikethrough`` component shape;
+    * Tempad's root-list ``text``/``color``/``index`` component shape;
+    * serialized JSON Component arrays stored inside an ordinary locale string,
+      as used by Actually Additions and Iron Furnaces update messages.
+
+    Unknown object/list values and unknown serialized JSON shapes stay outside
+    the translation plan.
+    """
+
+    name = "minecraft-lang-json"
+
+    def prepare(self, path: str, source_text: str) -> TranslationPlan:
+        base_plan = super().prepare(path, source_text)
+        units = list(base_plan.units)
+        metadata = dict(base_plan.metadata)
+        original_values = dict(metadata.get("original_values", {}))
+        unsupported = list(metadata.get("unsupported_non_string_keys", ()))
+        unit_keys = {unit.id: unit.context for unit in base_plan.units}
+        structured_locators: dict[str, str] = {}
+        structured_fingerprints: dict[str, str] = {}
+        structured_keys: list[str] = []
+        serialized_keys: list[str] = []
+        unit_encodings: dict[str, str] = {}
+
+        for entry in self._parse_entries(source_text):
+            if entry.is_string:
+                assert isinstance(entry.value, str)
+                serialized = self._serialized_component_targets(entry.value)
+                if serialized is None:
+                    continue
+
+                base_unit_id = f"key:{entry.key}"
+                units = [unit for unit in units if unit.id != base_unit_id]
+                original_values.pop(base_unit_id, None)
+                unit_keys.pop(base_unit_id, None)
+                if entry.key not in serialized_keys:
+                    serialized_keys.append(entry.key)
+
+                raw_token = source_text[entry.value_start : entry.value_end]
+                boundaries = self._decoded_json_string_boundaries(raw_token)
+                structured_fingerprints[entry.key] = self._serialized_component_skeleton(
+                    entry.value, serialized
+                )
+
+                for locator, node, value in serialized:
+                    if not self._is_serialized_translatable_text(value):
+                        continue
+                    masked, protected = self._protect(value)
+                    unit_id = f"key:{entry.key}:serialized:{locator}"
+                    start = entry.value_start + boundaries[node.start]
+                    end = entry.value_start + boundaries[node.end]
+                    units.append(
+                        TranslationUnit(
+                            id=unit_id,
+                            text=masked,
+                            start=start,
+                            end=end,
+                            kind="minecraft-serialized-locale-component",
+                            context=entry.key,
+                            protected=protected,
+                        )
+                    )
+                    original_values[unit_id] = value
+                    unit_keys[unit_id] = entry.key
+                    structured_locators[unit_id] = locator
+                    unit_encodings[unit_id] = _NESTED_LOCALE_JSON_STRING
+                continue
+
+            raw = source_text[entry.value_start : entry.value_end]
+            targets = self._component_targets(raw)
+            if targets is None:
+                continue
+
+            structured_keys.append(entry.key)
+            unsupported = [key for key in unsupported if key != entry.key]
+            structured_fingerprints[entry.key] = self._component_skeleton(raw, targets)
+
+            for locator, node, value in targets:
+                if not MinecraftTextComponentAdapter._has_prose(value):
+                    continue
+                masked, protected = self._protect(value)
+                unit_id = f"key:{entry.key}:component:{locator}"
+                units.append(
+                    TranslationUnit(
+                        id=unit_id,
+                        text=masked,
+                        start=entry.value_start + node.start,
+                        end=entry.value_start + node.end,
+                        kind="minecraft-structured-locale-component",
+                        context=entry.key,
+                        protected=protected,
+                    )
+                )
+                original_values[unit_id] = value
+                unit_keys[unit_id] = entry.key
+                structured_locators[unit_id] = locator
+
+        metadata.update(
+            {
+                "fingerprint": self.fingerprint(source_text),
+                "original_values": original_values,
+                "unsupported_non_string_keys": tuple(unsupported),
+                "structured_component_keys": tuple(structured_keys),
+                "serialized_component_keys": tuple(serialized_keys),
+                "unit_keys": unit_keys,
+                "structured_unit_locators": structured_locators,
+                "structured_key_fingerprints": structured_fingerprints,
+                "unit_encodings": unit_encodings,
+            }
+        )
+        return TranslationPlan(
+            path=path,
+            source_text=source_text,
+            units=tuple(units),
+            metadata=metadata,
+        )
+
+    def apply(self, plan: TranslationPlan, translations: Mapping[str, str]) -> str:
+        known = {unit.id for unit in plan.units}
+        unknown = set(translations) - known
+        if unknown:
+            raise ValidationError(f"Unknown translation unit ids: {sorted(unknown)!r}")
+        original_values = plan.metadata.get("original_values")
+        if not isinstance(original_values, dict):
+            raise ValidationError("Translation plan is missing original locale values")
+        unit_encodings = plan.metadata.get("unit_encodings", {})
+        if not isinstance(unit_encodings, dict):
+            raise ValidationError("Translation plan has invalid locale unit encodings")
+
+        replacements: list[tuple[int, int, str]] = []
+        for unit in plan.units:
+            if unit.id not in translations:
+                continue
+            restored = self._restore_protected(unit, translations[unit.id])
+            if restored == original_values.get(unit.id):
+                token = plan.source_text[unit.start : unit.end]
+            elif unit_encodings.get(unit.id) == _NESTED_LOCALE_JSON_STRING:
+                token = self._encode_nested_locale_string(restored)
+            else:
+                token = json.dumps(restored, ensure_ascii=False)
+            replacements.append((unit.start, unit.end, token))
+
+        output = plan.source_text
+        for start, end, token in sorted(replacements, reverse=True):
+            output = output[:start] + token + output[end:]
+        self.validate(plan.source_text, output)
+        return output
+
+    def validate(self, source_text: str, output_text: str) -> None:
+        if self.fingerprint(source_text) != self.fingerprint(output_text):
+            raise ValidationError("Minecraft lang JSON structure changed during reconstruction")
+
+    def fingerprint(self, text: str) -> StructuredLangFingerprint:
+        entries = self._parse_entries(text)
+        ignored_metadata = self._repeated_metadata_keys(entries)
+        spans: list[tuple[int, int, str]] = []
+        locators: list[tuple[str, str]] = []
+
+        for entry in entries:
+            if entry.is_string and entry.key not in ignored_metadata:
+                assert isinstance(entry.value, str)
+                serialized = self._serialized_component_targets(entry.value)
+                if serialized is None:
+                    spans.append((entry.value_start, entry.value_end, '"<mineai-value>"'))
+                    continue
+
+                raw_token = text[entry.value_start : entry.value_end]
+                boundaries = self._decoded_json_string_boundaries(raw_token)
+                for locator, node, value in serialized:
+                    if not self._is_serialized_translatable_text(value):
+                        continue
+                    spans.append(
+                        (
+                            entry.value_start + boundaries[node.start],
+                            entry.value_start + boundaries[node.end],
+                            '\\"<mineai-serialized-text>\\"',
+                        )
+                    )
+                    locators.append((entry.key, "serialized:" + locator))
+                continue
+            if entry.is_string:
+                continue
+
+            raw = text[entry.value_start : entry.value_end]
+            targets = self._component_targets(raw)
+            if targets is None:
+                continue
+            for locator, node, _ in targets:
+                spans.append(
+                    (
+                        entry.value_start + node.start,
+                        entry.value_start + node.end,
+                        '"<mineai-component-text>"',
+                    )
+                )
+                locators.append((entry.key, locator))
+
+        out: list[str] = []
+        cursor = 0
+        for start, end, marker in sorted(spans):
+            if start < cursor:
+                raise ValidationError("Overlapping Minecraft locale translation spans")
+            out.append(text[cursor:start])
+            out.append(marker)
+            cursor = end
+        out.append(text[cursor:])
+        return StructuredLangFingerprint(
+            keys=tuple(entry.key for entry in entries),
+            component_locators=tuple(locators),
+            skeleton="".join(out),
+        )
+
+    @staticmethod
+    def _component_targets(raw: str):
+        parser = MinecraftTextComponentAdapter()
+        root = parser._parse(raw)
+        gag = MinecraftLangJsonAdapter._gag_component_targets(root)
+        if gag is not None:
+            return gag
+        return MinecraftLangJsonAdapter._tempad_component_targets(root)
+
+    @staticmethod
+    def _gag_component_targets(root):
+        if root.kind != "array":
+            return None
+        targets: list[tuple[str, object, str]] = []
+        seen = {"object": False, "text": False, "extra": False, "strikethrough": False}
+
+        def walk(node, locator: str) -> bool:
+            if node.kind == "string":
+                assert isinstance(node.value, str)
+                targets.append((locator or "/", node, node.value))
+                return True
+            if node.kind == "array":
+                return all(walk(item, f"{locator}/{index}") for index, item in enumerate(node.items))
+            if node.kind != "object":
+                return False
+
+            seen["object"] = True
+            members = {member.key: member.value for member in node.members}
+            if not members or not set(members).issubset(_GAG_COMPONENT_KEYS):
+                return False
+            if "text" not in members and "extra" not in members:
+                return False
+
+            text_node = members.get("text")
+            if text_node is not None:
+                seen["text"] = True
+                if text_node.kind != "string":
+                    return False
+                assert isinstance(text_node.value, str)
+                targets.append((locator + "/text", text_node, text_node.value))
+
+            extra = members.get("extra")
+            if extra is not None:
+                seen["extra"] = True
+                if extra.kind != "array":
+                    return False
+                for index, item in enumerate(extra.items):
+                    if not walk(item, f"{locator}/extra/{index}"):
+                        return False
+
+            strike = members.get("strikethrough")
+            if strike is not None:
+                seen["strikethrough"] = True
+                if not (strike.kind == "scalar" and isinstance(strike.value, bool)):
+                    return False
+            return True
+
+        if not walk(root, "") or not all(seen.values()):
+            return None
+        return tuple(targets)
+
+    @staticmethod
+    def _tempad_component_targets(root):
+        if root.kind != "array" or len(root.items) < 2:
+            return None
+        first = root.items[0]
+        if first.kind != "string" or first.value != "":
+            return None
+
+        targets: list[tuple[str, object, str]] = []
+        seen_text = False
+        for index, item in enumerate(root.items[1:], start=1):
+            if item.kind != "object":
+                return None
+            members = {member.key: member.value for member in item.members}
+            if not members or not set(members).issubset(_TEMPAD_COMPONENT_KEYS):
+                return None
+            color = members.get("color")
+            if color is None or color.kind != "string":
+                return None
+
+            text_node = members.get("text")
+            index_node = members.get("index")
+            if (text_node is None) == (index_node is None):
+                return None
+            if text_node is not None:
+                if text_node.kind != "string":
+                    return None
+                assert isinstance(text_node.value, str)
+                targets.append((f"/{index}/text", text_node, text_node.value))
+                seen_text = True
+            else:
+                if not (
+                    index_node.kind == "scalar"
+                    and isinstance(index_node.value, int)
+                    and not isinstance(index_node.value, bool)
+                ):
+                    return None
+        return tuple(targets) if seen_text else None
+
+    @staticmethod
+    def _component_skeleton(raw: str, targets) -> str:
+        out: list[str] = []
+        cursor = 0
+        for _, node, _ in sorted(targets, key=lambda item: item[1].start):
+            out.append(raw[cursor : node.start])
+            out.append('"<mineai-component-text>"')
+            cursor = node.end
+        out.append(raw[cursor:])
+        try:
+            normalized = json.loads("".join(out))
+        except json.JSONDecodeError as exc:
+            raise ValidationError("Structured locale Component normalization failed") from exc
+        return json.dumps(
+            normalized, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        )
+
+    @staticmethod
+    def _serialized_component_targets(decoded: str):
+        parser = MinecraftTextComponentAdapter()
+        try:
+            root = parser._parse(decoded)
+        except ValidationError:
+            return None
+        if root.kind != "array" or len(root.items) < 2:
+            return None
+
+        targets: list[tuple[str, object, str]] = []
+        seen_color = False
+        for index, item in enumerate(root.items):
+            if item.kind != "object":
+                return None
+            members = {member.key: member.value for member in item.members}
+            if not members or not set(members).issubset(_SERIALIZED_COMPONENT_KEYS):
+                return None
+            text_node = members.get("text")
+            if text_node is None or text_node.kind != "string":
+                return None
+            assert isinstance(text_node.value, str)
+            targets.append((f"/{index}/text", text_node, text_node.value))
+
+            color = members.get("color")
+            if color is not None:
+                if color.kind != "string":
+                    return None
+                seen_color = True
+
+            click = members.get("clickEvent")
+            if click is not None:
+                if click.kind != "object":
+                    return None
+                click_members = {member.key: member.value for member in click.members}
+                if set(click_members) != _SERIALIZED_CLICK_EVENT_KEYS:
+                    return None
+                action = click_members["action"]
+                value = click_members["value"]
+                if action.kind != "string" or value.kind != "string":
+                    return None
+                if action.value != "open_url" or value.value != "%s":
+                    return None
+
+        if not seen_color:
+            return None
+        return tuple(targets)
+
+    def _serialized_component_skeleton(self, decoded: str, targets) -> str:
+        out: list[str] = []
+        cursor = 0
+        for _, node, value in sorted(targets, key=lambda item: item[1].start):
+            if not self._is_serialized_translatable_text(value):
+                continue
+            out.append(decoded[cursor : node.start])
+            out.append('"<mineai-serialized-text>"')
+            cursor = node.end
+        out.append(decoded[cursor:])
+        try:
+            normalized = json.loads("".join(out))
+        except json.JSONDecodeError as exc:
+            raise ValidationError("Serialized locale Component normalization failed") from exc
+        return json.dumps(
+            normalized, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        )
+
+    def _is_serialized_translatable_text(self, value: str) -> bool:
+        masked, protected = self._protect(value)
+        visible = masked
+        for fragment in protected:
+            visible = visible.replace(fragment.placeholder, "")
+        return any(char.isalpha() for char in visible)
+
+    @staticmethod
+    def _decoded_json_string_boundaries(raw_token: str) -> tuple[int, ...]:
+        """Map decoded-string character boundaries to offsets in its JSON token."""
+
+        if len(raw_token) < 2 or raw_token[0] != '"' or raw_token[-1] != '"':
+            raise ValidationError("Serialized locale Component is not a JSON string token")
+        try:
+            decoded = json.loads(raw_token)
+        except json.JSONDecodeError as exc:
+            raise ValidationError("Invalid serialized locale JSON string token") from exc
+        if not isinstance(decoded, str):
+            raise ValidationError("Serialized locale token did not decode to a string")
+
+        boundaries = [1]
+        index = 1
+        while index < len(raw_token) - 1:
+            if raw_token[index] != "\\":
+                piece = raw_token[index]
+                index += 1
+            else:
+                if index + 1 >= len(raw_token) - 1:
+                    raise ValidationError("Incomplete escape in serialized locale string")
+                if raw_token[index + 1] == "u":
+                    if index + 6 > len(raw_token) - 1:
+                        raise ValidationError("Incomplete Unicode escape in serialized locale string")
+                    chunk = raw_token[index : index + 6]
+                    try:
+                        codepoint = int(raw_token[index + 2 : index + 6], 16)
+                    except ValueError as exc:
+                        raise ValidationError("Invalid Unicode escape in serialized locale string") from exc
+                    if (
+                        0xD800 <= codepoint <= 0xDBFF
+                        and index + 12 <= len(raw_token) - 1
+                        and raw_token[index + 6 : index + 8] == "\\u"
+                    ):
+                        try:
+                            low = int(raw_token[index + 8 : index + 12], 16)
+                        except ValueError as exc:
+                            raise ValidationError("Invalid surrogate escape in serialized locale string") from exc
+                        if 0xDC00 <= low <= 0xDFFF:
+                            chunk = raw_token[index : index + 12]
+                    try:
+                        piece = json.loads('"' + chunk + '"')
+                    except json.JSONDecodeError as exc:
+                        raise ValidationError("Invalid Unicode escape in serialized locale string") from exc
+                    index += len(chunk)
+                else:
+                    chunk = raw_token[index : index + 2]
+                    try:
+                        piece = json.loads('"' + chunk + '"')
+                    except json.JSONDecodeError as exc:
+                        raise ValidationError("Invalid escape in serialized locale string") from exc
+                    index += 2
+            if not isinstance(piece, str) or len(piece) != 1:
+                raise ValidationError("Ambiguous decoded span in serialized locale string")
+            boundaries.append(index)
+
+        if len(boundaries) != len(decoded) + 1:
+            raise ValidationError("Serialized locale source-span mapping failed")
+        return tuple(boundaries)
+
+    @staticmethod
+    def _encode_nested_locale_string(value: str) -> str:
+        inner = json.dumps(value, ensure_ascii=False)
+        return json.dumps(inner, ensure_ascii=False)[1:-1]
+
+
+class LocaleMergePlanner(_RuntimeLocaleMergePlanner):
+    """Merge ordinary and strict structured locale Components from EN structure."""
+
+    def __init__(self, adapter: MinecraftLangJsonAdapter | None = None) -> None:
+        super().__init__(adapter or MinecraftLangJsonAdapter())
+
+    def plan(
+        self,
+        source_path: str,
+        source_text: str,
+        target_code: str,
+        target_text: str | None = None,
+        mode: str = "append",
+    ) -> LocaleMergePlan:
+        if mode not in self.VALID_MODES:
+            raise ValueError(f"Unsupported locale merge mode: {mode}")
+        source_plan = self.adapter.prepare(source_path, source_text)
+        original_values = source_plan.metadata.get("original_values")
+        unit_keys = source_plan.metadata.get("unit_keys")
+        structured_locators = source_plan.metadata.get("structured_unit_locators")
+        structured_fingerprints = source_plan.metadata.get("structured_key_fingerprints")
+        if not isinstance(original_values, dict) or not isinstance(unit_keys, dict):
+            raise ValidationError("Source locale plan is missing merge metadata")
+        if not isinstance(structured_locators, dict) or not isinstance(structured_fingerprints, dict):
+            raise ValidationError("Source locale plan is missing structured Component metadata")
+
+        target_parse_failed = False
+        if target_text is None:
+            target_values = {}
+        else:
+            try:
+                target_values = self._catalog_extended(target_text)
+            except ValidationError:
+                target_values = {}
+                target_parse_failed = True
+
+        source_keys = {unit_keys[unit.id] for unit in source_plan.units}
+        target_keys = set(target_values)
+        missing = tuple(sorted(source_keys - target_keys))
+        orphan = tuple(sorted(target_keys - source_keys))
+        existing: dict[str, str] = {}
+        pending: list[str] = []
+        invalid: set[str] = set(source_keys) if target_parse_failed else set()
+
+        grouped: dict[str, list[TranslationUnit]] = {}
+        for unit in source_plan.units:
+            grouped.setdefault(unit_keys[unit.id], []).append(unit)
+
+        for key, key_units in grouped.items():
+            if mode == "force":
+                pending.extend(unit.id for unit in key_units)
+                continue
+            target = target_values.get(key)
+            is_structured = any(unit.id in structured_locators for unit in key_units)
+
+            if target is None:
+                pending.extend(unit.id for unit in key_units)
+                continue
+
+            if is_structured:
+                if (
+                    target.kind != "structured"
+                    or target.fingerprint != structured_fingerprints.get(key)
+                    or target.leaves is None
+                ):
+                    invalid.add(key)
+                    pending.extend(unit.id for unit in key_units)
+                    continue
+                for unit in key_units:
+                    locator = structured_locators.get(unit.id)
+                    current = target.leaves.get(locator) if locator is not None else None
+                    if current is None or current == "":
+                        pending.append(unit.id)
+                        continue
+                    source_value = original_values[unit.id]
+                    if not self._critical_placeholders_match(source_value, current):
+                        invalid.add(key)
+                        pending.append(unit.id)
+                        continue
+                    if mode == "append" and current == source_value:
+                        pending.append(unit.id)
+                        continue
+                    existing[unit.id] = current
+                continue
+
+            if target.kind != "string" or target.value is None or target.value == "":
+                if target.kind != "string":
+                    invalid.add(key)
+                pending.extend(unit.id for unit in key_units)
+                continue
+            unit = key_units[0]
+            source_value = original_values[unit.id]
+            if not self._critical_placeholders_match(source_value, target.value):
+                invalid.add(key)
+                pending.append(unit.id)
+                continue
+            if mode == "append" and target.value == source_value:
+                pending.append(unit.id)
+                continue
+            existing[unit.id] = target.value
+
+        return LocaleMergePlan(
+            source_plan=source_plan,
+            target_path=self.adapter.target_path(source_path, target_code),
+            mode=mode,
+            pending_ids=tuple(pending),
+            existing_values=existing,
+            missing_keys=missing,
+            orphan_target_keys=orphan,
+            invalid_existing_keys=tuple(sorted(invalid)),
+        )
+
+    def build(self, plan: LocaleMergePlan, translations: Mapping[str, str]) -> str:
+        required = set(plan.pending_ids)
+        unknown = set(translations) - required
+        if unknown:
+            raise ValidationError(f"Translations contain non-pending ids: {sorted(unknown)!r}")
+        missing = required - set(translations)
+        if missing:
+            raise ValidationError(f"Missing translations for pending ids: {sorted(missing)!r}")
+
+        originals = plan.source_plan.metadata.get("original_values")
+        if not isinstance(originals, dict):
+            raise ValidationError("Source locale plan is missing original values")
+        unit_encodings = plan.source_plan.metadata.get("unit_encodings", {})
+        if not isinstance(unit_encodings, dict):
+            raise ValidationError("Source locale plan has invalid unit encodings")
+
+        replacements: list[tuple[int, int, str]] = []
+        for unit in plan.source_plan.units:
+            if unit.id in plan.existing_values:
+                value = plan.existing_values[unit.id]
+            elif unit.id in translations:
+                value = self.adapter._restore_protected(unit, translations[unit.id])
+            else:
+                continue
+
+            if value == originals.get(unit.id):
+                token = plan.source_plan.source_text[unit.start : unit.end]
+            elif unit_encodings.get(unit.id) == _NESTED_LOCALE_JSON_STRING:
+                token = self.adapter._encode_nested_locale_string(value)
+            else:
+                token = json.dumps(value, ensure_ascii=False)
+            replacements.append((unit.start, unit.end, token))
+
+        output = plan.source_plan.source_text
+        for start, end, token in sorted(replacements, reverse=True):
+            output = output[:start] + token + output[end:]
+        self.adapter.validate(plan.source_plan.source_text, output)
+        return output
+
+    def _catalog_extended(self, text: str) -> dict[str, _TargetValue]:
+        out: dict[str, _TargetValue] = {}
+        for entry in self.adapter._parse_entries(text):
+            if entry.is_string:
+                assert isinstance(entry.value, str)
+                serialized = self.adapter._serialized_component_targets(entry.value)
+                if serialized is None:
+                    out[entry.key] = _TargetValue("string", value=entry.value)
+                    continue
+                leaves = {
+                    locator: value
+                    for locator, _, value in serialized
+                    if self.adapter._is_serialized_translatable_text(value)
+                }
+                out[entry.key] = _TargetValue(
+                    "structured",
+                    leaves=leaves,
+                    fingerprint=self.adapter._serialized_component_skeleton(
+                        entry.value, serialized
+                    ),
+                )
+                continue
+
+            raw = text[entry.value_start : entry.value_end]
+            targets = self.adapter._component_targets(raw)
+            if targets is None:
+                out[entry.key] = _TargetValue("unsupported")
+                continue
+            leaves = {locator: value for locator, _, value in targets}
+            out[entry.key] = _TargetValue(
+                "structured",
+                leaves=leaves,
+                fingerprint=self.adapter._component_skeleton(raw, targets),
+            )
+        return out

--- a/start.bat
+++ b/start.bat
@@ -1,20 +1,25 @@
 @echo off
 setlocal
-chcp 65001 >nul
+cd /d "%~dp0"
+
 echo Installing dependencies...
 python -m pip install -r requirements.txt -q
-if errorlevel 1 (
-    echo Failed to install dependencies.
-    if not defined CI pause
-    exit /b 1
-)
+if errorlevel 1 goto :deps_error
+
 echo =========================================
 echo Starting MineAI Translator...
 python -m mineai
-if errorlevel 1 (
-    echo MineAI Translator exited with an error.
-    if not defined CI pause
-    exit /b 1
-)
+if errorlevel 1 goto :run_error
+
 if not defined CI pause
 exit /b 0
+
+:deps_error
+echo ERROR: Failed to install dependencies.
+if not defined CI pause
+exit /b 1
+
+:run_error
+echo ERROR: MineAI Translator exited with an error.
+if not defined CI pause
+exit /b 1

--- a/tests/test_formatkit_analyzer_alignment.py
+++ b/tests/test_formatkit_analyzer_alignment.py
@@ -1,0 +1,111 @@
+import json
+import os
+import shutil
+import tempfile
+import unittest
+import zipfile
+
+from mineai.processors.analyzer import ModpackAnalyzer
+from mineai.processors.formatkit_pilot import FormatKitStringEstimator
+from mineai.runtime.state import JobState
+
+
+TARGET_LANG = {"file": "ru_ru", "api": "ru", "name": "Russian", "regex": r"[А-Яа-яЁё]"}
+
+
+def serialized_component(*texts: str) -> str:
+    nodes = []
+    for index, text in enumerate(texts):
+        node = {"text": text}
+        if index == len(texts) - 1:
+            node["color"] = "dark_green"
+            node["clickEvent"] = {"action": "open_url", "value": "%s"}
+        nodes.append(node)
+    return json.dumps(nodes, separators=(",", ":"))
+
+
+class FormatKitAnalyzerAlignmentTests(unittest.TestCase):
+    def _make_jar(self, source: dict[str, str], target: dict[str, str] | None = None) -> str:
+        temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, temp_dir)
+        path = os.path.join(temp_dir, "actuallyadditions.jar")
+        with zipfile.ZipFile(path, "w") as archive:
+            archive.writestr(
+                "assets/actuallyadditions/lang/en_us.json",
+                json.dumps(source, ensure_ascii=False),
+            )
+            if target is not None:
+                archive.writestr(
+                    "assets/actuallyadditions/lang/ru_ru.json",
+                    json.dumps(target, ensure_ascii=False),
+                )
+        return path
+
+    def _analyze(self, path: str):
+        state = JobState()
+        state.start()
+        rows = []
+        counts = ModpackAnalyzer(state)._analyze_jar(
+            path,
+            "ru_ru.json",
+            TARGET_LANG["regex"],
+            True,
+            False,
+            lambda *row: rows.append(row),
+            "Actuallyadditions",
+        )
+        return counts, rows
+
+    def test_real_runtime_1021_to_1027_component_drift_is_closed(self) -> None:
+        # Reproduce the exact cardinality seen in the FTB Evolution pilot:
+        # legacy top-level JSON sees 1021 strings, while four serialized
+        # Component strings contain ten independently translatable text leaves.
+        source = {f"plain.{index}": f"Visible text {index}" for index in range(1017)}
+        source.update(
+            {
+                "update.one": serialized_component("Update available", "Open page"),
+                "update.two": serialized_component("Current version", "New version"),
+                "update.three": serialized_component("Download", "Website", "Later"),
+                "update.four": serialized_component("Update failed", "Try again", "Close"),
+            }
+        )
+        self.assertEqual(len(source), 1021)
+        path = self._make_jar(source)
+
+        analyzed, rows = self._analyze(path)
+
+        state = JobState()
+        state.start()
+        estimated = FormatKitStringEstimator(state)._estimate_jar(
+            path,
+            "ru_ru.json",
+            TARGET_LANG,
+            "force",
+            True,
+            False,
+            False,
+        )
+
+        self.assertEqual(analyzed, (1027, 0))
+        self.assertEqual(estimated, 1027)
+        self.assertEqual(rows, [("📦", "Actuallyadditions", "Интерфейс", 0, 1027, 0)])
+
+    def test_analyzer_reuses_the_same_safe_existing_target_as_formatkit(self) -> None:
+        source = {
+            "plain": "Visible text",
+            "update": serialized_component("Update available", "Open page"),
+        }
+        target = {
+            "plain": "Видимый текст",
+            "update": serialized_component("Доступно обновление", "Открыть страницу"),
+        }
+        path = self._make_jar(source, target)
+
+        analyzed, rows = self._analyze(path)
+
+        self.assertEqual(analyzed, (3, 3))
+        self.assertEqual(rows, [("📦", "Actuallyadditions", "Интерфейс", 3, 3, 100)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_formatkit_apotheosis_cache_regression_v341.py
+++ b/tests/test_formatkit_apotheosis_cache_regression_v341.py
@@ -1,0 +1,68 @@
+import json
+import unittest
+
+from mineai.constants import LANGUAGES
+from mineai.formatkit_books_bridge import plan_book_work, validate_book_candidate
+
+
+RU = LANGUAGES["Русский"]
+
+
+class ApotheosisSemanticCacheRegressionV341Tests(unittest.TestCase):
+    def test_cached_synonym_cannot_hide_extra_label_before_semantic_anchor(self):
+        path = (
+            "assets/apotheosis/patchouli_books/apoth_chronicle/en_us/entries/"
+            "adventure/affix_loot/affixes.json"
+        )
+        source = json.dumps(
+            {
+                "pages": [
+                    {
+                        "type": "patchouli:text",
+                        "text": (
+                            "An $(6)Affix$() is the driving force behind Affix Items. "
+                            "Each affix is very similar to an enchantment, providing a "
+                            "specific bonus to the item it is attached to.$(p)This book "
+                            "will not list all the affixes, as that is for you to figure "
+                            "out, but it will help explain them."
+                        ),
+                    }
+                ]
+            },
+            separators=(",", ":"),
+        )
+        work = plan_book_work(path, source, "ru_ru", RU["regex"], None, "force")
+        assert work is not None
+        child = next(
+            unit
+            for unit in work.source_plan.units
+            if unit.kind == "patchouli-semantic-child"
+        )
+        parent = next(
+            unit
+            for unit in work.source_plan.units
+            if unit.kind == "patchouli-text"
+        )
+
+        # Exact conflict observed in the real acceptance cache: the child had a
+        # synonym while the parent independently invented another Affix label.
+        bad_cached_parent = (
+            "Аффикс [#0#] — это движущая сила предметов с аффиксами. "
+            "Каждый аффикс очень похож на зачарование, предоставляя определённый "
+            "бонус предмету, к которому он прикреплён.[#1#]В этой книге не "
+            "перечислены все аффиксы, так как это нужно выяснить вам, но она "
+            "поможет их объяснить."
+        )
+        ok, reason = validate_book_candidate(
+            work,
+            parent.id,
+            bad_cached_parent,
+            resolved_semantic={child.id: "Прикрепление"},
+        )
+
+        self.assertFalse(ok)
+        self.assertIn("introduces an extra label", reason)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_formatkit_atomic_semantic_fallback_v341.py
+++ b/tests/test_formatkit_atomic_semantic_fallback_v341.py
@@ -1,0 +1,62 @@
+import json
+import unittest
+
+from mineai.constants import LANGUAGES
+from mineai.formatkit_books_bridge import build_book_output, plan_book_work
+
+
+RU = LANGUAGES["Русский"]
+
+
+class AtomicSemanticFallbackV341Tests(unittest.TestCase):
+    path = (
+        "assets/apotheosis/patchouli_books/apoth_chronicle/en_us/"
+        "entries/adventure/affix_loot/affixes.json"
+    )
+
+    def _work(self):
+        source = json.dumps(
+            {
+                "pages": [
+                    {
+                        "type": "patchouli:text",
+                        "text": "An $(6)Affix$() is the driving force behind Affix Items.",
+                    }
+                ]
+            },
+            separators=(",", ":"),
+        )
+        work = plan_book_work(
+            self.path,
+            source,
+            "ru_ru",
+            RU["regex"],
+            None,
+            "force",
+        )
+        self.assertIsNotNone(work)
+        return work
+
+    def test_rejected_parent_does_not_mix_translated_child_into_source_fallback(self):
+        work = self._work()
+        child = next(
+            unit
+            for unit in work.source_plan.units
+            if unit.kind == "patchouli-semantic-child"
+        )
+
+        # The child succeeded, but the parent is intentionally absent from the
+        # result to model a validator rejection. The entire semantic fragment
+        # must fall back to canonical source instead of mixing languages.
+        output = json.loads(build_book_output(work, {child.id: "Прикрепление"}))
+        text = output["pages"][0]["text"]
+
+        self.assertEqual(
+            text,
+            "An $(6)Affix$() is the driving force behind Affix Items.",
+        )
+        self.assertNotIn("$(6)Прикрепление$()", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_formatkit_books_pilot_v3.py
+++ b/tests/test_formatkit_books_pilot_v3.py
@@ -1,0 +1,217 @@
+import json
+import os
+import shutil
+import tempfile
+import unittest
+import zipfile
+from types import SimpleNamespace
+
+from mineai.constants import LANGUAGES
+from mineai.formatkit_books_bridge import build_book_output, plan_book_work
+from mineai.processors.formatkit_books_pilot import (
+    FormatKitBooksJarProcessor,
+    FormatKitBooksStringEstimator,
+    FormatKitModpackAnalyzer,
+)
+from mineai.runtime.state import JobState
+from mineai_formatkit import PatchouliBookJsonAdapter, ValidationError
+
+RU = LANGUAGES["Русский"]
+
+
+class FormatKitPatchouliV3Tests(unittest.TestCase):
+    path = "assets/advancedperipherals/patchouli_books/manual/en_us/entries/peripherals/chat_box.json"
+
+    def test_real_chat_box_literal_dollar_and_patchouli_token_are_protected(self):
+        source = json.dumps(
+            {
+                "name": "Chat Box",
+                "pages": [
+                    {
+                        "type": "patchouli:text",
+                        "text": "Start the message with a `$`.$(p)Read the documentation.",
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        )
+        work = plan_book_work(self.path, source, "ru_ru", RU["regex"], None, "force")
+        assert work is not None
+        text_id = next(k for k in work.pending if "/pages/0/text" in k)
+        masked = work.pending[text_id]
+        self.assertNotIn("`$`", masked)
+        self.assertNotIn("$(p)", masked)
+        self.assertEqual(masked.count("[#"), 2)
+
+        output = json.loads(
+            build_book_output(
+                work,
+                {
+                    "json:/name": "Чат-окно",
+                    text_id: "Начните сообщение с [#0#].[#1#]Читайте документацию.",
+                },
+            )
+        )
+        self.assertIn("`$`", output["pages"][0]["text"])
+        self.assertIn("$(p)", output["pages"][0]["text"])
+        self.assertNotIn("`$$", output["pages"][0]["text"])
+
+    def test_patchouli_sdk_owns_balanced_style_payload_semantically(self):
+        source = '{"pages":[{"type":"patchouli:text","text":"Use $(9)Name$() then $(p)More"}]}'
+        adapter = PatchouliBookJsonAdapter()
+        plan = adapter.prepare(self.path, source)
+        outer = next(unit for unit in plan.units if unit.kind == "patchouli-text")
+        child = next(unit for unit in plan.units if unit.kind == "patchouli-semantic-child")
+        self.assertEqual(child.text, "Name")
+        self.assertNotIn("$(9)", outer.text)
+        self.assertNotIn("$()", outer.text)
+        output = json.loads(
+            adapter.apply(
+                plan,
+                {
+                    outer.id: outer.text.replace("Use", "Используйте").replace("then", "затем").replace("More", "Далее"),
+                    child.id: "Имя",
+                },
+            )
+        )
+        self.assertIn("$(9)Имя$()", output["pages"][0]["text"])
+
+    def test_corrupted_existing_dollar_is_not_reused(self):
+        source = '{"pages":[{"type":"patchouli:text","text":"Start with a `$`.$(p)More"}]}'
+        target = '{"pages":[{"type":"patchouli:text","text":"Начните с `$$.$(p)Подробнее"}]}'
+        work = plan_book_work(self.path, source, "ru_ru", RU["regex"], target, "append")
+        assert work is not None
+        self.assertEqual(len(work.preserved), 0)
+        self.assertEqual(len(work.pending), 1)
+
+    def test_safe_nonsemantic_existing_patchouli_target_is_reused(self):
+        source = '{"name":"Chat Box","pages":[{"type":"patchouli:text","text":"Start with a `$`.$(p)More"}]}'
+        target = json.dumps(
+            {
+                "name": "Чат-окно",
+                "pages": [{"type": "patchouli:text", "text": "Начните с `$`.$(p)Подробнее"}],
+            },
+            ensure_ascii=False,
+            indent=4,
+        )
+        work = plan_book_work(self.path, source, "ru_ru", RU["regex"], target, "append")
+        assert work is not None
+        self.assertFalse(work.target_reuse_disabled)
+        self.assertIsNone(work.target_parse_error)
+        self.assertEqual(len(work.pending), 0)
+        self.assertEqual(len(work.preserved), 2)
+
+
+class FormatKitIeManualV3Tests(unittest.TestCase):
+    path = "assets/immersiveengineering/manual/en_us/arc_furnace.txt"
+
+    def test_manual_preserves_line_structure_tokens_and_style_ownership(self):
+        source = (
+            "Arc Furnace\n"
+            "Use <link;machines/arc_furnace;Arc Furnace> to smelt ores.\n"
+            "Keep §6power§r supplied.\n"
+        )
+        work = plan_book_work(self.path, source, "ru_ru", RU["regex"], None, "force")
+        assert work is not None
+        outer = next(
+            unit for unit in work.source_plan.units
+            if unit.kind == "ie-manual-prose" and "Keep" in unit.text
+        )
+        child = next(
+            unit for unit in work.source_plan.units
+            if unit.kind == "ie-format-semantic-child"
+        )
+        translated = {unit_id: text for unit_id, text in work.pending.items()}
+        translated[outer.id] = outer.text.replace("Keep", "Поддерживайте").replace("supplied", "доступной")
+        translated[child.id] = "энергию"
+        output = build_book_output(work, translated)
+        self.assertEqual(output.count("\n"), source.count("\n"))
+        self.assertEqual(len(output.splitlines()), len(source.splitlines()))
+        self.assertIn("<link;machines/arc_furnace;", output)
+        self.assertIn("§6энергию§r", output)
+        work.adapter.validate(source, output)
+
+    def test_manual_rejects_semantic_anchor_loss(self):
+        source = "Keep §6power§r supplied.\n"
+        work = plan_book_work(self.path, source, "ru_ru", RU["regex"], None, "force")
+        assert work is not None
+        outer = next(
+            unit for unit in work.source_plan.units if unit.kind == "ie-manual-prose"
+        )
+        with self.assertRaises(ValidationError):
+            build_book_output(work, {outer.id: "Поддерживайте энергию доступной."})
+
+
+class FormatKitBookParityV3Tests(unittest.TestCase):
+    def _make_jar(self):
+        temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, temp_dir)
+        path = os.path.join(temp_dir, "books.jar")
+        patchouli = json.dumps(
+            {
+                "name": "Chat Box",
+                "pages": [{"type": "patchouli:text", "text": "Start with a `$`.$(p)More"}],
+            }
+        )
+        manual = "Arc Furnace\nUse <link;machines/arc_furnace;Arc Furnace>.\nKeep §6power§r supplied.\n"
+        with zipfile.ZipFile(path, "w") as z:
+            z.writestr(
+                "assets/advancedperipherals/patchouli_books/manual/en_us/entries/chat_box.json",
+                patchouli,
+            )
+            z.writestr("assets/immersiveengineering/manual/en_us/arc_furnace.txt", manual)
+        return path
+
+    def test_analyzer_and_estimator_share_formatkit_book_counts(self):
+        path = self._make_jar()
+        state = JobState(); state.start()
+        rows = []
+        analyzed = FormatKitModpackAnalyzer(state)._analyze_jar(
+            path, "ru_ru.json", RU["regex"], False, True,
+            lambda *row: rows.append(row), "Books",
+        )
+        estimated = FormatKitBooksStringEstimator(state)._estimate_jar(
+            path, "ru_ru.json", RU, "force", False, True, True
+        )
+        self.assertEqual(analyzed[0], estimated)
+        self.assertGreater(estimated, 0)
+        self.assertTrue(any(row[2] == "Книга(JSON)" for row in rows))
+        self.assertTrue(any(row[2] == "Книга(MD)" for row in rows))
+
+    def test_processor_routes_patchouli_through_formatkit(self):
+        path = self._make_jar()
+        class Service:
+            config = SimpleNamespace(getboolean=lambda *_args, **_kwargs: True)
+            def translate_dict(self, pending, _lang, _callbacks, **_kwargs):
+                out = {}
+                for key, value in pending.items():
+                    if "Chat Box" in value:
+                        out[key] = "Чат-окно"
+                    elif value.count("[#") == 2:
+                        out[key] = "Начните с [#0#].[#1#]Подробнее"
+                    elif value == "Arc Furnace":
+                        out[key] = "Дуговая печь"
+                    else:
+                        out[key] = value
+                return out
+        class Writer:
+            def __init__(self): self.writes = {}
+            def write(self, p, payload): self.writes[p] = payload
+        logs=[]; writer=Writer()
+        processor = FormatKitBooksJarProcessor(
+            Service(), SimpleNamespace(should_run=lambda: True),
+            SimpleNamespace(on_log=lambda text, color: logs.append(text)),
+        )
+        with zipfile.ZipFile(path) as z:
+            locale={e.filename.lower():e for e in z.infolist()}
+            item=z.getinfo("assets/advancedperipherals/patchouli_books/manual/en_us/entries/chat_box.json")
+            ok=processor._process_book_json(z,None,item,locale,RU,"force","resourcepack",writer,"Advancedperipherals",set())
+        self.assertTrue(ok)
+        self.assertIn("assets/advancedperipherals/patchouli_books/manual/ru_ru/entries/chat_box.json", writer.writes)
+        output=json.loads(writer.writes[next(iter(writer.writes))].decode())
+        self.assertIn("`$`", output["pages"][0]["text"])
+        self.assertTrue(any("Patchouli/FormatKit" in line for line in logs))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_formatkit_books_pilot_v32.py
+++ b/tests/test_formatkit_books_pilot_v32.py
@@ -1,0 +1,298 @@
+import json
+import os
+import shutil
+import tempfile
+import unittest
+import zipfile
+from types import SimpleNamespace
+
+from mineai.constants import LANGUAGES
+from mineai.engines.base import EngineCallbacks, TranslationEngine
+from mineai.engines.service import TranslationService
+from mineai.formatkit_books_bridge import (
+    plan_book_work,
+    validate_book_candidate,
+)
+from mineai.processors.formatkit_books_pilot import FormatKitBooksJarProcessor
+from mineai_formatkit import PatchouliBookJsonAdapter
+
+RU = LANGUAGES["Русский"]
+
+
+class _Config:
+    def getboolean(self, section, key):
+        if (section, key) == ("GENERAL", "smart_glue"):
+            return True
+        if (section, key) == ("AI", "fallback_google"):
+            return False
+        raise AssertionError((section, key))
+
+    def getint(self, _section, _key, fallback=0):
+        return fallback
+
+
+class _MemoryCache:
+    def __init__(self):
+        self.values = {}
+        self.identities = set()
+        self.discarded = []
+
+    def get(self, api_code, source):
+        key = (api_code, source)
+        if key in self.values:
+            return self.values[key], False
+        if key in self.identities:
+            return source, False
+        return None, False
+
+    def set(self, api_code, source, translated):
+        self.values[(api_code, source)] = translated
+
+    def set_identity(self, api_code, source):
+        self.identities.add((api_code, source))
+
+    def discard(self, api_code, source, *, include_imported=False):
+        self.values.pop((api_code, source), None)
+        self.identities.discard((api_code, source))
+        self.discarded.append((api_code, source, include_imported))
+
+    def save_if_threshold(self):
+        pass
+
+
+class _Engine(TranslationEngine):
+    def __init__(self, responses):
+        self.responses = responses
+        self.calls = []
+
+    def translate_batch(self, items, target_lang, callbacks):
+        self.calls.append(tuple(items))
+        return {
+            key: self.responses.get(item.original, item.original)
+            for key, item in items.items()
+        }
+
+
+class _Service(TranslationService):
+    def __init__(self, engine, cache):
+        super().__init__("ai", cache, _Config(), ai_batch=20)
+        self.engine = engine
+
+    def _build_engine(self, context="", prompt_type="mods"):
+        return self.engine
+
+
+class _Writer:
+    def __init__(self):
+        self.writes = {}
+
+    def write(self, path, payload):
+        self.writes[path] = payload
+
+
+def _callbacks(logs):
+    return EngineCallbacks(
+        should_run=lambda: True,
+        wait_if_paused=lambda: None,
+        on_log=lambda message, tag: logs.append((message, tag)),
+        on_status=lambda _message: None,
+        on_progress=lambda _count: None,
+    )
+
+
+class FormatKitPerUnitFallbackV32Tests(unittest.TestCase):
+    patchouli_path = (
+        "assets/apotheosis/patchouli_books/apoth_chronicle/en_us/"
+        "entries/adventure/attributes/cold_damage.json"
+    )
+
+    def _make_jar(self, path, source):
+        temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, temp_dir)
+        jar = os.path.join(temp_dir, "book.jar")
+        with zipfile.ZipFile(jar, "w") as archive:
+            archive.writestr(path, source)
+        return jar
+
+    def _run_processor(self, path, source, responses, cache=None):
+        cache = cache or _MemoryCache()
+        logs = []
+        writer = _Writer()
+        service = _Service(_Engine(responses), cache)
+        processor = FormatKitBooksJarProcessor(
+            service,
+            SimpleNamespace(should_run=lambda: True),
+            EngineCallbacks(
+                should_run=lambda: True,
+                wait_if_paused=lambda: None,
+                on_log=lambda text, color: logs.append((text, color)),
+                on_status=lambda _message: None,
+                on_progress=lambda _count: None,
+            ),
+        )
+        jar = self._make_jar(path, source)
+        with zipfile.ZipFile(jar) as archive:
+            locale = {entry.filename.lower(): entry for entry in archive.infolist()}
+            item = archive.getinfo(path)
+            if path.endswith(".json"):
+                ok = processor._process_book_json(
+                    archive, None, item, locale, RU, "force", "resourcepack",
+                    writer, "TestMod", set(),
+                )
+            else:
+                ok = processor._process_book_md(
+                    archive, None, item, locale, RU, "force", "resourcepack",
+                    writer, "TestMod", set(),
+                )
+        return ok, writer, cache, logs
+
+    def test_bad_patchouli_newline_falls_back_per_unit_and_file_is_written(self):
+        source = json.dumps(
+            {
+                "name": "Cold Damage",
+                "pages": [
+                    {
+                        "type": "patchouli:text",
+                        "text": "Cold Damage is bonus magic damage.",
+                    }
+                ],
+            },
+            separators=(",", ":"),
+        )
+        ok, writer, cache, logs = self._run_processor(
+            self.patchouli_path,
+            source,
+            {
+                "Cold Damage": "Холод\nПовреждение",
+                "Cold Damage is bonus magic damage.": "Холодный урон — дополнительный магический урон.",
+            },
+        )
+        self.assertTrue(ok)
+        target = self.patchouli_path.replace("/en_us/", "/ru_ru/")
+        self.assertIn(target, writer.writes)
+        output = json.loads(writer.writes[target].decode("utf-8"))
+        # Only the unsafe unit falls back; the rest of the file is retained.
+        self.assertEqual(output["name"], "Cold Damage")
+        self.assertEqual(
+            output["pages"][0]["text"],
+            "Холодный урон — дополнительный магический урон.",
+        )
+        self.assertNotIn(("ru", "Cold Damage"), cache.values)
+        self.assertIn(
+            ("ru", "Cold Damage is bonus magic damage."),
+            cache.values,
+        )
+        self.assertTrue(any("FormatKit:" in message for message, _ in logs))
+        self.assertFalse(any("отклонил реконструкцию книги" in message for message, _ in logs))
+
+    def test_bad_formatkit_cache_entry_is_discarded_before_reuse(self):
+        source = json.dumps(
+            {
+                "name": "Cold Damage",
+                "pages": [{"type": "patchouli:text", "text": "Cold damage text."}],
+            },
+            separators=(",", ":"),
+        )
+        work = plan_book_work(
+            self.patchouli_path, source, "ru_ru", RU["regex"], None, "force"
+        )
+        assert work is not None
+        cache = _MemoryCache()
+        cache.values[("ru", "Cold Damage")] = "Холод\nПовреждение"
+        engine = _Engine(
+            {
+                "Cold Damage": "Холодный урон",
+                "Cold damage text.": "Текст о холодном уроне.",
+            }
+        )
+        service = _Service(engine, cache)
+        logs = []
+        result = service.translate_dict(
+            dict(work.pending),
+            RU,
+            _callbacks(logs),
+            candidate_validator=lambda unit_id, candidate: validate_book_candidate(
+                work, unit_id, candidate
+            ),
+            preserve_source_structure=True,
+        )
+        self.assertEqual(result["json:/name"], "Холодный урон")
+        self.assertIn(("ru", "Cold Damage", False), cache.discarded)
+        self.assertEqual(cache.values[("ru", "Cold Damage")], "Холодный урон")
+        self.assertTrue(any("кэша отброшена" in message for message, _ in logs))
+
+    def test_ie_newline_falls_back_only_for_bad_line_and_manual_is_written(self):
+        path = "assets/immersiveengineering/manual/en_us/circuit_breakers.txt"
+        source = "Circuit Breakers\nClap on - Clap off\nKeep the network safe.\n"
+        ok, writer, cache, logs = self._run_processor(
+            path,
+            source,
+            {
+                "Circuit Breakers": "Автоматические выключатели",
+                "Clap on - Clap off": "Хлопок\nвыключает",
+                "Keep the network safe.": "Поддерживайте безопасность сети.",
+            },
+        )
+        self.assertTrue(ok)
+        target = path.replace("/en_us/", "/ru_ru/")
+        output = writer.writes[target].decode("utf-8")
+        self.assertEqual(output.count("\n"), source.count("\n"))
+        self.assertEqual(
+            output.splitlines(),
+            [
+                "Автоматические выключатели",
+                "Clap on - Clap off",
+                "Поддерживайте безопасность сети.",
+            ],
+        )
+        self.assertNotIn(("ru", "Clap on - Clap off"), cache.values)
+        self.assertFalse(any("отклонил реконструкцию книги" in message for message, _ in logs))
+
+    def test_introduced_literal_backslashes_are_rejected_before_cache(self):
+        path = "assets/productivebees/patchouli_books/guide/en_us/entries/cubee.json"
+        source = json.dumps(
+            {"name": "CuBee", "pages": [{"type": "patchouli:text", "text": "A copper bee."}]},
+            separators=(",", ":"),
+        )
+        ok, writer, cache, _logs = self._run_processor(
+            path,
+            source,
+            {
+                "CuBee": r"Ф\е\р\о",
+                "A copper bee.": "Медная пчела.",
+            },
+        )
+        self.assertTrue(ok)
+        target = path.replace("/en_us/", "/ru_ru/")
+        output = json.loads(writer.writes[target].decode("utf-8"))
+        self.assertEqual(output["name"], "CuBee")
+        self.assertEqual(output["pages"][0]["text"], "Медная пчела.")
+        self.assertNotIn(("ru", "CuBee"), cache.values)
+
+
+class PatchouliStableFingerprintV32Tests(unittest.TestCase):
+    def test_fingerprint_is_schema_based_not_translation_prose_classification(self):
+        path = "assets/example/patchouli_books/guide/en_us/entries/test.json"
+        source = json.dumps(
+            {
+                "name": "Cold Damage",
+                "description": "Long source description",
+                "pages": [{"type": "patchouli:text", "text": "Visible prose here"}],
+            },
+            separators=(",", ":"),
+        )
+        from mineai.formatkit_books_bridge import book_adapter_for
+
+        adapter = book_adapter_for(path)
+        assert adapter is not None
+        plan = adapter.prepare(path, source)
+        # A one-character target does not satisfy the adapter's prose heuristic,
+        # but that must not change which structural field locations exist.
+        output = adapter.apply(plan, {"json:/name": "Я"})
+        parsed = json.loads(output)
+        self.assertEqual(parsed["name"], "Я")
+        adapter.validate(source, output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_formatkit_modonomicon_description_ids_v341.py
+++ b/tests/test_formatkit_modonomicon_description_ids_v341.py
@@ -1,0 +1,89 @@
+import json
+import unittest
+
+from mineai.constants import LANGUAGES
+from mineai.formatkit_books_bridge import plan_book_work
+from mineai.formatkit_profile import MineAiModonomiconBookJsonAdapter
+
+
+RU = LANGUAGES["Русский"]
+PATH = (
+    "data/geneticsresequenced/modonomicon/books/guide/entries/negative_genes/"
+    "geneticsresequenced/poison.json"
+)
+
+
+class ModonomiconDescriptionIdV341Tests(unittest.TestCase):
+    def test_genetics_slash_description_ids_are_never_translation_units(self):
+        source = json.dumps(
+            {
+                "description": "book.geneticsresequenced.guide.negative_genes.geneticsresequenced/poison.description",
+                "name": "book.geneticsresequenced.guide.negative_genes.geneticsresequenced/poison.name",
+                "pages": [
+                    {
+                        "type": "modonomicon:text",
+                        "text": "book.geneticsresequenced.guide.negative_genes.geneticsresequenced/poison.page_0.text",
+                        "title": "book.geneticsresequenced.guide.negative_genes.geneticsresequenced/poison.page_0.title",
+                    },
+                    {
+                        "type": "modonomicon:text",
+                        "text": "book.geneticsresequenced.guide.negative_genes.geneticsresequenced/poison.page_1.text",
+                        "title": "book.geneticsresequenced.guide.negative_genes.geneticsresequenced/poison.page_1.title",
+                    },
+                ],
+            },
+            separators=(",", ":"),
+        )
+        adapter = MineAiModonomiconBookJsonAdapter()
+        plan = adapter.prepare(PATH, source)
+        self.assertEqual(plan.units, ())
+        self.assertEqual(adapter.apply(plan, {}), source)
+
+        work = plan_book_work(PATH, source, "ru_ru", RU["regex"], None, "force")
+        self.assertIsNotNone(work)
+        assert work is not None
+        self.assertEqual(work.pending, {})
+        self.assertEqual(work.preserved, {})
+        self.assertEqual(work.passthrough, {})
+
+    def test_literal_modonomicon_prose_still_translates(self):
+        source = json.dumps(
+            {
+                "description": "Poison weakens the target over time.",
+                "name": "Poison Gene",
+                "pages": [
+                    {
+                        "type": "modonomicon:text",
+                        "text": "This is visible player-facing prose.",
+                        "title": "Poison",
+                    }
+                ],
+            },
+            separators=(",", ":"),
+        )
+        plan = MineAiModonomiconBookJsonAdapter().prepare(PATH, source)
+        values = {unit.text for unit in plan.units}
+        self.assertEqual(
+            values,
+            {
+                "Poison weakens the target over time.",
+                "Poison Gene",
+                "This is visible player-facing prose.",
+                "Poison",
+            },
+        )
+
+    def test_prose_with_spaces_is_not_misclassified_as_description_id(self):
+        source = json.dumps(
+            {
+                "description": "Book. Genetics is fascinating to study.",
+                "pages": [],
+            },
+            separators=(",", ":"),
+        )
+        plan = MineAiModonomiconBookJsonAdapter().prepare(PATH, source)
+        self.assertEqual([unit.text for unit in plan.units], ["Book. Genetics is fascinating to study."])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_formatkit_patchouli_templates_v31.py
+++ b/tests/test_formatkit_patchouli_templates_v31.py
@@ -1,0 +1,127 @@
+import json
+import os
+import shutil
+import tempfile
+import unittest
+import zipfile
+from types import SimpleNamespace
+
+from mineai.constants import LANGUAGES
+from mineai.formatkit_books_bridge import build_book_output, plan_book_work
+from mineai.processors.formatkit_books_pilot import FormatKitBooksJarProcessor
+from mineai_formatkit import PatchouliBookJsonAdapter
+
+RU = LANGUAGES["Русский"]
+
+
+class PatchouliTemplateAdapterV31Tests(unittest.TestCase):
+    path = "assets/ars_nouveau/patchouli_books/worn_notebook/en_us/templates/glyph_recipe.json"
+
+    def test_processor_variables_are_never_exposed(self):
+        source = json.dumps({
+            "processor": "example.Processor",
+            "components": [
+                {"type": "patchouli:text", "text": "#tier#", "x": 0, "y": 105},
+                {"type": "patchouli:text", "text": "#mana_cost#", "x": 0, "y": 115},
+                {"type": "patchouli:text", "text": "#schools#", "x": 0, "y": 125},
+                {"type": "patchouli:header", "text": "block.ars_nouveau.scribes_table", "x": -1, "y": -1},
+            ],
+        }, separators=(",", ":"))
+        adapter = PatchouliBookJsonAdapter()
+        plan = adapter.prepare(self.path, source)
+        self.assertEqual(plan.units, ())
+        self.assertTrue(plan.metadata.get("patchouli_template_immutable"))
+        self.assertEqual(adapter.apply(plan, {}), source)
+        self.assertEqual(
+            adapter.target_path(self.path, "ru_ru"),
+            "assets/ars_nouveau/patchouli_books/worn_notebook/ru_ru/templates/glyph_recipe.json",
+        )
+
+    def test_current_sdk_keeps_even_literal_template_text_immutable(self):
+        path = "data/silentgear/patchouli_books/gears_guide/en_us/templates/compounding_recipe.json"
+        source = json.dumps({
+            "processor": "example.Processor",
+            "components": [
+                {"type": "header", "text": "#title", "x": 4, "y": 0},
+                {"type": "item", "item": "#item1", "x": 10, "y": 10},
+                {"type": "text", "text": "Result:", "x": 70, "y": 20},
+            ],
+        }, separators=(",", ":"))
+        adapter = PatchouliBookJsonAdapter()
+        plan = adapter.prepare(path, source)
+        self.assertEqual(plan.units, ())
+        self.assertEqual(adapter.apply(plan, {}), source)
+
+    def test_corrupted_existing_template_is_never_reused(self):
+        source = json.dumps({
+            "processor": "example.Processor",
+            "components": [
+                {"type": "patchouli:text", "text": "#tier#", "x": 0, "y": 105},
+                {"type": "patchouli:text", "text": "#mana_cost#", "x": 0, "y": 115},
+            ],
+        }, separators=(",", ":"))
+        corrupted = json.dumps({
+            "processor": "example.Processor",
+            "components": [
+                {"type": "patchouli:text", "text": "#ярус#", "x": 0, "y": 105},
+                {"type": "patchouli:text", "text": "#стоимость_маны#", "x": 0, "y": 115},
+            ],
+        }, ensure_ascii=False, separators=(",", ":"))
+        work = plan_book_work(self.path, source, "ru_ru", RU["regex"], corrupted, "append")
+        assert work is not None
+        self.assertEqual(work.adapter_name, "patchouli-template-json")
+        self.assertEqual(work.total_translatable, 0)
+        self.assertTrue(work.emit_structural_copy)
+        self.assertEqual(build_book_output(work, {}), source)
+
+    def test_mixed_variable_text_is_copied_instead_of_guessed(self):
+        source = json.dumps({
+            "components": [{"type": "patchouli:text", "text": "Cost: #cost", "x": 0, "y": 0}]
+        })
+        adapter = PatchouliBookJsonAdapter()
+        plan = adapter.prepare(self.path, source)
+        self.assertEqual(plan.units, ())
+        self.assertEqual(adapter.apply(plan, {}), source)
+
+
+class PatchouliTemplateProcessorV31Tests(unittest.TestCase):
+    def test_zero_unit_template_is_still_copied_to_target_locale(self):
+        temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, temp_dir)
+        jar = os.path.join(temp_dir, "templates.jar")
+        path = "assets/ars_nouveau/patchouli_books/worn_notebook/en_us/templates/glyph_recipe.json"
+        source = json.dumps({
+            "processor": "example.Processor",
+            "components": [{"type": "patchouli:text", "text": "#tier#", "x": 0, "y": 105}],
+        }, separators=(",", ":"))
+        with zipfile.ZipFile(jar, "w") as z:
+            z.writestr(path, source)
+
+        class Service:
+            config = SimpleNamespace(getboolean=lambda *_args, **_kwargs: True)
+            def translate_dict(self, *_args, **_kwargs):
+                raise AssertionError("zero-unit template must not call the LLM")
+
+        class Writer:
+            def __init__(self): self.writes = {}
+            def write(self, path, payload): self.writes[path] = payload
+
+        writer = Writer()
+        processor = FormatKitBooksJarProcessor(
+            Service(),
+            SimpleNamespace(should_run=lambda: True),
+            SimpleNamespace(on_log=lambda *_args: None),
+        )
+        with zipfile.ZipFile(jar) as z:
+            locale = {e.filename.lower(): e for e in z.infolist()}
+            ok = processor._process_book_json(
+                z, None, z.getinfo(path), locale, RU, "append",
+                "resourcepack", writer, "Ars Nouveau", set(),
+            )
+        self.assertTrue(ok)
+        target = path.replace("/en_us/", "/ru_ru/")
+        self.assertEqual(writer.writes[target].decode("utf-8"), source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_formatkit_pilot.py
+++ b/tests/test_formatkit_pilot.py
@@ -1,0 +1,277 @@
+import io
+import json
+import unittest
+import zipfile
+from types import SimpleNamespace
+
+from mineai.constants import LANGUAGES
+from mineai.formatkit_bridge import (
+    FORMATKIT_SOURCE_SHA,
+    build_locale_output,
+    plan_locale_work,
+    target_path_for_locale,
+)
+from mineai.processors.formatkit_pilot import (
+    FormatKitJarProcessor,
+    FormatKitStringEstimator,
+)
+
+
+RU = LANGUAGES["Русский"]
+EXPECTED_FORMATKIT_SHA = "5cfd1e28c1581caf144f9a5ef767c631d9199f8c"
+
+
+class FormatKitBridgeTests(unittest.TestCase):
+    def test_pilot_is_pinned_to_certified_formatkit_snapshot(self) -> None:
+        self.assertEqual(FORMATKIT_SOURCE_SHA, EXPECTED_FORMATKIT_SHA)
+
+    def test_append_reuses_safe_target_and_filters_technical_values(self) -> None:
+        source = json.dumps(
+            {
+                "a": "Hello",
+                "b": "Run /create with %s",
+                "tech": "demo.resource_id",
+            },
+            ensure_ascii=False,
+        )
+        target = json.dumps(
+            {
+                "a": "Привет",
+                "b": "Run /create with %s",
+            },
+            ensure_ascii=False,
+        )
+        work = plan_locale_work(
+            "assets/demo/lang/en_us.json",
+            source,
+            "ru_ru",
+            target,
+            "append",
+        )
+        self.assertIsNotNone(work)
+        assert work is not None
+        self.assertEqual(work.total_translatable, 2)
+        self.assertEqual(set(work.pending), {"key:b"})
+        self.assertNotIn("key:tech", work.pending)
+        self.assertIn("[#", work.pending["key:b"])
+
+        output = json.loads(build_locale_output(work, {"key:b": "Запустить [#0#] с [#1#]"}))
+        self.assertEqual(output["a"], "Привет")
+        self.assertIn("/create", output["b"])
+        self.assertIn("%s", output["b"])
+        self.assertEqual(output["tech"], "demo.resource_id")
+
+    def test_unicode_prose_slash_is_not_protected_but_real_command_is(self) -> None:
+        work = plan_locale_work(
+            "assets/demo/lang/en_us.json",
+            '{"a":"Документация/Wiki and /create"}',
+            "ru_ru",
+            None,
+            "force",
+        )
+        assert work is not None
+        text = work.pending["key:a"]
+        self.assertIn("Документация/Wiki", text)
+        self.assertNotIn("/create", text)
+        self.assertIn("[#", text)
+
+    def test_identical_duplicate_key_is_one_unit_and_updates_all_aliases(self) -> None:
+        source = '{\n  "same": "Hello",\n  "same": "Hello"\n}\n'
+        work = plan_locale_work(
+            "assets/demo/lang/en_us.json",
+            source,
+            "ru_ru",
+            None,
+            "append",
+        )
+        assert work is not None
+        self.assertEqual(list(work.pending), ["key:same"])
+        output = build_locale_output(work, {"key:same": "Привет"})
+        self.assertEqual(output.count('"Привет"'), 2)
+
+    def test_tempad_structured_component_keeps_color_and_index(self) -> None:
+        source_value = [
+            "",
+            {"text": "Open Tempad", "color": "gold"},
+            {"index": 1, "color": "gray"},
+        ]
+        source = json.dumps({"tempad.demo": source_value}, ensure_ascii=False)
+        work = plan_locale_work(
+            "assets/tempad/lang/en_us.json",
+            source,
+            "ru_ru",
+            None,
+            "append",
+        )
+        assert work is not None
+        self.assertEqual(len(work.pending), 1)
+        unit_id = next(iter(work.pending))
+        output = json.loads(build_locale_output(work, {unit_id: "Открыть Темпад"}))
+        self.assertEqual(output["tempad.demo"][1]["text"], "Открыть Темпад")
+        self.assertEqual(output["tempad.demo"][1]["color"], "gold")
+        self.assertEqual(output["tempad.demo"][2], {"index": 1, "color": "gray"})
+
+    def test_serialized_component_exposes_only_visible_text_leaves(self) -> None:
+        nested = json.dumps(
+            [
+                {"text": "There is an Update for "},
+                {
+                    "text": "Actually Additions",
+                    "color": "dark_green",
+                    "clickEvent": {"action": "open_url", "value": "%s"},
+                },
+            ],
+            separators=(",", ":"),
+        )
+        source = json.dumps({"update.message": nested})
+        work = plan_locale_work(
+            "assets/actuallyadditions/lang/en_us.json",
+            source,
+            "ru_ru",
+            None,
+            "append",
+        )
+        assert work is not None
+        self.assertEqual(len(work.pending), 2)
+        translated = {}
+        for unit_id, text in work.pending.items():
+            translated[unit_id] = (
+                "Доступно обновление для " if "There is" in text else "Actually Additions"
+            )
+        output = json.loads(build_locale_output(work, translated))
+        decoded = json.loads(output["update.message"])
+        self.assertEqual(decoded[0]["text"], "Доступно обновление для ")
+        self.assertEqual(decoded[1]["color"], "dark_green")
+        self.assertEqual(decoded[1]["clickEvent"], {"action": "open_url", "value": "%s"})
+
+    def test_malformed_optional_target_is_discarded_not_structural_truth(self) -> None:
+        work = plan_locale_work(
+            "assets/demo/lang/en_us.json",
+            '{"a":"Hello"}',
+            "ru_ru",
+            '{"a":"Привет"',
+            "append",
+        )
+        assert work is not None
+        self.assertIsNotNone(work.target_parse_error)
+        self.assertEqual(set(work.pending), {"key:a"})
+
+    def test_mineai_skip_keeps_legacy_source_identical_pending_semantics(self) -> None:
+        source = '{"a":"Hello","b":"World"}'
+        target = '{"a":"Hello","b":"Мир"}'
+        work = plan_locale_work(
+            "assets/demo/lang/en_us.json",
+            source,
+            "ru_ru",
+            target,
+            "skip",
+        )
+        assert work is not None
+        self.assertEqual(set(work.pending), {"key:a"})
+
+    def test_config_locale_target_paths_are_exact_allow_list(self) -> None:
+        self.assertEqual(
+            target_path_for_locale("config/collapsiblegroups/lang/en_us.json", "ru_ru"),
+            "config/collapsiblegroups/lang/ru_ru.json",
+        )
+        self.assertEqual(
+            target_path_for_locale("config/jaopca/lang/en_us.json", "ru_ru"),
+            "config/jaopca/lang/ru_ru.json",
+        )
+        self.assertIsNone(target_path_for_locale("config/random/lang/en_us.json", "ru_ru"))
+
+    def test_missing_translation_result_falls_back_to_source_and_validates(self) -> None:
+        source = '{"a":"Hello %s"}'
+        work = plan_locale_work(
+            "assets/demo/lang/en_us.json",
+            source,
+            "ru_ru",
+            None,
+            "append",
+        )
+        assert work is not None
+        self.assertEqual(build_locale_output(work, {}), source)
+
+
+class FormatKitPilotProcessorTests(unittest.TestCase):
+    @staticmethod
+    def _archive(source: str, target: str | None = None):
+        data = io.BytesIO()
+        with zipfile.ZipFile(data, "w") as out:
+            out.writestr("assets/demo/lang/en_us.json", source)
+            if target is not None:
+                out.writestr("assets/demo/lang/ru_ru.json", target)
+        data.seek(0)
+        return data
+
+    def test_estimator_uses_same_formatkit_pending_count(self) -> None:
+        source = '{"a":"Hello","b":"Run /create with %s","tech":"demo.resource_id"}'
+        target = '{"a":"Привет","b":"Run /create with %s"}'
+        data = self._archive(source, target)
+        with zipfile.ZipFile(data, "r") as archive:
+            item = archive.getinfo("assets/demo/lang/en_us.json")
+            locale = {entry.filename.lower(): entry for entry in archive.infolist()}
+            estimator = FormatKitStringEstimator(SimpleNamespace())
+            count = estimator._count_lang(
+                archive,
+                item,
+                locale,
+                "ru_ru.json",
+                "append",
+                RU["regex"],
+            )
+        self.assertEqual(count, 1)
+
+    def test_resourcepack_processor_writes_validated_formatkit_output(self) -> None:
+        source = '{\n  "a": "Hello",\n  "b": "Run /create with %s"\n}\n'
+        target = '{"a":"Привет","b":"Run /create with %s"}'
+        data = self._archive(source, target)
+
+        class Service:
+            def translate_dict(self, pending, _lang, _callbacks, **_kwargs):
+                self.pending = dict(pending)
+                unit_id = next(iter(pending))
+                return {unit_id: "Запустить [#0#] с [#1#]"}
+
+        class PackWriter:
+            def __init__(self):
+                self.writes = {}
+
+            def write(self, path, payload):
+                self.writes[path] = payload
+
+        service = Service()
+        writer = PackWriter()
+        logs = []
+        callbacks = SimpleNamespace(on_log=lambda text, color: logs.append((text, color)))
+        state = SimpleNamespace(should_run=lambda: True)
+        processor = FormatKitJarProcessor(service, state, callbacks)
+
+        with zipfile.ZipFile(data, "r") as archive:
+            item = archive.getinfo("assets/demo/lang/en_us.json")
+            locale = {entry.filename.lower(): entry for entry in archive.infolist()}
+            modified = processor._process_lang_entry(
+                archive,
+                None,
+                item,
+                locale,
+                "ru_ru.json",
+                RU,
+                "append",
+                "resourcepack",
+                writer,
+                "Demo",
+                set(),
+            )
+
+        self.assertTrue(modified)
+        payload = writer.writes["assets/demo/lang/ru_ru.json"].decode("utf-8")
+        output = json.loads(payload)
+        self.assertEqual(output["a"], "Привет")
+        self.assertIn("/create", output["b"])
+        self.assertIn("%s", output["b"])
+        self.assertIn("[Интерфейс/FormatKit]", "\n".join(text for text, _ in logs))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_formatkit_pilot_v2.py
+++ b/tests/test_formatkit_pilot_v2.py
@@ -1,0 +1,135 @@
+import json
+import unittest
+
+from mineai.constants import LANGUAGES
+from mineai.engines.base import EngineCallbacks, EngineItem
+from mineai.engines.llm_v2 import (
+    BatchLlmEngine,
+    build_translation_prompt,
+    marker_validation_error,
+)
+from mineai.formatkit_bridge import plan_locale_work
+from mineai.text_processing import mask_protected_fragments
+
+
+RU = LANGUAGES["Русский"]
+
+
+def callbacks() -> EngineCallbacks:
+    return EngineCallbacks(
+        should_run=lambda: True,
+        wait_if_paused=lambda: None,
+        on_log=lambda _message, _tag: None,
+        on_status=lambda _message: None,
+    )
+
+
+def prompt_payload(prompt: str) -> dict[str, str]:
+    return json.loads(prompt.split("DATA:\n", 1)[1])
+
+
+class PilotV2LlmSafetyTests(unittest.TestCase):
+    def test_manifest_uses_real_source_order(self) -> None:
+        prompt = build_translation_prompt(
+            {"key": "Put [#9#] in [#13#][#10#] then [#11#]"},
+            "Russian",
+            mode="safe",
+            context="",
+        )
+        self.assertIn('"key": [#9#] [#13#] [#10#] [#11#]', prompt)
+        self.assertIn("SOURCE ORDER", prompt)
+
+    def test_same_marker_counts_in_wrong_order_are_rejected(self) -> None:
+        source = "The [#0#]Drill[#1#] uses [#2#]CF[#3#]"
+        reordered = "Бур [#0#][#1#] использует [#3#]CF[#2#]"
+        self.assertEqual(
+            marker_validation_error(reordered, source),
+            "Изменён порядок маркеров [#N#]",
+        )
+
+    def test_real_actually_additions_markup_reordering_is_rejected(self) -> None:
+        source = "The <item>Farmer<r> can <imp>plant and harvest<r> crops."
+        masked, _mapping = mask_protected_fragments(source)
+        broken = (
+            masked.replace("[#1#]", "__M1__")
+            .replace("[#2#]", "[#1#]")
+            .replace("__M1__", "[#2#]")
+        )
+        self.assertEqual(
+            marker_validation_error(broken, masked),
+            "Изменён порядок маркеров [#N#]",
+        )
+
+    def test_bare_hash_marker_hallucination_is_rejected_and_retried(self) -> None:
+        calls: list[str] = []
+
+        def call_api(prompt: str, _limit: int) -> str:
+            calls.append(prompt)
+            if "BROKEN TRANSLATION:" in prompt:
+                return json.dumps({"key": "Размещение наверху"}, ensure_ascii=False)
+            normal = [p for p in calls if "BROKEN TRANSLATION:" not in p]
+            if len(normal) == 1:
+                return json.dumps({"key": "#0#Размещение наверху"}, ensure_ascii=False)
+            return json.dumps({"key": "Размещение наверху"}, ensure_ascii=False)
+
+        engine = BatchLlmEngine(call_api=call_api)
+        items = {"key": EngineItem("key", "Place on top", "Place on top")}
+        result = engine.translate_batch(items, RU, callbacks())
+        self.assertEqual(result["key"], "Размещение наверху")
+        self.assertEqual(sum("BROKEN TRANSLATION:" in p for p in calls), 1)
+
+    def test_eight_marker_string_is_sent_alone(self) -> None:
+        calls: list[set[str]] = []
+        source = "A " + " ".join(f"[#{index}#]" for index in range(8))
+
+        def call_api(prompt: str, _limit: int) -> str:
+            payload = prompt_payload(prompt)
+            calls.append(set(payload))
+            if "complex" in payload:
+                return json.dumps(
+                    {"complex": source.replace("A ", "Текст ", 1)},
+                    ensure_ascii=False,
+                )
+            return json.dumps({"simple": "Просто"}, ensure_ascii=False)
+
+        engine = BatchLlmEngine(call_api=call_api)
+        result = engine.translate_batch(
+            {
+                "complex": EngineItem("complex", source, source),
+                "simple": EngineItem("simple", "Simple", "Simple"),
+            },
+            RU,
+            callbacks(),
+        )
+        self.assertIn("complex", result)
+        self.assertEqual(result["simple"], "Просто")
+        self.assertEqual(calls, [{"complex"}, {"simple"}])
+
+
+class PilotV2TechnicalFilterTests(unittest.TestCase):
+    def test_obvious_runtime_technical_values_do_not_enter_llm_pending(self) -> None:
+        source = json.dumps(
+            {
+                "shift": "[SHIFT]",
+                "coords": "9.17 N 19.89 E",
+                "uuid": "UUID: %s",
+                "formula": "+%s (%d)",
+                "lower_true": "true",
+                "visible": "Requires %s power",
+                "visible_true": "True",
+            }
+        )
+        work = plan_locale_work(
+            "assets/demo/lang/en_us.json",
+            source,
+            "ru_ru",
+            None,
+            "force",
+        )
+        assert work is not None
+        self.assertEqual(work.total_translatable, 2)
+        self.assertEqual(set(work.pending), {"key:visible", "key:visible_true"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_formatkit_pilot_v33.py
+++ b/tests/test_formatkit_pilot_v33.py
@@ -1,0 +1,328 @@
+import json
+import os
+import shutil
+import tempfile
+import unittest
+import zipfile
+from types import SimpleNamespace
+
+from mineai.constants import LANGUAGES
+from mineai.engines.base import EngineCallbacks, TranslationEngine
+from mineai.engines.service import TranslationService
+from mineai.formatkit_books_bridge import plan_book_work, validate_book_candidate
+from mineai.formatkit_bridge import (
+    modonomicon_locale_adapter,
+    plan_locale_work,
+    validate_locale_candidate,
+)
+from mineai.processors.formatkit_books_pilot import (
+    FormatKitBooksJarProcessor,
+    FormatKitBooksStringEstimator,
+    FormatKitModpackAnalyzer,
+)
+from mineai.runtime.state import JobState
+from mineai_formatkit import ModonomiconBookJsonAdapter, ValidationError
+
+RU = LANGUAGES["Русский"]
+
+
+class _Config:
+    def getboolean(self, section, key):
+        if (section, key) == ("GENERAL", "smart_glue"):
+            return True
+        if (section, key) == ("AI", "fallback_google"):
+            return False
+        raise AssertionError((section, key))
+
+    def getint(self, _section, _key, fallback=0):
+        return fallback
+
+
+class _MemoryCache:
+    def __init__(self):
+        self.values = {}
+        self.identities = set()
+        self.discarded = []
+
+    def get(self, api_code, source):
+        key = (api_code, source)
+        if key in self.values:
+            return self.values[key], False
+        if key in self.identities:
+            return source, False
+        return None, False
+
+    def set(self, api_code, source, translated):
+        self.values[(api_code, source)] = translated
+
+    def set_identity(self, api_code, source):
+        self.identities.add((api_code, source))
+
+    def discard(self, api_code, source, *, include_imported=False):
+        self.values.pop((api_code, source), None)
+        self.identities.discard((api_code, source))
+        self.discarded.append((api_code, source, include_imported))
+
+    def save_if_threshold(self):
+        pass
+
+
+class _Engine(TranslationEngine):
+    def __init__(self, responses):
+        self.responses = responses
+
+    def translate_batch(self, items, target_lang, callbacks):
+        return {
+            key: self.responses.get(item.original, item.original)
+            for key, item in items.items()
+        }
+
+
+class _Service(TranslationService):
+    def __init__(self, responses):
+        self.cache_for_test = _MemoryCache()
+        super().__init__("ai", self.cache_for_test, _Config(), ai_batch=20)
+        self.engine_for_test = _Engine(responses)
+
+    def _build_engine(self, context="", prompt_type="mods"):
+        return self.engine_for_test
+
+
+class _Writer:
+    def __init__(self):
+        self.writes = {}
+
+    def write(self, path, payload):
+        self.writes[path] = payload
+
+
+def _callbacks(logs):
+    return EngineCallbacks(
+        should_run=lambda: True,
+        wait_if_paused=lambda: None,
+        on_log=lambda message, tag: logs.append((message, tag)),
+        on_status=lambda _message: None,
+        on_progress=lambda _count: None,
+    )
+
+
+class FormatKitPilotV33Tests(unittest.TestCase):
+    book_path = "data/demo/modonomicon/books/guide/entries/start.json"
+    lang_path = "assets/demo/lang/en_us.json"
+
+    def _make_jar(self, files):
+        root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, root)
+        jar = os.path.join(root, "demo.jar")
+        with zipfile.ZipFile(jar, "w") as archive:
+            for path, payload in files.items():
+                archive.writestr(path, payload)
+        return jar
+
+    def test_modonomicon_book_translates_only_literal_prose(self):
+        source = json.dumps(
+            {
+                "id": "demo:start",
+                "name": "book.demo.start.name",
+                "description": "Visible literal description",
+                "pages": [
+                    {
+                        "type": "modonomicon:text",
+                        "title": "Literal title",
+                        "text": "Read [the next entry](entry://demo/next).",
+                        "recipe": "demo:machine",
+                    }
+                ],
+            },
+            separators=(",", ":"),
+        )
+        adapter = ModonomiconBookJsonAdapter()
+        plan = adapter.prepare(self.book_path, source)
+        self.assertEqual(
+            {unit.id for unit in plan.units},
+            {"json:/description", "json:/pages/0/title", "json:/pages/0/text"},
+        )
+        text_unit = plan.by_id()["json:/pages/0/text"]
+        self.assertIn("the next entry", text_unit.text)
+        self.assertNotIn("entry://demo/next", text_unit.text)
+        translated = {
+            "json:/description": "Видимое описание",
+            "json:/pages/0/title": "Заголовок",
+            "json:/pages/0/text": text_unit.text.replace("Read", "Читайте").replace(
+                "the next entry", "следующую запись"
+            ),
+        }
+        output = json.loads(adapter.apply(plan, translated))
+        self.assertEqual(output["id"], "demo:start")
+        self.assertEqual(output["name"], "book.demo.start.name")
+        self.assertEqual(output["pages"][0]["recipe"], "demo:machine")
+        self.assertEqual(
+            output["pages"][0]["text"],
+            "Читайте [следующую запись](entry://demo/next).",
+        )
+
+    def test_modonomicon_candidate_rejects_marker_reorder_and_newline(self):
+        source = json.dumps(
+            {
+                "pages": [
+                    {
+                        "type": "modonomicon:text",
+                        "text": "Open [Guide](entry://demo/guide) and [Next](entry://demo/next).",
+                    }
+                ]
+            },
+            separators=(",", ":"),
+        )
+        work = plan_book_work(self.book_path, source, "ru_ru", RU["regex"], None, "force")
+        self.assertIsNotNone(work)
+        unit_id, masked = next(iter(work.pending.items()))
+        markers = [fragment.placeholder for fragment in work.units_by_id[unit_id].protected]
+        self.assertGreaterEqual(len(markers), 2)
+        bad_order = masked.replace(markers[0], "__A__", 1)
+        bad_order = bad_order.replace(markers[1], markers[0], 1)
+        bad_order = bad_order.replace("__A__", markers[1], 1)
+        ok, _reason = validate_book_candidate(work, unit_id, bad_order)
+        self.assertFalse(ok)
+        ok, reason = validate_book_candidate(work, unit_id, masked + "\nBAD")
+        self.assertFalse(ok)
+        self.assertIn("line-break", reason)
+
+    def test_modonomicon_lenient_raw_newline_identity_is_lexically_preserved(self):
+        source = '{"name":"Improved Anvil Smashing","pages":[{"type":"modonomicon:text","text":"First line\\\n\t\\\n\tSecond line"}],"id":"demo:anvil"}'
+        adapter = ModonomiconBookJsonAdapter()
+        plan = adapter.prepare(self.book_path, source)
+        identity = {unit.id: unit.text for unit in plan.units}
+        self.assertEqual(adapter.apply(plan, identity), source)
+        text_unit = next(unit for unit in plan.units if unit.id == "json:/pages/0/text")
+        with self.assertRaises(ValidationError):
+            adapter.validate_candidate(plan, text_unit.id, text_unit.text + "\nBAD")
+
+    def test_modonomicon_locale_preserves_runtime_markdown_and_marker_order(self):
+        source = json.dumps(
+            {
+                "book.demo.start": "Open [Guide](entry://demo/guide) with %s",
+                "ui.demo": "General UI",
+            },
+            separators=(",", ":"),
+        )
+        work = plan_locale_work(
+            self.lang_path,
+            source,
+            "ru_ru",
+            None,
+            "force",
+            adapter=modonomicon_locale_adapter(),
+            key_filter=lambda key: key.startswith("book."),
+        )
+        self.assertIsNotNone(work)
+        self.assertEqual(set(work.pending), {"key:book.demo.start"})
+        masked = work.pending["key:book.demo.start"]
+        placeholders = [fragment.placeholder for fragment in work.plan.source_plan.by_id()["key:book.demo.start"].protected]
+        self.assertGreaterEqual(len(placeholders), 2)
+        translated = masked.replace("Open", "Откройте").replace("Guide", "Руководство")
+        ok, reason = validate_locale_candidate(work, "key:book.demo.start", translated)
+        self.assertTrue(ok, reason)
+        swapped = translated.replace(placeholders[0], "__A__", 1).replace(placeholders[1], placeholders[0], 1).replace("__A__", placeholders[1], 1)
+        ok, _reason = validate_locale_candidate(work, "key:book.demo.start", swapped)
+        self.assertFalse(ok)
+
+    def test_layered_locale_protection_manifest_follows_source_occurrence_order(self):
+        adapter = modonomicon_locale_adapter()
+        source = json.dumps(
+            {"book.demo.layered": "&7Before %s [Guide](entry://demo/guide) after"},
+            separators=(",", ":"),
+        )
+        plan = adapter.prepare(self.lang_path, source)
+        unit = plan.by_id()["key:book.demo.layered"]
+        marker_order = [m.group(0) for m in __import__("re").finditer(r"\[#\d+#\]", unit.text)]
+        self.assertEqual(marker_order, [fragment.placeholder for fragment in unit.protected])
+        adapter.validate_candidate(plan, unit.id, unit.text.replace("Before", "До").replace("after", "после"))
+
+    def test_books_only_processor_emits_modonomicon_locale_and_datapack_overlay(self):
+        lang = json.dumps(
+            {
+                "book.demo.start.name": "Getting Started",
+                "book.demo.start.text": "Open [Guide](entry://demo/guide).",
+                "ui.demo": "Do not translate in books-only mode",
+            },
+            separators=(",", ":"),
+        )
+        book = json.dumps(
+            {
+                "name": "book.demo.start.name",
+                "description": "Literal description",
+                "id": "demo:start",
+            },
+            separators=(",", ":"),
+        )
+        jar = self._make_jar({self.lang_path: lang, self.book_path: book})
+        service = _Service(
+            {
+                "Getting Started": "Начало работы",
+                "Open [#0#]Guide[#1#].": "Откройте [#0#]Руководство[#1#].",
+                "Literal description": "Литеральное описание",
+            }
+        )
+        writer = _Writer()
+        logs = []
+        state = SimpleNamespace(should_run=lambda: True, wait_if_paused=lambda: None)
+        processor = FormatKitBooksJarProcessor(service, state, _callbacks(logs))
+        processor.process(
+            jar,
+            target_lang=RU,
+            mode="force",
+            output_mode="resourcepack",
+            translate_mods=False,
+            translate_books=True,
+            pack_writer=writer,
+        )
+        self.assertIn("assets/demo/lang/ru_ru.json", writer.writes)
+        self.assertIn(self.book_path, writer.writes)
+        locale_out = json.loads(writer.writes["assets/demo/lang/ru_ru.json"].decode("utf-8"))
+        data_out = json.loads(writer.writes[self.book_path].decode("utf-8"))
+        self.assertEqual(locale_out["book.demo.start.name"], "Начало работы")
+        self.assertEqual(locale_out["ui.demo"], "Do not translate in books-only mode")
+        self.assertEqual(data_out["description"], "Литеральное описание")
+        self.assertEqual(data_out["id"], "demo:start")
+        self.assertTrue(any("Modonomicon Locale/FormatKit" in message for message, _ in logs))
+        self.assertTrue(any("Modonomicon/FormatKit" in message for message, _ in logs))
+
+    def test_modonomicon_analyzer_and_estimator_share_the_same_plan(self):
+        lang = json.dumps(
+            {
+                "book.demo.name": "Guide Name",
+                "book.demo.text": "Guide Text",
+                "ui.demo": "UI Text",
+            },
+            separators=(",", ":"),
+        )
+        book = json.dumps(
+            {"name": "book.demo.name", "description": "Literal page description", "id": "demo:start"},
+            separators=(",", ":"),
+        )
+        jar = self._make_jar({self.lang_path: lang, self.book_path: book})
+        state = JobState()
+        state.start()
+        estimator = FormatKitBooksStringEstimator(state)
+        estimated = estimator._estimate_jar(
+            jar, "ru_ru.json", RU, "force", False, True, False
+        )
+        rows = []
+        analyzer = FormatKitModpackAnalyzer(state)
+        analyzed = analyzer._analyze_jar(
+            jar,
+            "ru_ru.json",
+            RU["regex"],
+            False,
+            True,
+            lambda *row: rows.append(row),
+            "Demo",
+        )
+        self.assertEqual(estimated, 3)
+        self.assertEqual(analyzed, (3, 0))
+        self.assertTrue(any("Modonomicon Locale/FormatKit" in row[2] for row in rows))
+        self.assertTrue(any("Modonomicon/FormatKit" in row[2] for row in rows))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_formatkit_sdk_sync_v34.py
+++ b/tests/test_formatkit_sdk_sync_v34.py
@@ -1,0 +1,251 @@
+import hashlib
+import json
+import re
+import unittest
+from pathlib import Path
+
+from mineai.constants import LANGUAGES
+from mineai.formatkit_books_bridge import (
+    build_book_output,
+    plan_book_work,
+    target_path_for_book,
+)
+from mineai.formatkit_bridge import (
+    build_locale_output,
+    locale_adapter_for,
+    modonomicon_locale_adapter,
+    plan_locale_work,
+)
+from mineai_formatkit import (
+    FORMATKIT_SOURCE_SHA,
+    FORMATKIT_VENDOR_BLOBS,
+    ImmersiveEngineeringManualAdapter,
+    ModonomiconBookJsonAdapter,
+    PatchouliBookJsonAdapter,
+)
+
+RU = LANGUAGES["Русский"]
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _git_blob_sha(payload: bytes) -> str:
+    header = f"blob {len(payload)}\0".encode("ascii")
+    return hashlib.sha1(header + payload).hexdigest()
+
+
+def _canonical_git_text_bytes(path: Path) -> bytes:
+    # Git may materialize text files with CRLF on Windows even though the
+    # repository blob is canonical LF. Verify the repository-equivalent text,
+    # not checkout-specific line endings.
+    text = path.read_text(encoding="utf-8")
+    return text.replace("\r\n", "\n").replace("\r", "\n").encode("utf-8")
+
+
+class FormatKitSdkSyncV34Tests(unittest.TestCase):
+    def test_active_sdk_modules_are_exactly_pinned_to_formatkit_commit(self):
+        self.assertEqual(FORMATKIT_SOURCE_SHA, "5cfd1e28c1581caf144f9a5ef767c631d9199f8c")
+        sdk_root = ROOT / "mineai_formatkit"
+        for filename, expected_blob in FORMATKIT_VENDOR_BLOBS.items():
+            payload = _canonical_git_text_bytes(sdk_root / filename)
+            self.assertEqual(
+                _git_blob_sha(payload),
+                expected_blob,
+                f"vendored SDK module drifted: {filename}",
+            )
+        self.assertFalse((sdk_root / "patchouli_template.py").exists())
+
+    def test_book_bridge_does_not_reach_into_sdk_private_parsers(self):
+        source = (ROOT / "mineai" / "formatkit_books_bridge.py").read_text(encoding="utf-8")
+        self.assertNotIn("._parse(", source)
+        self.assertNotIn("._protect(", source)
+        self.assertNotIn("PatchouliTemplateJsonAdapter", source)
+        self.assertNotIn("validate_translation_candidate", source)
+
+    def test_normal_locale_path_uses_one_modonomicon_aware_sdk_adapter(self):
+        adapter = locale_adapter_for("assets/demo/lang/en_us.json")
+        self.assertIs(adapter, modonomicon_locale_adapter())
+        source = json.dumps(
+            {"book.demo": "&7Open [Guide](entry://demo/guide) with %s"},
+            separators=(",", ":"),
+        )
+        plan = adapter.prepare("assets/demo/lang/en_us.json", source)
+        unit = plan.by_id()["key:book.demo"]
+        marker_order = [m.group(0) for m in re.finditer(r"\[#\d+#\]", unit.text)]
+        self.assertEqual(marker_order, [fragment.placeholder for fragment in unit.protected])
+
+    def test_unsafe_existing_modonomicon_value_cannot_drop_the_whole_locale(self):
+        path = "assets/occultism/lang/en_us.json"
+        source = json.dumps(
+            {
+                "book.safe": "Visible safe text",
+                "book.legacy": "Read **carefully** now",
+                "screen.label": "Settings",
+            },
+            separators=(",", ":"),
+        )
+        target = json.dumps(
+            {
+                "book.safe": "Безопасный перевод",
+                # Legacy target prose lost Modonomicon's source-owned emphasis.
+                # The SDK planner can initially consider the value reusable,
+                # but full reconstruction must reject it.
+                "book.legacy": "Читайте внимательно",
+                "screen.label": "Настройки",
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        work = plan_locale_work(
+            path,
+            source,
+            "ru_ru",
+            target,
+            "append",
+            adapter=modonomicon_locale_adapter(),
+            key_filter=lambda key: key.startswith("book."),
+        )
+        assert work is not None
+
+        # Reproduces the runtime v3.4 failure: direct SDK build rejects one
+        # reused legacy value and would otherwise make MineAI omit ru_ru.json.
+        with self.assertRaisesRegex(ValueError, "Modonomicon lang markup changed"):
+            work.planner.build(work.plan, {})
+
+        output = json.loads(build_locale_output(work, {}))
+        self.assertEqual(output["book.safe"], "Безопасный перевод")
+        self.assertEqual(output["screen.label"], "Настройки")
+        # Only the unsafe reused unit falls back to canonical source text.
+        self.assertEqual(output["book.legacy"], "Read **carefully** now")
+
+
+class PatchouliSemanticOwnershipV34Tests(unittest.TestCase):
+    path = "assets/apotheosis/patchouli_books/apoth_chronicle/en_us/entries/adventure/affixes.json"
+
+    def _source(self):
+        return json.dumps(
+            {
+                "pages": [
+                    {
+                        "type": "patchouli:text",
+                        "text": "An $(6)Affix$() is the driving force behind Affix Items.",
+                    }
+                ]
+            },
+            separators=(",", ":"),
+        )
+
+    def test_style_payload_is_a_semantic_child_and_old_flat_cache_shape_cannot_hit(self):
+        work = plan_book_work(self.path, self._source(), "ru_ru", RU["regex"], None, "force")
+        assert work is not None
+        outer = next(unit for unit in work.source_plan.units if unit.kind == "patchouli-text")
+        child = next(unit for unit in work.source_plan.units if unit.kind == "patchouli-semantic-child")
+        self.assertEqual(child.text, "Affix")
+        self.assertTrue(work.target_reuse_disabled)
+        old_v33_cache_source = "An [#0#]Affix[#1#] is the driving force behind Affix Items."
+        self.assertNotIn(old_v33_cache_source, work.pending.values())
+
+        translated = {
+            outer.id: outer.text.replace("An ", "").replace(
+                " is the driving force behind Affix Items.",
+                " — основа предметов с аффиксами.",
+            ),
+            child.id: "Аффикс",
+        }
+        output = json.loads(build_book_output(work, translated))
+        text = output["pages"][0]["text"]
+        self.assertIn("$(6)Аффикс$()", text)
+        self.assertNotIn("$(6) — основа", text)
+
+    def test_old_semantically_drifted_append_target_is_quarantined(self):
+        bad_target = json.dumps(
+            {
+                "pages": [
+                    {
+                        "type": "patchouli:text",
+                        "text": "Аффикс $(6) — это движущая сила предметов с аффиксами.$()",
+                    }
+                ]
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        work = plan_book_work(
+            self.path,
+            self._source(),
+            "ru_ru",
+            RU["regex"],
+            bad_target,
+            "append",
+        )
+        assert work is not None
+        self.assertTrue(work.target_reuse_disabled)
+        self.assertEqual(work.preserved, {})
+        self.assertGreater(len(work.pending), 0)
+
+
+class IeSemanticOwnershipV34Tests(unittest.TestCase):
+    path = "assets/immersiveengineering/manual/en_us/wires.txt"
+
+    def test_section_style_owns_only_the_original_visible_payload(self):
+        source = "The §2left port§r is for inputting energy.\n"
+        work = plan_book_work(self.path, source, "ru_ru", RU["regex"], None, "force")
+        assert work is not None
+        outer = next(unit for unit in work.source_plan.units if unit.kind == "ie-manual-prose")
+        child = next(unit for unit in work.source_plan.units if unit.kind == "ie-format-semantic-child")
+        translated = {
+            outer.id: outer.text.replace("The ", "").replace(
+                " is for inputting energy.", " используется для ввода энергии."
+            ),
+            child.id: "левый порт",
+        }
+        output = build_book_output(work, translated)
+        self.assertIn("§2левый порт§r", output)
+        self.assertNotIn("§2 используется", output)
+        ImmersiveEngineeringManualAdapter().validate(source, output)
+
+
+class ConservativeTemplateAndModonomiconV34Tests(unittest.TestCase):
+    template_path = "assets/ars_nouveau/patchouli_books/worn_notebook/en_us/templates/glyph_recipe.json"
+
+    def test_patchouli_template_is_owned_but_never_sent_to_llm(self):
+        source = json.dumps(
+            {
+                "processor": "example.Processor",
+                "components": [
+                    {"type": "patchouli:text", "text": "#tier#"},
+                    {"type": "patchouli:text", "text": "Result:"},
+                ],
+            },
+            separators=(",", ":"),
+        )
+        adapter = PatchouliBookJsonAdapter()
+        self.assertTrue(adapter.matches(self.template_path))
+        plan = adapter.prepare(self.template_path, source)
+        self.assertEqual(plan.units, ())
+        self.assertTrue(plan.metadata.get("patchouli_template_immutable"))
+        work = plan_book_work(
+            self.template_path, source, "ru_ru", RU["regex"], None, "append"
+        )
+        assert work is not None
+        self.assertEqual(work.adapter_name, "patchouli-template-json")
+        self.assertTrue(work.emit_structural_copy)
+        self.assertEqual(build_book_output(work, {}), source)
+
+    def test_modonomicon_target_path_is_host_output_policy_not_sdk_parser_policy(self):
+        path = "data/demo/modonomicon/books/guide/entries/start.json"
+        adapter = ModonomiconBookJsonAdapter()
+        with self.assertRaises(ValueError):
+            adapter.target_path(path, "ru_ru")
+        self.assertEqual(target_path_for_book(path, "ru_ru"), path)
+
+    def test_gson_lenient_modonomicon_identity_is_preserved(self):
+        path = "data/demo/modonomicon/books/guide/entries/start.json"
+        source = '{"name":"Visible title","description":"First line\n\tSecond line"}'
+        adapter = ModonomiconBookJsonAdapter()
+        plan = adapter.prepare(path, source)
+        identity = {unit.id: unit.text for unit in plan.units}
+        self.assertEqual(adapter.apply(plan, identity), source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_formatkit_semantic_anchor_guard_v341.py
+++ b/tests/test_formatkit_semantic_anchor_guard_v341.py
@@ -1,0 +1,239 @@
+import json
+import unittest
+
+from mineai.constants import LANGUAGES
+from mineai.engines.base import EngineCallbacks, TranslationEngine
+from mineai.engines.service import TranslationService
+from mineai.processors.formatkit_books_pilot_v341 import FormatKitBooksJarProcessor as V341BooksJarProcessor
+from mineai.formatkit_books_bridge import (
+    build_book_output,
+    plan_book_work,
+    semantic_resolved_values,
+    split_semantic_book_pending,
+    validate_book_candidate,
+)
+
+RU = LANGUAGES["Русский"]
+
+
+class _Config:
+    def getboolean(self, section, key):
+        if (section, key) == ("GENERAL", "smart_glue"):
+            return True
+        if (section, key) == ("AI", "fallback_google"):
+            return False
+        raise AssertionError((section, key))
+
+    def getint(self, _section, _key, fallback=0):
+        return fallback
+
+
+class _Cache:
+    def __init__(self):
+        self.values = {}
+        self.discarded = []
+
+    def get(self, api_code, source):
+        value = self.values.get((api_code, source))
+        return (value, False) if value is not None else (None, False)
+
+    def set(self, api_code, source, translated):
+        self.values[(api_code, source)] = translated
+
+    def set_identity(self, api_code, source):
+        self.values[(api_code, source)] = source
+
+    def discard(self, api_code, source, *, include_imported=False):
+        self.values.pop((api_code, source), None)
+        self.discarded.append((api_code, source, include_imported))
+
+    def save_if_threshold(self):
+        pass
+
+
+class _Engine(TranslationEngine):
+    def __init__(self, responses):
+        self.responses = responses
+
+    def translate_batch(self, items, target_lang, callbacks):
+        return {
+            key: self.responses.get(item.original, item.original)
+            for key, item in items.items()
+        }
+
+
+class _Service(TranslationService):
+    def __init__(self, cache, responses):
+        super().__init__("ai", cache, _Config(), ai_batch=20)
+        self.engine = _Engine(responses)
+
+    def _build_engine(self, context="", prompt_type="mods"):
+        return self.engine
+
+
+def _callbacks(logs):
+    return EngineCallbacks(
+        should_run=lambda: True,
+        wait_if_paused=lambda: None,
+        on_log=lambda message, tag: logs.append((message, tag)),
+        on_status=lambda _message: None,
+        on_progress=lambda _count: None,
+    )
+
+
+class V341RuntimeWiringTests(unittest.TestCase):
+    def test_runtime_wrapper_is_a_narrow_subclass(self):
+        from mineai.processors.formatkit_books_pilot import FormatKitBooksJarProcessor as Base
+
+        self.assertTrue(issubclass(V341BooksJarProcessor, Base))
+        self.assertIsNot(V341BooksJarProcessor, Base)
+
+
+class PatchouliSemanticAnchorGuardV341Tests(unittest.TestCase):
+    path = "assets/apotheosis/patchouli_books/apoth_chronicle/en_us/entries/adventure/affixes.json"
+
+    @staticmethod
+    def source(text="An $(6)Affix$() is the driving force behind Affix Items."):
+        return json.dumps(
+            {"pages": [{"type": "patchouli:text", "text": text}]},
+            separators=(",", ":"),
+        )
+
+    def _work(self, source=None):
+        work = plan_book_work(
+            self.path,
+            source or self.source(),
+            "ru_ru",
+            RU["regex"],
+            None,
+            "force",
+        )
+        assert work is not None
+        return work
+
+    def test_semantic_child_is_scheduled_before_dependent_parent(self):
+        work = self._work()
+        children, remaining = split_semantic_book_pending(work)
+        child = next(unit for unit in work.source_plan.units if unit.kind == "patchouli-semantic-child")
+        parent = next(unit for unit in work.source_plan.units if unit.kind == "patchouli-text")
+        self.assertEqual(set(children), {child.id})
+        self.assertIn(parent.id, remaining)
+        self.assertNotIn(parent.id, children)
+
+    def test_repeating_translated_child_next_to_anchor_is_rejected(self):
+        work = self._work()
+        child = next(unit for unit in work.source_plan.units if unit.kind == "patchouli-semantic-child")
+        parent = next(unit for unit in work.source_plan.units if unit.kind == "patchouli-text")
+        resolved = {child.id: "Аффикс"}
+        bad = parent.text.replace("An ", "Аффикс ").replace(
+            " is the driving force behind Affix Items.",
+            " является движущей силой предметов с аффиксами.",
+        )
+        ok, reason = validate_book_candidate(
+            work, parent.id, bad, resolved_semantic=resolved
+        )
+        self.assertFalse(ok)
+        self.assertIn("duplicates translated child", reason)
+
+    def test_good_parent_keeps_style_owned_by_child(self):
+        work = self._work()
+        child = next(unit for unit in work.source_plan.units if unit.kind == "patchouli-semantic-child")
+        parent = next(unit for unit in work.source_plan.units if unit.kind == "patchouli-text")
+        resolved = {child.id: "Аффикс"}
+        good = parent.text.replace("An ", "").replace(
+            " is the driving force behind Affix Items.",
+            " является движущей силой предметов с аффиксами.",
+        )
+        ok, reason = validate_book_candidate(
+            work, parent.id, good, resolved_semantic=resolved
+        )
+        self.assertTrue(ok, reason)
+        output = json.loads(build_book_output(work, {child.id: "Аффикс", parent.id: good}))
+        text = output["pages"][0]["text"]
+        self.assertIn("$(6)Аффикс$() является", text)
+        self.assertNotIn("Аффикс $(6)Аффикс$()", text)
+
+    def test_source_owned_repetition_is_not_a_false_positive(self):
+        source = self.source("Use $(thing)very$() very carefully.")
+        work = self._work(source)
+        child = next(unit for unit in work.source_plan.units if unit.kind == "patchouli-semantic-child")
+        parent = next(unit for unit in work.source_plan.units if unit.kind == "patchouli-text")
+        resolved = {child.id: "очень"}
+        candidate = parent.text.replace("Use ", "Используйте ").replace(
+            " very carefully.", " очень осторожно."
+        )
+        ok, reason = validate_book_candidate(
+            work, parent.id, candidate, resolved_semantic=resolved
+        )
+        self.assertTrue(ok, reason)
+
+    def test_bad_parent_cache_is_discarded_before_it_can_reappear(self):
+        work = self._work()
+        children, remaining = split_semantic_book_pending(work)
+        child = next(unit for unit in work.source_plan.units if unit.kind == "patchouli-semantic-child")
+        parent = next(unit for unit in work.source_plan.units if unit.kind == "patchouli-text")
+        self.assertEqual(set(children), {child.id})
+        resolved = {child.id: "Аффикс"}
+        bad = parent.text.replace("An ", "Аффикс ").replace(
+            " is the driving force behind Affix Items.",
+            " является движущей силой предметов с аффиксами.",
+        )
+        good = parent.text.replace("An ", "").replace(
+            " is the driving force behind Affix Items.",
+            " является движущей силой предметов с аффиксами.",
+        )
+        cache = _Cache()
+        cache.values[("ru", parent.text)] = bad
+        service = _Service(cache, {parent.text: good})
+        logs = []
+        result = service.translate_dict(
+            remaining,
+            RU,
+            _callbacks(logs),
+            context="Apotheosis",
+            candidate_validator=lambda unit_id, candidate: validate_book_candidate(
+                work,
+                unit_id,
+                candidate,
+                resolved_semantic=resolved,
+            ),
+            preserve_source_structure=True,
+        )
+        self.assertEqual(result[parent.id], good)
+        self.assertTrue(any(entry[:2] == ("ru", parent.text) for entry in cache.discarded))
+        self.assertNotEqual(cache.values[("ru", parent.text)], bad)
+
+
+class IeSemanticAnchorGuardV341Tests(unittest.TestCase):
+    path = "assets/immersiveengineering/manual/en_us/mining_drill.txt"
+
+    def test_ie_parent_cannot_repeat_drill_head_outside_style(self):
+        source = "The §2Drill Head§r determines the mining speed.\n"
+        work = plan_book_work(self.path, source, "ru_ru", RU["regex"], None, "force")
+        assert work is not None
+        child = next(unit for unit in work.source_plan.units if unit.kind == "ie-format-semantic-child")
+        parent = next(unit for unit in work.source_plan.units if unit.kind == "ie-manual-prose")
+        resolved = {child.id: "Буровая головка"}
+        bad = parent.text.replace("The ", "Буровая головка ").replace(
+            "determines the mining speed.", "определяет скорость добычи."
+        )
+        ok, reason = validate_book_candidate(
+            work, parent.id, bad, resolved_semantic=resolved
+        )
+        self.assertFalse(ok)
+        self.assertIn("duplicates translated child", reason)
+
+        good = parent.text.replace("The ", "").replace(
+            "determines the mining speed.", "определяет скорость добычи."
+        )
+        ok, reason = validate_book_candidate(
+            work, parent.id, good, resolved_semantic=resolved
+        )
+        self.assertTrue(ok, reason)
+        output = build_book_output(work, {child.id: "Буровая головка", parent.id: good})
+        self.assertIn("§2Буровая головка§r определяет", output)
+        self.assertNotIn("Буровая головка §2Буровая головка§r", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_job_failed_string_terminal_status_v341.py
+++ b/tests/test_job_failed_string_terminal_status_v341.py
@@ -1,0 +1,73 @@
+import unittest
+from unittest import mock
+
+from mineai.runtime.job import TranslationJob, TranslationOptions
+from mineai.runtime.state import JobState
+
+
+class FailedStringTerminalStatusV341Tests(unittest.TestCase):
+    def test_rejected_string_metrics_cannot_finish_as_success(self):
+        config = mock.Mock()
+        config.getboolean.return_value = True
+        state = JobState(is_running=True)
+        cache = mock.Mock()
+        logs = []
+        statuses = []
+        job = TranslationJob(
+            config,
+            cache,
+            cache,
+            state,
+            on_log=lambda message, _tag: logs.append(message),
+            on_status=lambda *args: statuses.append(args),
+            on_row=mock.Mock(),
+        )
+        options = TranslationOptions(
+            mc_dir="C:/Minecraft",
+            language_label="Русский",
+            mc_version="1.20.1",
+            output_mode="inplace",
+            pack_name="MineAI_Pack",
+            engine="google",
+            google_mode="single",
+            ai_mode="safe",
+            ai_batch=20,
+            ai_provider="local",
+            process_mode="append",
+            translate_mods=False,
+            translate_books=False,
+            translate_quests=True,
+        )
+
+        def mark_rejected_line(*_args, **_kwargs):
+            state.increment_translated()
+            state.mark_failed()
+
+        with (
+            mock.patch("mineai.runtime.job.discover_jar_files", return_value=[]),
+            mock.patch(
+                "mineai.runtime.job.discover_loose_lang_files",
+                return_value=["dummy.json"],
+            ),
+            mock.patch("mineai.runtime.job.discover_snbt_files", return_value=[]),
+            mock.patch("mineai.runtime.job.discover_bq_files", return_value=[]),
+            mock.patch("mineai.runtime.job.StringEstimator") as estimator_cls,
+            mock.patch("mineai.runtime.job.TranslationService"),
+            mock.patch("mineai.runtime.job.JarProcessor"),
+            mock.patch(
+                "mineai.runtime.job.LooseJsonProcessor.process",
+                side_effect=mark_rejected_line,
+            ),
+            mock.patch("mineai.runtime.job.SnbtProcessor"),
+            mock.patch("mineai.runtime.job.BQProcessor"),
+        ):
+            estimator_cls.return_value.estimate.return_value = 1
+            job.run_translation(options)
+
+        self.assertTrue(any("ошибок строк — 1" in message for message in logs))
+        self.assertFalse(any("УСПЕШНО ЗАВЕРШЕН" in message for message in logs))
+        self.assertEqual(statuses[-1], ("Завершено с ошибками", 1.0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_markdown_ai_isolation_v17.py
+++ b/tests/test_markdown_ai_isolation_v17.py
@@ -1,0 +1,128 @@
+import tempfile
+import unittest
+
+from mineai.cache import TranslationCache
+from mineai.engines.base import EngineCallbacks
+from mineai.engines.service import TranslationService
+from mineai.processors.formatkit_books_pilot_v341 import (
+    _MARKDOWN_CACHE_SCOPE,
+    _markdown_translation_service,
+)
+
+
+TARGET_LANG = {
+    "file": "ru_ru",
+    "api": "ru",
+    "name": "Russian",
+    "regex": r"[А-Яа-яЁё]",
+}
+
+
+class _Config:
+    def getboolean(self, section: str, key: str, default=False) -> bool:
+        return False
+
+
+class _RecordingEngine:
+    def __init__(self, translated_by_source: dict[str, str]) -> None:
+        self.translated_by_source = translated_by_source
+        self.calls: list[tuple[str, ...]] = []
+
+    def translate_batch(self, items, _target_lang, _callbacks):
+        self.calls.append(tuple(items.keys()))
+        return {
+            key: self.translated_by_source[item.original]
+            for key, item in items.items()
+        }
+
+
+class _RecordingService(TranslationService):
+    def __init__(self, cache, engine) -> None:
+        super().__init__(
+            "kobold",
+            cache,
+            _Config(),
+            ai_batch=20,
+            ai_provider="local",
+        )
+        self._recording_engine = engine
+
+    def _build_engine(self, context: str = "", prompt_type: str = "mods"):
+        return self._recording_engine
+
+
+def _callbacks() -> EngineCallbacks:
+    return EngineCallbacks(
+        should_run=lambda: True,
+        wait_if_paused=lambda: None,
+        on_log=lambda *_args: None,
+        on_status=lambda *_args: None,
+        on_progress=lambda *_args: None,
+    )
+
+
+class MarkdownAiIsolationV17Tests(unittest.TestCase):
+    def test_markdown_uses_singleton_ai_batches_and_ignores_legacy_cache(self) -> None:
+        source_a = "pressing the hotkey, (N by default)."
+        source_b = "In this screen you can add or remove upgrades."
+        translated_a = "Нажмите горячую клавишу (по умолчанию N)."
+        translated_b = "На этом экране можно добавлять или удалять улучшения."
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache = TranslationCache(f"{temp_dir}/ai_cache.json")
+            # These are structurally valid but semantically shifted neighbour values,
+            # matching the failure class observed in the paused full-modpack run.
+            cache.set("ru", source_a, "На этом экране можно добавлять улучшения.")
+            cache.set("ru", source_b, "Карта подзарядки ME")
+
+            engine = _RecordingEngine(
+                {
+                    source_a: translated_a,
+                    source_b: translated_b,
+                }
+            )
+            service = _RecordingService(cache, engine)
+            guarded = _markdown_translation_service(service)
+
+            self.assertIsNot(guarded, service)
+            self.assertEqual(service.ai_batch, 20)
+            self.assertEqual(guarded.ai_batch, 1)
+
+            result = guarded.translate_dict(
+                {"10": source_a, "11": source_b},
+                TARGET_LANG,
+                _callbacks(),
+                context="Advanced AE",
+            )
+
+            self.assertEqual(
+                result,
+                {"10": translated_a, "11": translated_b},
+            )
+            self.assertEqual(engine.calls, [("10",), ("11",)])
+
+            # Old unscoped Markdown values are quarantined instead of reused.
+            self.assertIsNone(cache.get("ru", source_a)[0])
+            self.assertIsNone(cache.get("ru", source_b)[0])
+            self.assertEqual(
+                cache.get("ru", _MARKDOWN_CACHE_SCOPE + source_a)[0],
+                translated_a,
+            )
+            self.assertEqual(
+                cache.get("ru", _MARKDOWN_CACHE_SCOPE + source_b)[0],
+                translated_b,
+            )
+
+            # A second pass reuses only the new scoped values and makes no AI call.
+            second = guarded.translate_dict(
+                {"10": source_a, "11": source_b},
+                TARGET_LANG,
+                _callbacks(),
+                context="Advanced AE",
+            )
+            self.assertEqual(second, result)
+            self.assertEqual(engine.calls, [("10",), ("11",)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_markdown_guide_locale_classification.py
+++ b/tests/test_markdown_guide_locale_classification.py
@@ -1,0 +1,25 @@
+import unittest
+
+from mineai.processors.markdown_guides import is_source_markdown_guide
+
+
+class MarkdownGuideLocaleClassificationTests(unittest.TestCase):
+    def test_guideme_localized_subdirectories_are_not_sources(self) -> None:
+        for locale_dir in ("_ru_ru", "ru_ru"):
+            with self.subTest(locale_dir=locale_dir):
+                self.assertFalse(
+                    is_source_markdown_guide(
+                        f"assets/ae2/ae2guide/{locale_dir}/getting-started.md"
+                    )
+                )
+
+    def test_guideme_root_page_remains_a_source(self) -> None:
+        self.assertTrue(
+            is_source_markdown_guide(
+                "assets/ae2/ae2guide/getting-started.md"
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_markdown_guide_safety.py
+++ b/tests/test_markdown_guide_safety.py
@@ -1,0 +1,394 @@
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from mineai.engines.base import EngineCallbacks
+from mineai.processors.analyzer import ModpackAnalyzer
+from mineai.processors.estimator import StringEstimator
+from mineai.processors.jar import JarProcessor
+from mineai.processors.markdown_guides import (
+    get_markdown_target_path,
+    is_source_markdown_guide,
+)
+from mineai.processors.selection import (
+    collect_book_markdown_selection,
+    markdown_line_has_translatable_prose,
+)
+from mineai.runtime.state import JobState
+from mineai.text_processing import mask_protected_fragments, unmask_translation
+
+
+TARGET_LANG = {
+    "file": "ru_ru",
+    "api": "ru",
+    "name": "Russian",
+    "regex": r"[А-Яа-яЁё]",
+}
+
+
+class _Config:
+    def __init__(self, smart_glue: bool = False) -> None:
+        self.smart_glue = smart_glue
+
+    def getboolean(self, _section: str, key: str) -> bool:
+        return self.smart_glue if key == "smart_glue" else False
+
+
+class _ShieldingService:
+    def __init__(self, smart_glue: bool = False) -> None:
+        self.config = _Config(smart_glue)
+        self.calls: list[dict[str, str]] = []
+
+    def translate_dict(self, strings, _target_lang, _callbacks, **_kwargs):
+        self.calls.append(dict(strings))
+        translated: dict[str, str] = {}
+        for key, source in strings.items():
+            masked, mapping = mask_protected_fragments(source)
+            translated_masked = masked
+            translated_masked = translated_masked.replace(
+                "is used to store items.",
+                "используется для хранения предметов.",
+            )
+            translated_masked = translated_masked.replace(
+                "This machine stores energy.",
+                "Эта машина хранит энергию.",
+            )
+            translated_masked = translated_masked.replace(
+                "New paragraph",
+                "Новый абзац",
+            )
+            translated[key] = unmask_translation(translated_masked, mapping)
+        return translated
+
+
+class _Writer:
+    def __init__(self) -> None:
+        self.files: dict[str, bytes] = {}
+
+    def write(self, path: str, payload: bytes) -> None:
+        self.files[path] = payload
+
+
+def _callbacks() -> EngineCallbacks:
+    return EngineCallbacks(
+        should_run=lambda: True,
+        wait_if_paused=lambda: None,
+        on_log=lambda *_args: None,
+        on_status=lambda *_args: None,
+        on_progress=lambda *_args: None,
+    )
+
+
+def _state() -> JobState:
+    state = JobState()
+    state.start()
+    return state
+
+
+class MarkdownSelectionSafetyTests(unittest.TestCase):
+    def _selection(self, text: str, *, smart_glue: bool = False):
+        return collect_book_markdown_selection(
+            text,
+            "",
+            "append",
+            smart_glue=smart_glue,
+        )
+
+    def test_markup_only_component_is_not_selected(self) -> None:
+        source = '<ItemLink id="foo" />'
+        selection = self._selection(source)
+
+        self.assertEqual(selection.pending, {})
+        self.assertEqual(selection.total_translatable, 0)
+        self.assertFalse(markdown_line_has_translatable_prose(source))
+
+    def test_itemlink_plus_prose_is_selected_and_tag_round_trips(self) -> None:
+        source = '<ItemLink id="foo" /> is used to store items.'
+        selection = self._selection(source)
+
+        self.assertEqual(selection.pending, {"0": source})
+        self.assertTrue(markdown_line_has_translatable_prose(source))
+
+        masked, mapping = mask_protected_fragments(source)
+        self.assertNotIn("ItemLink", masked)
+        self.assertIn('<ItemLink id="foo" />', mapping.values())
+        translated = unmask_translation(
+            masked.replace(
+                "is used to store items.",
+                "используется для хранения предметов.",
+            ),
+            mapping,
+        )
+        self.assertEqual(
+            translated,
+            '<ItemLink id="foo" /> используется для хранения предметов.',
+        )
+
+    def test_html_markup_plus_prose_is_selected_and_href_is_protected(self) -> None:
+        source = '<a href="facades.md">Facades</a> will be hidden when disabled.'
+        selection = self._selection(source)
+
+        self.assertEqual(selection.pending, {"0": source})
+        masked, mapping = mask_protected_fragments(source)
+        self.assertNotIn("facades.md", masked)
+        self.assertIn('<a href="facades.md">', mapping.values())
+        self.assertIn("</a>", mapping.values())
+        restored = unmask_translation(masked, mapping)
+        self.assertEqual(restored, source)
+
+    def test_normal_markdown_text_is_still_selected(self) -> None:
+        source = "This machine stores energy."
+        selection = self._selection(source)
+
+        self.assertEqual(selection.pending, {"0": source})
+        self.assertEqual(selection.total_translatable, 1)
+
+    def test_image_and_markup_only_lines_do_not_create_translation_work(self) -> None:
+        source = "\n".join(
+            [
+                "![image](foo.png)",
+                '<SomeComponent foo="bar" />',
+                "![image](foo.png) Some caption text",
+            ]
+        )
+        selection = self._selection(source)
+
+        self.assertEqual(
+            selection.pending,
+            {"2": "![image](foo.png) Some caption text"},
+        )
+        self.assertEqual(selection.total_translatable, 1)
+
+        image = "![image](foo.png)"
+        masked, mapping = mask_protected_fragments(image)
+        self.assertNotIn("foo.png", masked)
+        self.assertIn("![image]", mapping.values())
+        self.assertIn("(foo.png)", mapping.values())
+        self.assertEqual(unmask_translation(masked, mapping), image)
+
+    def test_edge_case_markup_lines_detect_only_real_prose(self) -> None:
+        translatable = [
+            '<ItemLink id="foo" />Text immediately after tag',
+            '<ItemLink id="foo" /> Text after tag',
+            "<strong>Important:</strong> Do not break this.",
+            '<a href="../path/file.md">Click here</a> to continue.',
+            "![image](foo.png) Some caption text",
+        ]
+        technical_only = [
+            "![image](foo.png)",
+            '<SomeComponent foo="bar" />',
+            "<item:minecraft:dirt>",
+        ]
+
+        for line in translatable:
+            with self.subTest(line=line):
+                self.assertTrue(markdown_line_has_translatable_prose(line))
+        for line in technical_only:
+            with self.subTest(line=line):
+                self.assertFalse(markdown_line_has_translatable_prose(line))
+
+    def test_smart_glue_does_not_merge_markdown_structure(self) -> None:
+        source = "\n".join(
+            [
+                "---",
+                "navigation:",
+                "  title: Index/Table of Contents",
+                "  position: 0",
+                "---",
+                "![Logo](assets/logo.png)",
+                "This machine stores energy.",
+            ]
+        )
+        selection = self._selection(source, smart_glue=True)
+
+        self.assertEqual(selection.total_translatable, 2)
+        self.assertEqual(
+            selection.pending,
+            {
+                "2": "Index/Table of Contents",
+                "6": "This machine stores energy.",
+            },
+        )
+        self.assertIn("---\n![Logo](assets/logo.png)", selection.source_text)
+
+
+class MarkdownGuidePathTests(unittest.TestCase):
+    def test_direct_ae2_guide_without_en_us_is_source_markdown(self) -> None:
+        self.assertTrue(
+            is_source_markdown_guide(
+                "assets/ae2/ae2guide/getting-started.md"
+            )
+        )
+
+    def test_existing_en_us_guide_support_is_preserved(self) -> None:
+        self.assertTrue(
+            is_source_markdown_guide(
+                "assets/demo/guide/en_us/getting-started.md"
+            )
+        )
+
+    def test_unrelated_or_already_localized_markdown_is_not_source(self) -> None:
+        self.assertFalse(
+            is_source_markdown_guide("assets/demo/docs/readme.md")
+        )
+        self.assertFalse(
+            is_source_markdown_guide(
+                "assets/ae2/ae2guide/_ru_ru/getting-started.md"
+            )
+        )
+
+    def test_target_path_uses_guideme_locale_subdirectory(self) -> None:
+        source = "assets/ae2/ae2guide/getting-started.md"
+        target = get_markdown_target_path(source, "ru_ru")
+
+        self.assertEqual(
+            target,
+            "assets/ae2/ae2guide/_ru_ru/getting-started.md",
+        )
+        self.assertNotEqual(source, target)
+        self.assertEqual(
+            get_markdown_target_path(
+                "assets/demo/guide/en_us/page.md",
+                "ru_ru",
+            ),
+            "assets/demo/guide/ru_ru/page.md",
+        )
+
+
+class MarkdownGuidePipelineTests(unittest.TestCase):
+    @staticmethod
+    def _write_jar(path: Path, files: dict[str, str]) -> None:
+        with zipfile.ZipFile(path, "w") as archive:
+            for internal, content in files.items():
+                archive.writestr(internal, content.encode("utf-8"))
+
+    def test_direct_ae2_fixture_matches_analyzer_estimator_and_processor(self) -> None:
+        source_path = "assets/ae2/ae2guide/getting-started.md"
+        target_path = "assets/ae2/ae2guide/_ru_ru/getting-started.md"
+        source = "\n".join(
+            [
+                '<ItemLink id="foo" /> is used to store items.',
+                '<SomeComponent foo="bar" />',
+                "This machine stores energy.",
+            ]
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            jar_path = Path(temp_dir) / "ae2.jar"
+            self._write_jar(jar_path, {source_path: source})
+            source_jar_bytes = jar_path.read_bytes()
+
+            state = _state()
+            analyzer_rows: list[tuple] = []
+            analyzer = ModpackAnalyzer(state)
+            analyzed, translated = analyzer._analyze_jar(
+                str(jar_path),
+                "ru_ru.json",
+                TARGET_LANG["regex"],
+                False,
+                True,
+                lambda *row: analyzer_rows.append(row),
+                "AE2",
+            )
+
+            estimator = StringEstimator(state)
+            estimated = estimator.estimate(
+                [str(jar_path)],
+                [],
+                [],
+                [],
+                target_lang=TARGET_LANG,
+                mode="append",
+                translate_mods=False,
+                translate_books=True,
+                translate_quests=False,
+                smart_glue=False,
+            )
+
+            service = _ShieldingService()
+            writer = _Writer()
+            JarProcessor(service, state, _callbacks()).process(
+                str(jar_path),
+                target_lang=TARGET_LANG,
+                mode="append",
+                output_mode="resourcepack",
+                translate_mods=False,
+                translate_books=True,
+                pack_writer=writer,
+            )
+
+            self.assertEqual(analyzed, 2)
+            self.assertEqual(translated, 0)
+            self.assertEqual(estimated, 2)
+            self.assertEqual(len(service.calls), 1)
+            self.assertEqual(
+                service.calls[0],
+                {
+                    "0": '<ItemLink id="foo" /> is used to store items.',
+                    "2": "This machine stores energy.",
+                },
+            )
+            self.assertIn(target_path, writer.files)
+            self.assertNotIn(source_path, writer.files)
+            output = writer.files[target_path].decode("utf-8")
+            self.assertIn(
+                '<ItemLink id="foo" /> используется для хранения предметов.',
+                output,
+            )
+            self.assertIn("Эта машина хранит энергию.", output)
+            self.assertEqual(jar_path.read_bytes(), source_jar_bytes)
+            self.assertTrue(analyzer_rows)
+
+    def test_direct_ae2_append_skip_force_keep_estimator_processor_parity(self) -> None:
+        source_path = "assets/ae2/ae2guide/page.md"
+        target_path = "assets/ae2/ae2guide/_ru_ru/page.md"
+        source = "Existing paragraph\nNew paragraph"
+        target = "Существующий абзац\nNew paragraph"
+
+        expected = {"append": 1, "skip": 1, "force": 2}
+        for mode, expected_count in expected.items():
+            with self.subTest(mode=mode), tempfile.TemporaryDirectory() as temp_dir:
+                jar_path = Path(temp_dir) / "ae2.jar"
+                self._write_jar(
+                    jar_path,
+                    {
+                        source_path: source,
+                        target_path: target,
+                    },
+                )
+                state = _state()
+                estimator = StringEstimator(state)
+                estimated = estimator.estimate(
+                    [str(jar_path)],
+                    [],
+                    [],
+                    [],
+                    target_lang=TARGET_LANG,
+                    mode=mode,
+                    translate_mods=False,
+                    translate_books=True,
+                    translate_quests=False,
+                    smart_glue=False,
+                )
+
+                service = _ShieldingService()
+                writer = _Writer()
+                JarProcessor(service, state, _callbacks()).process(
+                    str(jar_path),
+                    target_lang=TARGET_LANG,
+                    mode=mode,
+                    output_mode="resourcepack",
+                    translate_mods=False,
+                    translate_books=True,
+                    pack_writer=writer,
+                )
+                actual = len(service.calls[0]) if service.calls else 0
+
+                self.assertEqual(estimated, expected_count)
+                self.assertEqual(actual, expected_count)
+                self.assertIn(target_path, writer.files)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_markdown_structural_pipeline.py
+++ b/tests/test_markdown_structural_pipeline.py
@@ -1,0 +1,115 @@
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from mineai.engines.base import EngineCallbacks
+from mineai.processors.jar import JarProcessor
+from mineai.runtime.state import JobState
+from mineai.text_processing import mask_protected_fragments, unmask_translation
+
+
+TARGET_LANG = {
+    "file": "ru_ru",
+    "api": "ru",
+    "name": "Russian",
+    "regex": r"[А-Яа-яЁё]",
+}
+
+
+class _Config:
+    def getboolean(self, _section: str, _key: str) -> bool:
+        return False
+
+
+class _PayloadOnlyService:
+    def __init__(self) -> None:
+        self.config = _Config()
+        self.calls: list[dict[str, str]] = []
+
+    def translate_dict(self, strings, _target_lang, _callbacks, **_kwargs):
+        self.calls.append(dict(strings))
+        result: dict[str, str] = {}
+        for key, source in strings.items():
+            masked, mapping = mask_protected_fragments(source)
+            translated = masked.replace(
+                "ME Extended Interface is a",
+                "МЕ Расширенный интерфейс — это",
+            ).replace(
+                "with a larger configuration inventory.",
+                "с более обширным списком конфигураций.",
+            )
+            result[key] = unmask_translation(translated, mapping)
+        return result
+
+
+class _Writer:
+    def __init__(self) -> None:
+        self.files: dict[str, bytes] = {}
+
+    def write(self, path: str, payload: bytes) -> None:
+        self.files[path] = payload
+
+
+def _callbacks() -> EngineCallbacks:
+    return EngineCallbacks(
+        should_run=lambda: True,
+        wait_if_paused=lambda: None,
+        on_log=lambda *_args: None,
+        on_status=lambda *_args: None,
+        on_progress=lambda *_args: None,
+    )
+
+
+class MarkdownStructuralPipelineTests(unittest.TestCase):
+    def test_processor_never_sends_block_structure_to_translation_service(self) -> None:
+        source_path = "assets/ae2/ae2guide/structure-test.md"
+        target_path = "assets/ae2/ae2guide/_ru_ru/structure-test.md"
+        source_line = (
+            '*   ME Extended Interface is a <ItemLink id="ae2:interface" /> '
+            "with a larger configuration inventory.  "
+        )
+        expected_payload = (
+            'ME Extended Interface is a <ItemLink id="ae2:interface" /> '
+            "with a larger configuration inventory."
+        )
+        expected_output = (
+            '*   МЕ Расширенный интерфейс — это <ItemLink id="ae2:interface" /> '
+            "с более обширным списком конфигураций.  "
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            jar_path = Path(temp_dir) / "ae2.jar"
+            with zipfile.ZipFile(jar_path, "w") as archive:
+                archive.writestr(source_path, source_line.encode("utf-8"))
+            original_jar = jar_path.read_bytes()
+
+            state = JobState()
+            state.start()
+            service = _PayloadOnlyService()
+            writer = _Writer()
+
+            JarProcessor(service, state, _callbacks()).process(
+                str(jar_path),
+                target_lang=TARGET_LANG,
+                mode="force",
+                output_mode="resourcepack",
+                translate_mods=False,
+                translate_books=True,
+                pack_writer=writer,
+            )
+
+            self.assertEqual(service.calls, [{"0": expected_payload}])
+            self.assertNotIn("*   ", service.calls[0]["0"])
+            self.assertIn('<ItemLink id="ae2:interface" />', service.calls[0]["0"])
+            self.assertIn(target_path, writer.files)
+            self.assertNotIn(source_path, writer.files)
+            self.assertEqual(
+                writer.files[target_path].decode("utf-8"),
+                expected_output,
+            )
+            self.assertEqual(jar_path.read_bytes(), original_jar)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_markdown_structure_integrity.py
+++ b/tests/test_markdown_structure_integrity.py
@@ -1,0 +1,201 @@
+import unittest
+
+from mineai.processors.selection import (
+    collect_book_markdown_selection,
+    split_markdown_block_structure,
+)
+from mineai.text_processing import mask_protected_fragments, unmask_translation
+
+
+class MarkdownDocumentStructureTests(unittest.TestCase):
+    def test_smart_glue_does_not_collapse_markdown_blocks(self) -> None:
+        source = "\n".join(
+            [
+                "---",
+                "navigation:",
+                "  title: Structure Test",
+                "---",
+                "![Logo](assets/logo.png)",
+                "",
+                "## Heading",
+                "Paragraph after heading.",
+                "",
+                "| Bytes | Types |",
+                "| --- | --- |",
+                "| One | Two |",
+                "",
+                "1. First item",
+                "2. Second item",
+            ]
+        )
+
+        selection = collect_book_markdown_selection(
+            source,
+            "",
+            "force",
+            smart_glue=True,
+        )
+
+        self.assertEqual(selection.source_text, source)
+        self.assertEqual(len(selection.lines_out), len(source.split("\n")))
+        self.assertEqual(selection.lines_out[3], "---")
+        self.assertEqual(selection.lines_out[4], "![Logo](assets/logo.png)")
+        self.assertEqual(selection.lines_out[6], "## Heading")
+        self.assertEqual(selection.lines_out[9], "| Bytes | Types |")
+        self.assertEqual(selection.lines_out[10], "| --- | --- |")
+        self.assertEqual(selection.lines_out[13], "1. First item")
+        self.assertEqual(selection.lines_out[14], "2. Second item")
+
+    def test_block_structure_is_split_byte_for_byte_from_payload(self) -> None:
+        cases = {
+            "*   Bullet item": ("*   ", "Bullet item", ""),
+            "  *   Nested bullet": ("  *   ", "Nested bullet", ""),
+            "1.  Ordered item": ("1.  ", "Ordered item", ""),
+            "   2)    Ordered item": ("   2)    ", "Ordered item", ""),
+            "##   Heading": ("##   ", "Heading", ""),
+            "##   Heading   ##": ("##   ", "Heading", "   ##"),
+            ">   Quoted text": (">   ", "Quoted text", ""),
+            "> *   Nested quote item": ("> *   ", "Nested quote item", ""),
+            "  Continuation text": ("  ", "Continuation text", ""),
+            "- [ ]   Task item": ("- [ ]   ", "Task item", ""),
+            "- [x] Done item": ("- [x] ", "Done item", ""),
+            "Plain paragraph": ("", "Plain paragraph", ""),
+            "Text with hard break  ": ("", "Text with hard break", "  "),
+        }
+        for source, expected in cases.items():
+            with self.subTest(source=source):
+                self.assertEqual(split_markdown_block_structure(source), expected)
+
+    def test_selection_sends_only_bullet_payload_to_translation_service(self) -> None:
+        source = '*   ME Extended Interface is a <ItemLink id="ae2:interface" /> with a larger configuration inventory.'
+        selection = collect_book_markdown_selection(
+            source,
+            "",
+            "force",
+            smart_glue=True,
+        )
+
+        key = "0"
+        self.assertEqual(
+            selection.pending[key],
+            'ME Extended Interface is a <ItemLink id="ae2:interface" /> with a larger configuration inventory.',
+        )
+        self.assertEqual(selection.title_meta[key], ("*   ", ""))
+
+        masked, mapping = mask_protected_fragments(selection.pending[key])
+        self.assertNotIn("*   ", masked)
+        self.assertNotIn('id="ae2:interface"', masked)
+        self.assertIn('<ItemLink id="ae2:interface" />', mapping.values())
+
+        translated_payload = masked.replace(
+            "ME Extended Interface is a",
+            "МЕ Расширенный интерфейс — это",
+        ).replace(
+            "with a larger configuration inventory.",
+            "с более обширным списком конфигураций.",
+        )
+        restored_payload = unmask_translation(translated_payload, mapping)
+        prefix, suffix = selection.title_meta[key]
+        final = prefix + restored_payload + suffix
+
+        self.assertEqual(
+            final,
+            '*   МЕ Расширенный интерфейс — это <ItemLink id="ae2:interface" /> с более обширным списком конфигураций.',
+        )
+
+    def test_selection_preserves_indent_and_hard_break_outside_payload(self) -> None:
+        source = "  Continuation text with hard break  "
+        selection = collect_book_markdown_selection(
+            source,
+            "",
+            "force",
+            smart_glue=False,
+        )
+
+        self.assertEqual(selection.pending, {"0": "Continuation text with hard break"})
+        self.assertEqual(selection.title_meta["0"], ("  ", "  "))
+
+    def test_fenced_code_block_is_not_selected_for_translation(self) -> None:
+        source = "\n".join(
+            [
+                "```json",
+                '{"text": "Do not translate this example"}',
+                "```",
+                "Translate this paragraph.",
+            ]
+        )
+        selection = collect_book_markdown_selection(
+            source,
+            "",
+            "force",
+            smart_glue=False,
+        )
+
+        self.assertNotIn("0", selection.pending)
+        self.assertNotIn("1", selection.pending)
+        self.assertNotIn("2", selection.pending)
+        self.assertEqual(selection.pending["3"], "Translate this paragraph.")
+
+
+class MarkdownInlineShieldTests(unittest.TestCase):
+    def test_block_markers_are_not_placeholder_fragments(self) -> None:
+        masked, mapping = mask_protected_fragments("## Heading")
+        self.assertNotIn("## ", mapping.values())
+        self.assertEqual(masked, "## Heading")
+
+        _masked, mapping = mask_protected_fragments("*   Bullet")
+        self.assertNotIn("*   ", mapping.values())
+
+    def test_inline_itemlink_round_trips_exactly(self) -> None:
+        source = 'ME Interface is a <ItemLink id="ae2:interface" /> component.'
+        masked, mapping = mask_protected_fragments(source)
+
+        self.assertNotIn('id="ae2:interface"', masked)
+        self.assertIn('<ItemLink id="ae2:interface" />', mapping.values())
+        translated = masked.replace("ME Interface is a", "Интерфейс ME — это").replace(
+            "component.",
+            "компонент.",
+        )
+        self.assertEqual(
+            unmask_translation(translated, mapping),
+            'Интерфейс ME — это <ItemLink id="ae2:interface" /> компонент.',
+        )
+
+    def test_table_delimiters_round_trip_exactly(self) -> None:
+        source = "| Bytes | Types |"
+        masked, mapping = mask_protected_fragments(source)
+
+        self.assertEqual(sum(value == "|" for value in mapping.values()), 3)
+        translated = masked.replace("Bytes", "Байты").replace("Types", "Типы")
+        restored = unmask_translation(translated, mapping)
+
+        self.assertEqual(restored, "| Байты | Типы |")
+        self.assertEqual(restored.count("|"), source.count("|"))
+
+    def test_markdown_link_brackets_and_destination_round_trip(self) -> None:
+        source = "[Facades](../items/facades.md) will be hidden."
+        masked, mapping = mask_protected_fragments(source)
+
+        self.assertNotIn("../items/facades.md", masked)
+        self.assertIn("[", mapping.values())
+        self.assertIn("](../items/facades.md)", mapping.values())
+
+        translated = masked.replace("Facades", "Фасады").replace(
+            "will be hidden.",
+            "будут скрыты.",
+        )
+        self.assertEqual(
+            unmask_translation(translated, mapping),
+            "[Фасады](../items/facades.md) будут скрыты.",
+        )
+
+    def test_image_markup_still_round_trips_without_translation(self) -> None:
+        source = "![image](foo.png)"
+        masked, mapping = mask_protected_fragments(source)
+
+        self.assertNotIn("foo.png", masked)
+        self.assertEqual(unmask_translation(masked, mapping), source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_windows_batch_archive_safety.py
+++ b/tests/test_windows_batch_archive_safety.py
@@ -1,0 +1,20 @@
+import unittest
+from pathlib import Path
+
+
+class WindowsBatchArchiveSafetyTests(unittest.TestCase):
+    def test_batch_files_are_ascii_and_crlf(self) -> None:
+        for filename in ("build.bat", "start.bat"):
+            with self.subTest(filename=filename):
+                data = Path(filename).read_bytes()
+                self.assertTrue(data.endswith(b"\r\n"))
+                self.assertNotIn(b"\n", data.replace(b"\r\n", b""))
+                data.decode("ascii")
+
+    def test_gitattributes_preserves_batch_blob_bytes(self) -> None:
+        attributes = Path(".gitattributes").read_text(encoding="utf-8")
+        self.assertIn("*.bat -text", attributes)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Что исправляет этот PR

Этот PR добавляет более безопасную обработку Patchouli, Modonomicon и Immersive Engineering при переводе книг и сложного форматированного текста.

Проблема была в том, что внутри таких строк находится не только обычный текст, но и разметка, placeholders, технические значения и связанные между собой части. Если LLM возвращала не совсем корректный ответ, JSON при этом мог оставаться валидным, но сама книга уже содержала испорченный текст или разметку.

Теперь такие переводы дополнительно проверяются перед записью. Если результат ломает структуру, теряет placeholders или неправильно дублирует связанные части строки, он не принимается. В таком случае безопаснее оставить исходный текст, чем записать повреждённый перевод.

Во время тестирования нашлись реальные примеры такого поведения. В Apotheosis, например, могла получиться строка вроде:

`Аффикс $(6)Аффикс$()`

Также был случай, когда после отклонения родительской строки внутрь английского оригинала всё равно подставлялся уже переведённый дочерний фрагмент. Теперь такой fallback выполняется целиком, без смешивания языков.

Для Modonomicon дополнительно защищены технические `DescriptionId`, чтобы они не попадали в перевод как обычный текст.

Старые результаты из `ai_cache.json` теперь тоже проходят те же проверки перед повторным использованием. Если запись в кэше нарушает структуру строки, она отбрасывается и не попадает в итоговый файл.

Также исправлен финальный статус задания. Если часть строк была отклонена валидатором, программа больше не показывает `Все задачи выполнены!` как будто ошибок не было. Такой запуск корректно завершается со статусом `Завершено с ошибками`.

## Проверка

Изменения сначала проверялись на отдельных проблемных модах, включая реальный Apotheosis 7.4.8, после чего был выполнен полный прогон большого модпака примерно на 567 модах.

После полного прогона отдельно проверены итоговые Resource Pack и Datapack:

- ZIP не повреждены;
- JSON корректно читаются;
- UTF-8 корректный;
- временные `[#N#]` placeholders в готовые файлы не попали;
- найденные ранее проблемы с semantic anchors больше не воспроизводятся;
- критических ошибок или падений в финальном прогоне не обнаружено.

После тестирования экспериментальная история была убрана, а изменения заново собраны одним чистым commit от актуальной `beta`.

Clean branch также прошёл CI на Windows и Ubuntu, Qt smoke test и сборку Windows EXE.

## Что не входит в этот PR

Markdown / AE2 GuideME остаётся отдельным PR #47.

Исправления `build.bat`, `start.bat` и Windows archive safety остаются отдельным PR #48.

В `analyzer.py` есть небольшое пересечение с #47. Если #47 будет принят раньше, при разрешении конфликта нужно сохранить изменения из обоих PR.